### PR TITLE
Fix incorrect version variable in spec file source

### DIFF
--- a/the_silver_searcher.spec
+++ b/the_silver_searcher.spec
@@ -6,7 +6,7 @@ Summary:	A code-searching tool similar to ack, but faster
 Group:		Applications/Utilities
 License:	Apache v2.0
 URL:		https://github.com/ggreer/%{name}
-Source0:	https://github.com/downloads/ggreer/%{name}/%{name}-${version}.tar.gz
+Source0:	https://github.com/downloads/ggreer/%{name}/%{name}-%{version}.tar.gz
 BuildRoot:	%(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 
 BuildRequires:	pkgconfig, autoconf, pcre-devel


### PR DESCRIPTION
This was just a typo in the spec file using `${version}` instead of the proper `%{version}` in the Source0 URL, which caused rpmbuild to fail:

```
error: File /home/vagrant/rpmbuild/SOURCES/the_silver_searcher-${version}.tar.gz: No such file or directory
```
