### PR TITLE
Spec file for generating RPM

### DIFF
--- a/the_silver_searcher.spec
+++ b/the_silver_searcher.spec
@@ -46,10 +46,6 @@ make %{?_smp_mflags}
 %install
 rm -rf %{buildroot}
 make install DESTDIR=%{buildroot}
-rm -rf %{buildroot}/usr/share/doc
-
-%post -p /sbin/ldconfig
-%postun -p /sbin/ldconfig
 
 %clean
 rm -rf %{buildroot}


### PR DESCRIPTION
This spec file generates an RPM. I used CentOS 6.3 to develop it, but I see no reason why it wouldn't work on other RPM-based distros.
