### PR TITLE
Respect the .git/info/exclude

### DIFF
--- a/src/ignore.c
+++ b/src/ignore.c
@@ -24,6 +24,7 @@ const char *evil_hardcoded_ignore_files[] = {
 const char *ignore_pattern_files[] = {
     ".agignore",
     ".gitignore",
+    ".git/info/exclude",
     ".hgignore",
     ".svn",
     NULL


### PR DESCRIPTION
This commit adds .git/info/exclude to the list of files that ignore rules are read from.  .git/info/exclude is just like the .gitignore (but local to the repo, so it is a good place to ignore files that other are specific to you or your tools).
