### PR TITLE
Add option to suppress line numbers output

### DIFF
--- a/ag.bashcomp.sh
+++ b/ag.bashcomp.sh
@@ -43,6 +43,7 @@ _ag() {
     --line-numbers
     --literal
     --max-count
+    --no-numbers
     --path-to-agignore
     --print-long-lines
     --search-binary

--- a/doc/ag.1
+++ b/doc/ag.1
@@ -139,6 +139,12 @@ Recursively search for PATTERN in PATH\. Like grep or ack, but faster\.
 \~\~\~\~ Skip the rest of a file after NUM matches\. Default is 10,000\.
 .
 .P
+\fB\-\-no\-numbers\fR:
+.
+.br
+\~\~\~\~ Don\'t show line numbers
+.
+.P
 \fB\-p \-\-path\-to\-agignore STRING\fR:
 .
 .br

--- a/doc/ag.1.md
+++ b/doc/ag.1.md
@@ -53,6 +53,8 @@ Recursively search for PATTERN in PATH. Like grep or ack, but faster.
     Only print filenames that don't contain matches.
   * `-m --max-count NUM`:
     Skip the rest of a file after NUM matches. Default is 10,000.
+  * `--no-numbers`:            
+    Don't show line numbers
   * `-p --path-to-agignore STRING`:
     Provide a path to a specific .agignore file.
   * `--pager COMMAND`:

--- a/src/options.c
+++ b/src/options.c
@@ -58,6 +58,7 @@ Search options:\n\
 -L --files-without-matches\n\
                         Only print filenames that don't contain matches\n\
 -m --max-count NUM      Skip the rest of a file after NUM matches (Default: 10,000)\n\
+--no-numbers            Don't show line numbers\n\
 -p --path-to-agignore STRING\n\
                         Use .agignore file at STRING\n\
 --print-long-lines      Print matches on very long lines (Default: >2k characters)\n\
@@ -175,6 +176,7 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
         { "literal", no_argument, NULL, 'Q' },
         { "match", no_argument, &useless, 0 },
         { "max-count", required_argument, NULL, 'm' },
+        { "no-numbers", no_argument, NULL, 0 },
         { "no-recurse", no_argument, NULL, 'n' },
         { "nobreak", no_argument, &opts.print_break, 0 },
         { "nocolor", no_argument, &opts.color, 0 },
@@ -328,6 +330,9 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
                     break;
                 } else if (strcmp(longopts[opt_index].name, "depth") == 0) {
                     opts.max_search_depth = atoi(optarg);
+                    break;
+                } else if (strcmp(longopts[opt_index].name, "no-numbers") == 0) {
+                    opts.print_line_numbers = FALSE;
                     break;
                 } else if (strcmp(longopts[opt_index].name, "ignore-dir") == 0) {
                     add_ignore_pattern(root_ignores, optarg);


### PR DESCRIPTION
What about adding option (like '--no-numbers' ) to disable line numbers output?

For example, you want to search for something in the form of "double ag":
$ ag <smth> | ag <smth2>

But if 'smth2' is a number, it may collide with line numbers from first 'ag' output.

P.S. sorry for issue and pull request mess
