### PR TITLE
Fixup load_ignore_patterns comment

### DIFF
--- a/src/ignore.c
+++ b/src/ignore.c
@@ -109,7 +109,7 @@ void add_ignore_pattern(ignores *ig, const char* pattern) {
     }
 }
 
-/* For loading git/svn/hg ignore patterns */
+/* For loading git/hg ignore patterns */
 void load_ignore_patterns(ignores *ig, const char *path) {
     FILE *fp = NULL;
     fp = fopen(path, "r");


### PR DESCRIPTION
I may be mistaken, but it looks like load_ignore_patterns isn't used to load SVN ignores (load_svn_ignore_patterns is) even though that's what the comment hints at. Fix the comment.
