### PR TITLE
If --stats not available, no need for the time_start variable

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -36,7 +36,9 @@ int main(int argc, char **argv) {
     }
 #endif
 
-    gettimeofday(&(stats.time_start), NULL);
+    if (opts.stats) {
+      gettimeofday(&(stats.time_start), NULL);
+    }
 
     parse_options(argc, argv, &paths);
     log_debug("PCRE Version: %s", pcre_version());


### PR DESCRIPTION
I'm no c programmer, but looked a bit into the source files of this project, and fell over main.c and that time_start variable is set (line #39) no matter if --stats param is set or not.

And further down the page, the time_end variable is only set if --stats is avail.

Am i wrong here ?
