### PR TITLE
Generate a more standard (and fish-friendly!) man page

### DIFF
--- a/doc/ag.1
+++ b/doc/ag.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "AG" "1" "January 2013" "" ""
+.TH "AG" "1" "February 2013" "" ""
 .
 .SH "NAME"
 \fBag\fR \- The Silver Searcher\. Like ack, but faster\.
@@ -13,115 +13,207 @@
 Recursively search for PATTERN in PATH\. Like grep or ack, but faster\.
 .
 .SH "OPTIONS"
+\fB\-\-ackmate\fR:
 .
-.IP "\(bu" 4
-\fB\-\-ackmate\fR: Output results in a format parseable by AckMate \fIhttps://github\.com/protocool/AckMate\fR\.
+.br
+\~\~\~\~ Output results in a format parseable by AckMate \fIhttps://github\.com/protocool/AckMate\fR\.
 .
-.IP "\(bu" 4
-\fB\-a \-\-all\-types\fR: Search all files\. This doesn\'t include hidden files, and also doesn\'t respect any ignore files
+.P
+\fB\-a \-\-all\-types\fR:
 .
-.IP "\(bu" 4
-\fB\-A \-\-after [LINES]\fR: Print lines before match\. Defaults to 2\.
+.br
+\~\~\~\~ Search all files\. This doesn\'t include hidden files, and also doesn\'t respect any ignore files
 .
-.IP "\(bu" 4
-\fB\-B \-\-before [LINES]\fR: Print lines after match\. Defaults to 2\.
+.P
+\fB\-A \-\-after [LINES]\fR:
 .
-.IP "\(bu" 4
-\fB\-\-[no]break\fR: Print a newline between matches in different files\. Enabled by default\.
+.br
+\~\~\~\~ Print lines before match\. Defaults to 2\.
 .
-.IP "\(bu" 4
-\fB\-\-[no]color\fR: Print color codes in results\. Enabled by default\.
+.P
+\fB\-B \-\-before [LINES]\fR:
 .
-.IP "\(bu" 4
-\fB\-\-column\fR: Print column numbers in results\.
+.br
+\~\~\~\~ Print lines after match\. Defaults to 2\.
 .
-.IP "\(bu" 4
-\fB\-C \-\-context [LINES]\fR: Print lines before and after matches\. Defaults to 2\.
+.P
+\fB\-\-[no]break\fR:
 .
-.IP "\(bu" 4
-\fB\-D \-\-debug\fR: Output ridiculous amounts of debugging info\. Probably not useful\.
+.br
+\~\~\~\~ Print a newline between matches in different files\. Enabled by default\.
 .
-.IP "\(bu" 4
-\fB\-\-depth NUM\fR: Search up to NUM directories deep\. Default is 25\.
+.P
+\fB\-\-[no]color\fR:
 .
-.IP "\(bu" 4
-\fB\-f \-\-follow\fR: Follow symlinks\.
+.br
+\~\~\~\~ Print color codes in results\. Enabled by default\.
 .
-.IP "\(bu" 4
+.P
+\fB\-\-column\fR:
+.
+.br
+\~\~\~\~ Print column numbers in results\.
+.
+.P
+\fB\-C \-\-context [LINES]\fR:
+.
+.br
+\~\~\~\~ Print lines before and after matches\. Defaults to 2\.
+.
+.P
+\fB\-D \-\-debug\fR:
+.
+.br
+\~\~\~\~ Output ridiculous amounts of debugging info\. Probably not useful\.
+.
+.P
+\fB\-\-depth NUM\fR:
+.
+.br
+\~\~\~\~ Search up to NUM directories deep\. Default is 25\.
+.
+.P
+\fB\-f \-\-follow\fR:
+.
+.br
+\~\~\~\~ Follow symlinks\.
+.
+.P
 \fB\-\-[no]group\fR
 .
-.IP "\(bu" 4
-\fB\-g PATTERN\fR: Print filenames matching PATTERN\.
+.br
+\fB\-g PATTERN\fR:
 .
-.IP "\(bu" 4
-\fB\-G\fR, \fB\-\-file\-search\-regex PATTERN\fR: Only search filenames matching PATTERN\.
+.br
+\~\~\~\~ Print filenames matching PATTERN\.
 .
-.IP "\(bu" 4
+.P
+\fB\-G\fR, \fB\-\-file\-search\-regex PATTERN\fR:
+.
+.br
+\~\~\~\~ Only search filenames matching PATTERN\.
+.
+.P
 \fB\-\-[no]heading\fR
 .
-.IP "\(bu" 4
-\fB\-\-hidden\fR: Search hidden files\. This option obeys ignore files\.
+.br
+\fB\-\-hidden\fR:
 .
-.IP "\(bu" 4
-\fB\-\-ignore PATTERN\fR: Ignore files/directories matching this pattern\. Literal file and directory names are also allowed\.
+.br
+\~\~\~\~ Search hidden files\. This option obeys ignore files\.
 .
-.IP "\(bu" 4
-\fB\-\-ignore\-dir NAME\fR: Alias for \-\-ignore for compatibility with ack\.
+.P
+\fB\-\-ignore PATTERN\fR:
 .
-.IP "\(bu" 4
-\fB\-i \-\-ignore\-case\fR: Match case insensitively\.
+.br
+\~\~\~\~ Ignore files/directories matching this pattern\. Literal file and directory names are also allowed\.
 .
-.IP "\(bu" 4
-\fB\-l \-\-files\-with\-matches\fR: Only print filenames containing matches, not matching lines\.
+.P
+\fB\-\-ignore\-dir NAME\fR:
 .
-.IP "\(bu" 4
-\fB\-L \-\-files\-without\-matches\fR: Only print filenames that don\'t contain matches\.
+.br
+\~\~\~\~ Alias for \-\-ignore for compatibility with ack\.
 .
-.IP "\(bu" 4
-\fB\-m \-\-max\-count NUM\fR: Skip the rest of a file after NUM matches\. Default is 10,000\.
+.P
+\fB\-i \-\-ignore\-case\fR:
 .
-.IP "\(bu" 4
-\fB\-p \-\-path\-to\-agignore STRING\fR: Provide a path to a specific \.agignore file\.
+.br
+\~\~\~\~ Match case insensitively\.
 .
-.IP "\(bu" 4
-\fB\-\-pager COMMAND\fR: Use a pager such as less\. Use \fB\-\-nopager\fR to override\. This option is also ignored if output is piped to another program\.
+.P
+\fB\-l \-\-files\-with\-matches\fR:
 .
-.IP "\(bu" 4
-\fB\-\-print\-long\-lines\fR: Print matches on very long lines (> 2k characters by default)
+.br
+\~\~\~\~ Only print filenames containing matches, not matching lines\.
 .
-.IP "\(bu" 4
-\fB\-Q \-\-literal\fR: Do not parse PATTERN as a regular expression\. Try to match it literally\.
+.P
+\fB\-L \-\-files\-without\-matches\fR:
 .
-.IP "\(bu" 4
-\fB\-s \-\-case\-sensitive\fR: Match case sensitively\. Enabled by default\.
+.br
+\~\~\~\~ Only print filenames that don\'t contain matches\.
 .
-.IP "\(bu" 4
-\fB\-S \-\-smart\-case\fR: Match case sensitively if there are any uppercase letters in PATTERN, or case insensitively otherwise\.
+.P
+\fB\-m \-\-max\-count NUM\fR:
 .
-.IP "\(bu" 4
-\fB\-\-search\-binary\fR: Search binary files for matches\.
+.br
+\~\~\~\~ Skip the rest of a file after NUM matches\. Default is 10,000\.
 .
-.IP "\(bu" 4
-\fB\-\-stats\fR: Print stats (files scanned, time taken, etc)
+.P
+\fB\-p \-\-path\-to\-agignore STRING\fR:
 .
-.IP "\(bu" 4
-\fB\-t \-\-all\-text\fR: Search all text files\. This doesn\'t include hidden files\.
+.br
+\~\~\~\~ Provide a path to a specific \.agignore file\.
 .
-.IP "\(bu" 4
-\fB\-u \-\-unrestricted\fR: Search \fIall\fR files\. This ignores \.agignore, \.gitignore, etc\. It searches binary and hidden files as well\.
+.P
+\fB\-\-pager COMMAND\fR:
 .
-.IP "\(bu" 4
-\fB\-U \-\-skip\-vcs\-ignores\fR: Ignore VCS ignore files (\.gitigore, \.hgignore, svn:ignore), but still use \.agignore\.
+.br
+\~\~\~\~ Use a pager such as less\. Use \fB\-\-nopager\fR to override\. This option is also ignored if output is piped to another program\.
 .
-.IP "\(bu" 4
+.P
+\fB\-\-print\-long\-lines\fR:
+.
+.br
+\~\~\~\~ Print matches on very long lines (> 2k characters by default)
+.
+.P
+\fB\-Q \-\-literal\fR:
+.
+.br
+\~\~\~\~ Do not parse PATTERN as a regular expression\. Try to match it literally\.
+.
+.P
+\fB\-s \-\-case\-sensitive\fR:
+.
+.br
+\~\~\~\~ Match case sensitively\. Enabled by default\.
+.
+.P
+\fB\-S \-\-smart\-case\fR:
+.
+.br
+\~\~\~\~ Match case sensitively if there are any uppercase letters in PATTERN, or case insensitively otherwise\.
+.
+.P
+\fB\-\-search\-binary\fR:
+.
+.br
+\~\~\~\~ Search binary files for matches\.
+.
+.P
+\fB\-\-stats\fR:
+.
+.br
+\~\~\~\~ Print stats (files scanned, time taken, etc)
+.
+.P
+\fB\-t \-\-all\-text\fR:
+.
+.br
+\~\~\~\~ Search all text files\. This doesn\'t include hidden files\.
+.
+.P
+\fB\-u \-\-unrestricted\fR:
+.
+.br
+\~\~\~\~ Search \fIall\fR files\. This ignores \.agignore, \.gitignore, etc\. It searches binary and hidden files as well\.
+.
+.P
+\fB\-U \-\-skip\-vcs\-ignores\fR:
+.
+.br
+\~\~\~\~ Ignore VCS ignore files (\.gitigore, \.hgignore, svn:ignore), but still use \.agignore\.
+.
+.P
 \fB\-v \-\-invert\-match\fR
 .
-.IP "\(bu" 4
-\fB\-w \-\-word\-regexp\fR: Only match whole words\.
+.br
+\fB\-w \-\-word\-regexp\fR:
 .
-.IP "" 0
+.br
+\~\~\~\~ Only match whole words\.
 .
-.SH "IGNORING FILES"
+.P
 By default, ag will ignore files matched by patterns in \.gitignore, \.hgignore, or \.agignore\. These files can be anywhere in the directories being searched\. Ag also ignores files matched by the svn:ignore property in subversion repositories\. Finally, ag looks in $HOME/\.agignore for ignore patterns\. Binary files are ignored by default as well\.
 .
 .P

--- a/doc/generate_man.sh
+++ b/doc/generate_man.sh
@@ -2,4 +2,48 @@
 
 # ronn is used to turn the markdown into a manpage.
 # Get ronn at https://github.com/rtomayko/ronn
-ronn -r ag.1.md
+
+awk '
+BEGIN{
+  in_options_block = 0;
+  first_item_in_list_of_options = 1;
+}
+
+{
+  if ($0 == "## OPTIONS") {
+    in_options_block = 1;
+  }
+
+  if (in_options_block == 1) { # in options block
+    first_4_chars = substr($0, 0, 4);
+
+    if (first_4_chars == "  * ") { # this line contains the option name
+
+      # print only 1 new line for cases like the following
+      # * `--[no]group`
+      # * `-g PATTERN`:
+      if (first_item_in_list_of_options == 1) {
+        print "";
+        first_item_in_list_of_options = 0;
+      }
+
+      # end the line with 2 spaces, so a literal <br> is inserted!
+      # more info at http://daringfireball.net/projects/markdown/syntax.php#p
+      printf("%s  \n", substr($0, 5));
+
+    } else if (first_4_chars == "    ") { # we are in a description line
+      printf("&nbsp;&nbsp;&nbsp;&nbsp;  %s\n", substr($0, 5));
+      first_item_in_list_of_options = 1;
+    } else if (first_4_chars == "## I") { # reached the end of #OPTIONS part
+      in_options_block = 0;
+    } else {
+      print $0;
+    }
+  } else { # outside options block
+    print $0;
+  }
+}' <ag.1.md >ag.1.md.tmp
+
+ronn -r ag.1.md.tmp
+
+rm -f ag.1.md.tmp


### PR DESCRIPTION
This is what `man ack` looks like on my machine ( _I strongly recommend you to enable colors for man pages, like I did. Instructions for [bash](http://blog.0x1fff.com/2009/11/linux-tip-color-enabled-pager-less.html) and [fish](https://github.com/pooriaazimi/dotfiles/blob/master/fish/config.fish#L50-L58)_ ):

![ack](https://f.cloud.github.com/assets/814637/121340/adf44140-6d8a-11e2-8407-cc499c280ee8.png)

This is `man ag`:

![ag-before](https://f.cloud.github.com/assets/814637/121341/c345ccf8-6d8a-11e2-9ddf-b49a78a2c946.png)

A couple things are wrong with `ag`'s man page:
1. Option lines start with a stupid, useless `o` (probably because they're list items in original markdown file)
2. Description lines are NOT in the line after option names (you know, like literally all other unix man pages!)

Why on earth would anyone care? Because I use the excellent [fish](http://ridiculousfish.com/shell/) shell. It has a handy little feature that quickly shows you all available options and their "meaning" when you press tab. For example, if you type `ag --a` and press tab, it will print the following in the terminal:

```
--ackmate:  (Output results in a format parseable by ... [See Man Page])
--after                                       (Print lines before match)
--all-text:                                      (Search all text files)
--all-types:                                          (Search all files)
```

or, when you type `ag -q`, the cursor will turn red (as there's no `-q` option!). These cases can bee seen in the following screenshot:

![ag-correct-and-wrong-options](https://f.cloud.github.com/assets/814637/121352/0ec36270-6d8c-11e2-81ea-70d5046082e4.png)

Even more useful, if you type `ag -` and press tab, it lists ALL options:

![fish-completions](https://f.cloud.github.com/assets/814637/121354/2748720e-6d8c-11e2-80b8-6bd92d0c289d.png)

The wonderful thing is that there's no `fish-completions` like there is for `bash` (`bash-completions`). `fish` literally generates this autocompletion list by parsing man pages.

So, this is why I care about "standard" man page.

Right now, `ag`'s man page is NOT standard and none of the above completions happen.

I changed the script that builds man pages (`doc/generate_man.sh` file) and added a fairly simple AWK script that tries to tidy up the markdown version of man page (`ag.1.md`). It writes the tidied version to a temp file (`ag.1.man.tmp`) that gets deleted at the end of the script. `ronn` now uses this temporary file to generate the actual man page.

The script is extremely straightforward. I've included a few comments that explain what (and why) I'm doing stuff (they might not be of best quality though, as it's 2:30 AM here!).

This is how `ag`'s man page looks like. As a bonus, I've even handled "multiline" options (two options that share the same description), as it's apparent in the second screenshot below. Currently, `ag`'s man page displays it all wrong and messed up.

![ag-after](https://f.cloud.github.com/assets/814637/121361/545e4ede-6d8d-11e2-8781-41dc0ca9b013.png)

![ag-after-multiline](https://f.cloud.github.com/assets/814637/121362/5c8bf3d6-6d8d-11e2-85ad-b4280c99b2e9.png)

Signed-off-by: Pooria Azimi pooriaazimi@me.com
