### PR TITLE
Attempt to mimic .gitignore more closely

### DIFF
--- a/src/ignore.c
+++ b/src/ignore.c
@@ -66,7 +66,7 @@ void add_ignore_pattern(ignores *ig, const char* pattern) {
     int pattern_len;
 
     /* Skip leading / — which, in .gitignore, doesn't mean filesystem root. */
-    if (strncmp(pattern, "/", 1) == 0) {
+    if ('/' == pattern[0]) {
         pattern += 1;
     }
 


### PR DESCRIPTION
man 5 gitignore says:

```
A leading slash matches the beginning of the pathname. For example,
"/*.c" matches "cat-file.c" but not "mozilla-sha1/sha1.c".
```

Certain frameworks, such as Ruby on Rails, generate patterns like this:

```
/*/*.log
```

Which were not getting ignored from `ag`. This patch fixes that for me,
but I'm not at all sure if it is otherwise correct.

Thanks!
