### PR TITLE
fix SIGSSEGV in mempy called from ag_scandir

### DIFF
--- a/src/scandir.c
+++ b/src/scandir.c
@@ -42,14 +42,13 @@ int ag_scandir(const char *dirname,
 	 * Solaris, we need to actually allocate enough space for the whole
 	 * string.
 	 */
-        d = malloc(sizeof(struct dirent) + strlen(entry->d_name) + 1);
+        d = calloc(1, sizeof(struct dirent) + strlen(entry->d_name) + 1);
 #else
-        d = malloc(sizeof(struct dirent));
+        d = calloc(1, sizeof(struct dirent));
 #endif
         if (d == NULL) {
             goto fail;
         }
-        memset(d, 0, sizeof(struct dirent));
         memcpy(d, entry, entry->d_reclen);
 #if defined (__SVR4) && defined (__sun)
         strcpy(d->d_name, entry->d_name);


### PR DESCRIPTION
In some cases, or perhaps depending on its OS, ag gets SEGV as below. In my case , this happens on OpenBSD 5.2

It seems like copying whole dirent with memcpy is not good. 
Actual dirent from readdir could be shorter than sizeof(struct dirent) and touching whole structure can sometimes cause SEGV.
The patch uses d_reclen for the length, which is passed as "length of the record".

```
% ~/Sources/the_silver_searcher/ag "boot processor"
arch/amd64/amd64/cpu.c
221: * the local APIC on the boot processor has been mapped.
375:         printf("apid %d (boot processor)\n", caa->cpu_number);
zsh: segmentation fault (core dumped)  ~/Sources/the_silver_searcher/ag "boot processor"
```
