### PR TITLE
Add installation instructions for ArchLinux

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ OS X:
 
     brew install the_silver_searcher
 
+ArchLinux:
+
+    pacman -S the_silver_searcher
+
 If you want a CentOS rpm or Ubuntu deb, take a look at [Vikram Dighe's packages](http://swiftsignal.com/packages/).
 
 ## Building from source ##


### PR DESCRIPTION
tss has been in Arch's [community] repo since January, almost everyone enables it so add Arch installation instructions. 

Maybe if another distro or 2 packages it, we should just scale this back to like: "Distros that officially package the_silver_searcher: Gentoo, ArchLinux, Brew (OS X)".
