### PR TITLE
Lack of additional info from pcre_study isn't fatal.

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -186,7 +186,7 @@ void parse_options(int argc, char **argv, char **paths[]) {
                 }
 
                 opts.file_search_regex_extra = pcre_study(opts.file_search_regex, 0, &pcre_err);
-                if (opts.file_search_regex_extra == NULL) {
+                if (opts.file_search_regex_extra == NULL && pcre_err != NULL) {
                   log_err("pcre_study of file-search-regex failed. Error: %s", pcre_err);
                   exit(1);
                 }


### PR DESCRIPTION
From pcre_study manpage:
If the function returns NULL, either it could not find any
additional information, or there was an error. You can tell the
difference by looking at the error value. It is NULL in first case.

Previously, Ag simply died if pcre_study returned NULL, without
checking to see which case had caused it.  This doesn't seem to
be a problem on OS X 10.8 with libpcre 8.31, but it causes
unnecessary failure on Debian 5 with libpcre 7.6.
