### PR TITLE
fix parsing for query and path, default to "." for directory

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -227,25 +227,13 @@ int main(int argc, char **argv) {
 
     char *query;
     char *path;
-    int path_len = 0;
     int pcre_opts = 0;
     int rv = 0;
     const char *pcre_err = NULL;
     int pcre_err_offset = 0;
     pcre *re = NULL;
 
-    parse_options(argc, argv);
-
-    query = malloc(strlen(argv[argc - 2]) + 1);
-    strcpy(query, argv[argc - 2]);
-
-    path_len = strlen(argv[argc - 1]);
-    path = malloc(path_len + 1);
-    strcpy(path, argv[argc - 1]);
-    // kill trailing slash
-    if (path_len > 0 && path[path_len-1] == '/') {
-        path[path_len-1] = '\0';
-    }
+    parse_options(argc, argv, &query, &path);
 
     if (opts.casing == CASE_INSENSITIVE) {
         pcre_opts = pcre_opts | PCRE_CASELESS;

--- a/src/options.c
+++ b/src/options.c
@@ -60,16 +60,16 @@ void cleanup_options() {
     }
 }
 
-void parse_options(int argc, char **argv) {
+void parse_options(int argc, char **argv, char **query, char **path) {
     int ch;
     const char *pcre_err = NULL;
     int pcre_err_offset = 0;
-
-    init_options();
-
+    int path_len = 0;
     int useless = 0;
     int help = 0;
     int version = 0;
+
+    init_options();
 
     struct option longopts[] = {
         { "ackmate", no_argument, &(opts.ackmate), 1 },
@@ -155,6 +155,9 @@ void parse_options(int argc, char **argv) {
         }
     }
 
+    argc -= optind;
+    argv += optind;
+
     if (help) {
         usage();
         exit(0);
@@ -179,6 +182,19 @@ void parse_options(int argc, char **argv) {
         opts.color = 0;
     }
 
-    argc -= optind;
-    argv += optind;
+    *query = malloc(strlen(argv[optind - 1]) + 1);
+    strcpy(*query, argv[optind - 1]);
+
+    if (optind < argc) {
+      path_len = strlen(argv[optind]);
+      *path = malloc(path_len);
+      strcpy(*path, argv[optind]);
+      // kill trailing slash
+      if (path_len > 0 && path[path_len-1] == '/') {
+        *path[path_len-1] = '\0';
+      }
+    }
+    else {
+      *path = strdup(".");
+    }
 }

--- a/src/options.h
+++ b/src/options.h
@@ -31,7 +31,7 @@ typedef struct {
 cli_options opts;
 
 void init_options();
-void parse_options(int argc, char **argv);
+void parse_options(int argc, char **argv, char **query, char **path);
 void cleanup_options();
 
 void usage();


### PR DESCRIPTION
Default to the current working directory for searching and fix parsing for query + path.
