### PR TITLE
Update makefile for win32

### DIFF
--- a/Makefile.w32
+++ b/Makefile.w32
@@ -10,8 +10,9 @@ SRCS = \
 	src/util.c
 OBJS = $(subst .c,.o,$(SRCS))
 
-CFLAGS = -O2
-LIBS = -lz -lpthread -lpcre -lshlwapi
+VERSION=
+CFLAGS = -O2 -Isrc/win32 -DPACKAGE_VERSION=\"0.15pre\"
+LIBS = -lz -lpthread -lpcre -llzma -lshlwapi
 TARGET = ag.exe
 
 all : $(TARGET)

--- a/src/win32/config.h
+++ b/src/win32/config.h
@@ -1,0 +1,1 @@
+#define HAVE_LZMA_H


### PR DESCRIPTION
Updated Makefile.win32, this make be possible to build without configure on windows.
