### PR TITLE
Fixed 2 warnings that pop up on non-BSD OS's

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -16,7 +16,8 @@ LDFLAGS="$LDFLAGS"
 
 AC_CHECK_DECL([PCRE_CONFIG_JIT], [AC_DEFINE([USE_PCRE_JIT], [], [Use PCRE JIT])], [], [#include <pcre.h>])
 
-AC_CHECK_FUNCS(getline strlcpy strlcat strndup)
+# the kqueue part of this is slightly ugly, but it's one cheap way to get BSD detection
+AC_CHECK_FUNCS(getline strlcpy strlcat strndup kqueue)
 
 AC_CONFIG_FILES([Makefile])
 AC_CONFIG_HEADERS([src/config.h])

--- a/src/search.c
+++ b/src/search.c
@@ -168,7 +168,12 @@ void search_dir(const pcre *re, const pcre_extra *re_extra, const char* path, co
     int i;
 
     /* find agignore/gitignore/hgignore/etc files to load ignore patterns from */
+	/* This is ugly, but it's the cleanest way to handle this */
+#ifndef HAVE_KQUEUE
+    results = scandir(path, &dir_list, (int (*)(const struct dirent *))&ignorefile_filter, &alphasort);
+#else
     results = scandir(path, &dir_list, &ignorefile_filter, &alphasort);
+#endif
     if (results > 0) {
         for (i = 0; i < results; i++) {
             dir = dir_list[i];
@@ -187,7 +192,12 @@ void search_dir(const pcre *re, const pcre_extra *re_extra, const char* path, co
     free(dir_list);
     dir_list = NULL;
 
+	/* This is ugly, but it's the cleanest way to handle this */
+#ifndef HAVE_KQUEUE
+    results = scandir(path, &dir_list, (int (*)(const struct dirent *))&filename_filter, &alphasort);
+#else
     results = scandir(path, &dir_list, &filename_filter, &alphasort);
+#endif
     if (results == 0)
     {
         log_debug("No results found in directory %s", path);


### PR DESCRIPTION
I added a configure detection for kqueue (which is BSD-only and is _VERY_ unlikely to ever be ported to linux at least) which offers decent, cheap BSD detection and used it for an ifdef in search.c and used a cast to const to avoid a warning that shows up on linux and it appears that const for that argument is the standard[1]. 

[1] http://pubs.opengroup.org/onlinepubs/9699919799/functions/scandir.html

:)
