### PR TITLE
Add cleanup()'s before process termination

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -142,6 +142,7 @@ int main(int argc, char **argv) {
     if (opts.pager) {
         pclose(out_fd);
     }
+    cleanup_options();
     pthread_cond_destroy(&files_ready);
     pthread_mutex_destroy(&work_queue_mtx);
     pthread_mutex_destroy(&stats_mtx);

--- a/src/options.c
+++ b/src/options.c
@@ -226,6 +226,8 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
 
     if (argc < 2) {
         usage();
+        cleanup_ignore(root_ignores);
+        cleanup_options();
         exit(1);
     }
 


### PR DESCRIPTION
`valgrind` showed some 'still reachable' memory blocks. It turned out that cleanup_options was never used.
Now `valgrind` outputs that 'no leaks are possible'. Hooray! 
