### PR TITLE
Remove a leading "./" before printing

### DIFF
--- a/src/print.c
+++ b/src/print.c
@@ -18,6 +18,7 @@ const char *colors_line_number = "\e[1;33m"; /* yellow with black background */
 
 void print_path(const char* path, const char sep) {
     log_debug("printing path");
+    path = normalize_path(path);
 
     if (opts.ackmate) {
         fprintf(out_fd, ":%s%c", path, sep);
@@ -31,6 +32,7 @@ void print_path(const char* path, const char sep) {
 }
 
 void print_binary_file_matches(const char* path) {
+    path = normalize_path(path);
     print_file_separator();
     fprintf(out_fd, "Binary file %s matches.\n", path);
 }
@@ -210,4 +212,12 @@ void print_file_separator() {
         fprintf(out_fd, "\n");
     }
     first_file_match = 0;
+}
+
+const char* normalize_path(const char* path) {
+	if (strlen(path) >= 3 && path[0] == '.' && path[1] == '/') {
+		return path + 2;
+	} else {
+		return path;
+	}
 }

--- a/src/print.h
+++ b/src/print.h
@@ -8,5 +8,6 @@ void print_binary_file_matches(const char* path);
 void print_file_matches(const char* path, const char* buf, const int buf_len, const match matches[], const int matches_len);
 void print_line_number(const int line, const char sep);
 void print_file_separator();
+const char* normalize_path(const char* path);
 
 #endif


### PR DESCRIPTION
There's a small difference between the pathnames from `ack` and the ones in `ag` for searches in the current directory:

Here's the output of `ack --nogroup --nocolor --column print_binary_file_matches`:

```
src/search.c:135:13:            print_binary_file_matches(dir_full_path);
src/print.h:7:6:void print_binary_file_matches(const char* path);
src/print.c:34:6:void print_binary_file_matches(const char* path) {
```

And here's the one from `ag --nogroup --nocolor --column print_binary_file_matches`:

```
./src/print.h:7:6:void print_binary_file_matches(const char* path);
./src/search.c:135:13:            print_binary_file_matches(dir_full_path);
./src/print.c:33:6:void print_binary_file_matches(const char* path) {
```

`Ag` outputs relative paths, even if you're currently in the same directory. This turns out to be particularly weird when fed to Vim, since it normalizes some of the paths and leaves others as-is, for some reason.

I've added a simple check to print `path + 2` instead of `path` whenever a path starts with `./`, and this seems to work just fine.

Bear in mind that I'm not very proficient with C and I can't say I've experimented a lot with the fix (in that line of thought, +1 to @sjl for #73), so if you have a better idea, feel free to ignore the code.
