### PR TITLE
Add -U/--skip-vcs-ignores

### DIFF
--- a/doc/ag.1.md
+++ b/doc/ag.1.md
@@ -60,6 +60,8 @@ Recursively search for PATTERN in PATH. Like grep or ack, but faster.
     Search all text files. This doesn't include hidden files.
   * `-u --unrestricted`:
     Search *all* files. This ignores .agignore, .gitignore, etc. It searches binary and hidden files as well.
+  * `-U, --skip-vcs-ignores`:
+    Ignore VCS ignore files (.gitigore, .hgignore, svn:ignore), but still use .agignore.
   * `-v --invert-match`
   * `-w --word-regexp`:
     Only match whole words.
@@ -67,6 +69,8 @@ Recursively search for PATTERN in PATH. Like grep or ack, but faster.
 ## IGNORING FILES
 
 By default, ag will ignore files matched by patterns in .gitignore, .hgignore, or .agignore. Ag also ignores files matched by the svn:ignore property in subversion repositories. Binary files are ignored by default as well.
+
+If you want to ignore .gitignore, .hgignore, and svn:ignore but still take .agignore into account, use `-U`.
 
 Use the `-a` option to search all text files, and `-u` to search *all* files.
 

--- a/src/options.c
+++ b/src/options.c
@@ -144,6 +144,7 @@ void parse_options(int argc, char **argv, char **paths[]) {
         { "nosmart-case", no_argument, &useless, 0 },
         { "stats", no_argument, &(opts.stats), 1 },
         { "unrestricted", no_argument, NULL, 'u' },
+        { "skip-vcs-ignores", no_argument, NULL, 'U' },
         { "version", no_argument, &version, 1 },
         { "word-regexp", no_argument, NULL, 'w' },
         { "workers", required_argument, NULL, 0 },
@@ -169,7 +170,7 @@ void parse_options(int argc, char **argv, char **paths[]) {
         group = 0;
     }
 
-    while ((ch = getopt_long(argc, argv, "A:aB:C:DG:g:fhiLlm:nQvVtuw", longopts, &opt_index)) != -1) {
+    while ((ch = getopt_long(argc, argv, "A:aB:C:DG:g:fhiLlm:nQvVtuUw", longopts, &opt_index)) != -1) {
         switch (ch) {
             case 'A':
                 opts.after = atoi(optarg);
@@ -220,11 +221,14 @@ void parse_options(int argc, char **argv, char **paths[]) {
                 break;
             case 't':
                 opts.search_all_files = 1;
-            break;
+                break;
             case 'u':
                 opts.search_binary_files = 1;
                 opts.search_all_files = 1;
                 opts.search_hidden_files = 1;
+                break;
+            case 'U':
+                opts.skip_vcs_ignores = 1;
                 break;
             case 'v':
                 opts.invert_match = 1;

--- a/src/options.h
+++ b/src/options.h
@@ -38,6 +38,7 @@ typedef struct {
     pcre_extra *re_extra;
     int recurse_dirs;
     int search_all_files;
+    int skip_vcs_ignores;
     int search_binary_files;
     int search_hidden_files;
     int search_stream; /* true if tail -F blah | ag */

--- a/src/search.c
+++ b/src/search.c
@@ -253,7 +253,7 @@ void search_dir(ignores *ig, const char* path, const int depth) {
     int i;
 
     /* find agignore/gitignore/hgignore/etc files to load ignore patterns from */
-    for (i = 0; ignore_pattern_files[i] != NULL; i++) {
+    for (i = 0; opts.skip_vcs_ignores ? (i == 0) : (ignore_pattern_files[i] != NULL); i++) {
         ignore_file = ignore_pattern_files[i];
         path_len = (size_t)(strlen(path) + strlen(ignore_file) + 2); /* 2 for slash and null char */
         dir_full_path = malloc(path_len);


### PR DESCRIPTION
This option skips VCS ignore files, but still takes .agignore into account.

This is pretty much a proof of concept, so feel free to ignore it if you want.  The option letter and longopt name could be better.  Plus I'm not sure how you'd want to actually implement the check -- I just added it where it'd be the fastest to see how it would work.
