### PR TITLE
Manpage fixes

### DIFF
--- a/doc/ag.1
+++ b/doc/ag.1
@@ -28,13 +28,13 @@ Recursively search for PATTERN in PATH\. Like grep or ack, but faster\.
 \fB\-A \-\-after [LINES]\fR:
 .
 .br
-\~\~\~\~ Print lines before match\. Defaults to 2\.
+\~\~\~\~ Print lines after match\. Defaults to 2\.
 .
 .P
 \fB\-B \-\-before [LINES]\fR:
 .
 .br
-\~\~\~\~ Print lines after match\. Defaults to 2\.
+\~\~\~\~ Print lines before match\. Defaults to 2\.
 .
 .P
 \fB\-\-[no]break\fR:


### PR DESCRIPTION
Hi!
The manpage explanations for `--after` and `--before` were swapped, this fixes it!
