### PR TITLE
Ignores _sgbak folders by default

### DIFF
--- a/src/ignore.c
+++ b/src/ignore.c
@@ -124,7 +124,7 @@ int filename_filter(struct dirent *dir) {
     int i;
     if(strcmp(filename, "_sgbak")==0)
     {
-      printf("File %s ignored because it's an _sgbak file", dir->d_name);
+      log_debug("File %s ignored because it's an _sgbak file", dir->d_name);
       return(0);
     }
     if (!opts.follow_symlinks && dir->d_type == DT_LNK) {


### PR DESCRIPTION
_sgbak folders hold the old versions in SourceGear's Vault directory. Ignoring it is the default behavior in ack. This is a pretty quick and dirty patch, and it seems like this will eventually go in the "huge-ass list of files we want to ignore by default". I dunno if you really want this, but I needed it and figured I'd throw it out there.
