### PR TITLE
support for AG_OPTIONS

### DIFF
--- a/src/options.h
+++ b/src/options.h
@@ -65,8 +65,9 @@ typedef struct {
 cli_options opts;
 
 void init_options();
-void parse_options(int argc, char **argv, char **base_paths[], char **paths[]);
+void parse_options(int argc0, char **argv0, char **base_paths[], char **paths[]);
 void cleanup_options();
+void ag_options(int argc0, char **argv0, int *argc, char ***argv);
 
 void usage();
 


### PR DESCRIPTION
Please be gentle - I haven't written any C in a while. Feel free to edit. :)

I renamed the original argc/argv to argc0/argv0.

I didn't bother freeing the copies at the end. I noticed some other leaks with valgrind, so I figured you don't care. Because of the way argc & argv are used you'd have to make a copy of the original pointers if you want to free them later.
