### PR TITLE
ensure work_queue_mutex is locked when signaling files_ready.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -121,8 +121,10 @@ int main(int argc, char **argv) {
             symhash = NULL;
             search_dir(root_ignores, base_paths[i], paths[i], 0);
         }
+        pthread_mutex_lock(&work_queue_mtx);
         done_adding_files = TRUE;
         pthread_cond_broadcast(&files_ready);
+        pthread_mutex_unlock(&work_queue_mtx);
         for (i = 0; i < workers_len; i++) {
             if (pthread_join(workers[i], NULL)) {
                 die("pthread_join failed!");

--- a/src/search.c
+++ b/src/search.c
@@ -445,8 +445,8 @@ void search_dir(ignores *ig, const char *base_path, const char *path, const int 
                 work_queue_tail->next = queue_item;
             }
             work_queue_tail = queue_item;
-            pthread_mutex_unlock(&work_queue_mtx);
             pthread_cond_signal(&files_ready);
+            pthread_mutex_unlock(&work_queue_mtx);
             log_debug("%s added to work queue", dir_full_path);
         } else if (opts.recurse_dirs) {
             if (depth < opts.max_search_depth) {


### PR DESCRIPTION
(Apparently) Fixes #182
