### PR TITLE
prints files and numbers like './build.md:70'

### DIFF
--- a/doc/ag.1.md
+++ b/doc/ag.1.md
@@ -55,6 +55,8 @@ Recursively search for PATTERN in PATH. Like grep or ack, but faster.
     Skip the rest of a file after NUM matches. Default is 10,000.
   * `--no-numbers`:            
     Don't show line numbers
+  * `-N --files-with-numbers`:
+	Print file names and line numbers that contain matches.
   * `-p --path-to-agignore STRING`:
     Provide a path to a specific .agignore file.
   * `--pager COMMAND`:

--- a/src/options.c
+++ b/src/options.c
@@ -74,6 +74,7 @@ Search options:\n\
                         Only print filenames that don't contain matches\n\
 -m --max-count NUM      Skip the rest of a file after NUM matches (Default: 10,000)\n\
 --no-numbers            Don't show line numbers\n\
+-N --files-and-numbers  Print file names and line numbers that contain matches\n\
 -p --path-to-agignore STRING\n\
                         Use .agignore file at STRING\n\
 --print-long-lines      Print matches on very long lines (Default: >2k characters)\n\
@@ -184,6 +185,7 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
         { "file-search-regex", required_argument, NULL, 'G' },
         { "files-with-matches", no_argument, NULL, 'l' },
         { "files-without-matches", no_argument, NULL, 'L' },
+		{ "files-with-numbers", no_argument, NULL, 'N' },
         { "follow", no_argument, &opts.follow_symlinks, 1 },
         { "group", no_argument, &group, 1 },
         { "heading", no_argument, &opts.print_heading, 1 },
@@ -253,7 +255,7 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
         opts.stdout_inode = statbuf.st_ino;
     }
 
-    while ((ch = getopt_long(argc, argv, "A:aB:C:DG:g:fhiLlm:np:QRrSsvVtuUwz", longopts, &opt_index)) != -1) {
+    while ((ch = getopt_long(argc, argv, "A:aB:C:DG:g:fhiLlm:np:NQRrSsvVtuUwz", longopts, &opt_index)) != -1) {
         switch (ch) {
             case 'A':
                 opts.after = atoi(optarg);
@@ -308,6 +310,9 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
             case 'n':
                 opts.recurse_dirs = 0;
                 break;
+			case 'N':
+				opts.print_files_and_numbers = 1;
+				break;
             case 'p':
                 opts.path_to_agignore = optarg;
                 break;

--- a/src/options.h
+++ b/src/options.h
@@ -42,6 +42,7 @@ typedef struct {
     char *path_to_agignore;
     int print_break;
     int print_filename_only;
+	int print_files_and_numbers;
     int print_heading;
     int print_line_numbers;
     int print_long_lines; /* TODO: support this in print.c */

--- a/src/print.c
+++ b/src/print.c
@@ -56,7 +56,7 @@ void print_file_matches(const char* path, const char* buf, const int buf_len, co
 
     print_file_separator();
 
-    if (opts.print_heading == TRUE) {
+    if (opts.print_heading == TRUE && opts.print_files_and_numbers == FALSE) {
         print_path(path, '\n');
     }
 
@@ -132,7 +132,9 @@ void print_file_matches(const char* path, const char* buf, const int buf_len, co
                     for (; j <= i; j++) {
                         fputc(buf[j], out_fd);
                     }
-                } else {
+                } else if (opts.print_files_and_numbers) {
+					print_path_and_line_number(path, line, '\n');
+				} else {
                     print_line_number(line, ':');
                     if (opts.column) {
                         fprintf(out_fd, "%i:", (matches[last_printed_match].start - prev_line_offset) + 1);
@@ -201,6 +203,20 @@ void print_line_number(const int line, const char sep) {
     } else {
         fprintf(out_fd, "%i%c", line, sep);
     }
+}
+
+void print_path_and_line_number(const char* path, const int line, const char sep) {
+	if (!opts.print_files_and_numbers) {
+		return;
+	}
+    /* path = normalize_path(path); */
+
+	if (opts.color) {
+		fprintf(out_fd, "%s%s%s%s%s%i%s%c", opts.color_path, path, color_reset, 
+				opts.color_line_number, ":", line, color_reset, sep);
+	} else {
+		fprintf(out_fd, "%s%s%i%c", path, ":", line, sep);
+	}
 }
 
 void print_file_separator() {

--- a/src/print.h
+++ b/src/print.h
@@ -7,6 +7,7 @@ void print_path(const char* path, const char sep);
 void print_binary_file_matches(const char* path);
 void print_file_matches(const char* path, const char* buf, const int buf_len, const match matches[], const int matches_len);
 void print_line_number(const int line, const char sep);
+void print_path_and_line_number(const char* path, const int line, const char sep);
 void print_file_separator();
 const char* normalize_path(const char* path);
 


### PR DESCRIPTION
I wanted to be able to list files and numbers of matches so I could do a checklist-type-thing. So now, when you do `ag -N "myMatch"`, (or `ag --files-and-numbers "myMatch"`) it prints out a list of matching files like 

```
file1.cpp:42
file1.cpp:57

file2.cpp:29
```

and you can use it with `--nobreak` to get rid of the newlines if you don't like them. It has coloured and uncoloured output and stuff too. :yellow_heart:

By the way, great code! Haven't written C in a _long_ time, the source was very legible and extensible. Let me know if I missed or broke anything!
