### PR TITLE
Fix search that starts at root directory "/"

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -395,7 +395,7 @@ void parse_options(int argc, char **argv, char **paths[]) {
             path = strdup(argv[i]);
             path_len = strlen(path);
             /* kill trailing slash */
-            if (path_len > 0 && path[path_len - 1] == '/') {
+            if (path_len > 1 && path[path_len - 1] == '/') {
               path[path_len - 1] = '\0';
             }
             (*paths)[i] = path;


### PR DESCRIPTION
Currently, ag fails if the user does a search starting at the root directory of the hard disk, specifying nothing more than "/" for the directory, e.g. "ag foo /".  This patch fixes that admittedly rare edge case.
