### PR TITLE
Fix to check piped

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -144,6 +144,8 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
     const char *home_dir = getenv("HOME");
     char *ignore_file_path = NULL;
     int needs_query = 1;
+    struct stat statbuf;
+    int rv;
 
     init_options();
 
@@ -212,8 +214,11 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
         exit(1);
     }
 
-    /* stdin isn't a tty. something's probably being piped to ag */
-    if (!isatty(fileno(stdin))) {
+    rv = fstat(fileno(stdin), &statbuf);
+    if (rv != 0) {
+        die("Error fstat()ing stdin");
+    }
+    if (S_ISFIFO(statbuf.st_mode)) {
         opts.search_stream = 1;
     }
 
@@ -226,8 +231,6 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
         group = 0;
 
         /* Don't search the file that stdout is redirected to */
-        struct stat statbuf;
-        int rv;
         rv = fstat(fileno(stdout), &statbuf);
         if (rv != 0) {
             die("Error fstat()ing stdout");


### PR DESCRIPTION
I think that it is not enough to check piped by `isatty`.

Sample code is below.

``` c
#include <stdio.h>
#include <unistd.h>

int main (void)
{
    if (isatty(STDIN_FILENO)) {
        printf("stdin is tty\n");
    } else {
        printf("stdin is not tty\n");
    }

    return 0;
}
```

I got following output with terminal emulater

```
% ./isatty.out
stdin is tty
% echo foo | ./isatty.out
stdin is not tty
```

But I got following output with Emacs, because `stdin` is not tty.

```
(call-process-shell-command "./isatty.out" nil t) ;; => stdin is not tty
(call-process-shell-command "echo foo | ./isatty.out" nil t) ;; => stdin is not tty
```

So I think `S_ISFIFO`  is better than `isatty`.

``` c
#include <stdio.h>
#include <sys/types.h>
#include <sys/stat.h>
#include <unistd.h>

int main (void)
{
    struct stat st;
    int ret;

    ret = fstat(STDIN_FILENO, &st);
    if (ret != 0) {
        perror("stat:");
        return 1;
    }

    if (S_ISFIFO(st.st_mode)) {
        printf("stdin is fifo\n");
    } else {
        printf("stdin is not fifo\n");
    }

    return 0;
}
```

Terminal emulator

```
% ./stat.out
stdin is not fifo
% echo foo | ./stat.out
stdin is fifo
```

Emacs

```
(call-process-shell-command "./stat.out" nil t) ;; => stdin is not fifo
(call-process-shell-command "echo foo | ./stat.out" nil t) ;; => stdin is fifo
```

I got same result by `S_ISFIFO`.

But this patch changes behavior of `stdin` redirect as below

```
% ag search_word < file
```

Original code searchs only file content, but code applied this patch searchs
under current dictroy(same as `ack`).

Please check this patch, if you have no problems.
