### PR TITLE
Minor documentation fix

### DIFF
--- a/doc/ag.1
+++ b/doc/ag.1
@@ -86,7 +86,7 @@ Recursively search for PATTERN in PATH\. Like grep or ack, but faster\.
 .IP "" 0
 .
 .SH "IGNORING FILES"
-Ag will ignore files matched by patterns in \.gitignore, \.hgignore, or \.aginore\. Ag also ignores binary files by default\.
+Ag will ignore files matched by patterns in \.gitignore, \.hgignore, or \.agignore\. Ag also ignores binary files by default\.
 .
 .SH "EXAMPLES"
 \fBag printf\fR: Find matches for "printf" in the current directory\.


### PR DESCRIPTION
I was also thinking about mentioning that multiple directories are not matched during the search (eg dist/something_special does not work but something_special does), but I'm not sure if that is a bug (as it works for git) or if it is left like so for performance reasons.
