### PR TITLE
replace strlcpy/strlcat by Apache Traffic Server's implementation

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -125,38 +125,58 @@ int is_regex(const char* query, const int query_len) {
 }
 
 /*
- * strlcat and strlcpy, taken from linux kernel
+ * strlcat and strlcpy, taken from Apache Traffic Server
  */
-size_t strlcat(char *dest, const char *src, size_t count)
+size_t strlcat(char *dst, const char *src, size_t siz)
 {
-    size_t dsize = strlen(dest);
-    size_t len = strlen(src);
-    size_t res = dsize + len;
+    char *d = dst;
+    const char *s = src;
+    size_t n = siz;
+    size_t dlen;
 
-    dest += dsize;
-    count -= dsize;
+  /* Find the end of dst and adjust bytes left but don't go past end */
+    while (n-- != 0 && *d != '\0')
+      d++;
+    dlen = d - dst;
+    n = siz - dlen;
 
-    if (len >= count) {
-        len = count - 1;
+    if (n == 0)
+      return (dlen + strlen(s));
+    while (*s != '\0') {
+      if (n != 1) {
+        *d++ = *s;
+        n--;
+      }
+      s++;
     }
+    *d = '\0';
 
-    memcpy(dest, src, len);
-
-    dest[len] = 0;
-
-    return(res);
+    return (dlen + (s - src));  /* count does not include NUL */
 }
 
-size_t strlcpy(char *dest, const char *src, size_t size)
+size_t strlcpy(char *dst, const char *src, size_t siz)
 {
-    size_t ret = strlen(src);
+    char *d = dst;
+    const char *s = src;
+    size_t n = siz;
 
-    if (size)
-    {
-        size_t len = (ret >= size) ? size - 1 : ret;
-        memcpy(dest, src, len);
-        dest[len] = '\0';
+    /* Copy as many bytes as will fit */
+    if (n != 0) {
+      while (--n != 0) {
+        if ((*d++ = *s++) == '\0')
+          break;
+      }
     }
 
-    return(ret);
+    /* Not enough room in dst, add NUL and traverse rest of src */
+    if (n == 0) {
+      if (siz != 0)
+        *d = '\0';      /* NUL-terminate dst */
+
+      while (*s++)
+        ;
+    }
+
+    return (s - src - 1);   /* count does not include NUL */
 }
+


### PR DESCRIPTION
to be license wise on the safe side.
Source:

http://git-wip-us.apache.org/repos/asf?p=trafficserver.git;a=blob;f=lib/ts/ink_string.cc;h=d504c2e5704137755480dab9b2832922657fe847;hb=HEAD
