### PR TITLE
Add support for decompressing of LZMA and XZ encoded files.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,7 @@ ACLOCAL_AMFLAGS = ${ACLOCAL_FLAGS}
 
 bin_PROGRAMS = ag
 ag_SOURCES = src/ignore.c src/log.c src/options.c src/print.c src/scandir.c src/search.c src/util.c src/decompress.c src/main.c
-ag_LDADD = ${PCRE_LIBS} -lz -lpthread
+ag_LDADD = ${PCRE_LIBS} ${LZMA_LIBS} -lz -lpthread
 
 man_MANS = doc/ag.1
 

--- a/configure.ac
+++ b/configure.ac
@@ -11,12 +11,13 @@ m4_ifdef(
 )
 
 PKG_CHECK_MODULES([PCRE], [libpcre])
+PKG_CHECK_MODULES([LZMA], [liblzma])
 
 # Run CFLAGS="-g" ./configure if you want debug symbols
 CFLAGS="$CFLAGS $PCRE_CFLAGS -Wall -Wextra -std=c89 -D_GNU_SOURCE"
 LDFLAGS="$LDFLAGS"
 
-AC_CHECK_HEADERS([pthread.h, zlib.h])
+AC_CHECK_HEADERS([pthread.h, zlib.h lzma.h])
 
 AC_CHECK_DECL([PCRE_CONFIG_JIT], [AC_DEFINE([USE_PCRE_JIT], [], [Use PCRE JIT])], [], [#include <pcre.h>])
 

--- a/src/decompress.h
+++ b/src/decompress.h
@@ -9,7 +9,8 @@ typedef enum {
     AG_NO_COMPRESSION,
     AG_GZIP,
     AG_COMPRESS,
-    AG_ZIP
+    AG_ZIP,
+    AG_XZ,
 } ag_compression_type;
 
 ag_compression_type is_zipped(const void* buf, const int buf_len);


### PR DESCRIPTION
- Add support for LZMA and XZ file formats, using liblzma.
- LZMA doesn't have a header format, so go with the 'best' we can without getting complicated. Seems to work in my test files.
- Only tested on OSX so far.
- Unsure how you want to do potentially optional dependencies, but everything should be behind `HAVE_LZMA_H` guards.
