### PR TITLE
First attempt to close issue #43

### DIFF
--- a/src/ignore.h
+++ b/src/ignore.h
@@ -20,5 +20,6 @@ void load_svn_ignore_patterns(const char *path, const int path_len);
 
 int ignorefile_filter(struct dirent *dir);
 int filename_filter(struct dirent *dir);
+int filepath_filter(char *filepath);
 
 #endif

--- a/src/search.c
+++ b/src/search.c
@@ -289,6 +289,9 @@ void search_dir(const pcre *re, const pcre_extra *re_extra, const char* path, co
         }
 
         log_debug("dir %s type %i", dir_full_path, dir->d_type);
+        if ( ! filepath_filter(dir_full_path)) {
+            goto cleanup;
+        }
 
         /* TODO: scan files in current dir before going deeper */
         if (dir->d_type == DT_DIR) {


### PR DESCRIPTION
Hi, 

I am using **ag** during development and this issue about not ignoring the files correctly is obfuscating my output. Since ag is really **faster** than ack and grep I tried to fix the issue. :D

Is not perfect yet but it helps a lot, with this commit you can put in _.agignore_ paths like:

```
./tests/unit/coverage
```

or

```
./tests/unit/coverage/*
```

And it will ignore the directories and files that matches the regex, for the moment you need the `./` prefix in pattern.
