### PR TITLE
Add the option to only print matching line parts

### DIFF
--- a/ag.bashcomp.sh
+++ b/ag.bashcomp.sh
@@ -45,6 +45,7 @@ _ag() {
     --literal
     --max-count
     --no-numbers
+    --only-matching
     --pager
     --nopager
     --parallel
@@ -67,10 +68,10 @@ _ag() {
   shtopt='
     -a -A -B -C -D
     -f -g -G -h -i
-    -l -L -m -n -p
-    -Q -r -R -s -S
-    -t -u -U -v -V
-    -w -z
+    -l -L -m -n -o
+    -p -Q -r -R -s
+    -S -t -u -U -v
+    -V -w -z
   '
 
   # these options require an argument

--- a/doc/ag.1.md
+++ b/doc/ag.1.md
@@ -53,6 +53,8 @@ Recursively search for PATTERN in PATH. Like grep or ack, but faster.
     Only print filenames that don't contain matches.
   * `-m --max-count NUM`:
     Skip the rest of a file after NUM matches. Default is 10,000.
+  * `-o --only-matching`:
+    Only print the matching part of a line.
   * `--no-numbers`:            
     Don't show line numbers
   * `-p --path-to-agignore STRING`:

--- a/src/options.c
+++ b/src/options.c
@@ -74,6 +74,7 @@ Search options:\n\
                         Only print filenames that don't contain matches\n\
 -m --max-count NUM      Skip the rest of a file after NUM matches (Default: 10,000)\n\
 --no-numbers            Don't show line numbers\n\
+-o --only-matching      Only print the matching part of lines\n\
 -p --path-to-agignore STRING\n\
                         Use .agignore file at STRING\n\
 --print-long-lines      Print matches on very long lines (Default: >2k characters)\n\
@@ -196,6 +197,7 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
         { "line-numbers", no_argument, &opts.print_line_numbers, 2 },
         { "literal", no_argument, NULL, 'Q' },
         { "match", no_argument, &useless, 0 },
+        { "only-matching", no_argument, &opts.only_matching, 'o' },
         { "max-count", required_argument, NULL, 'm' },
         { "no-numbers", no_argument, NULL, 0 },
         { "no-recurse", no_argument, NULL, 'n' },
@@ -253,7 +255,7 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
         opts.stdout_inode = statbuf.st_ino;
     }
 
-    while ((ch = getopt_long(argc, argv, "A:aB:C:DG:g:fhiLlm:np:QRrSsvVtuUwz", longopts, &opt_index)) != -1) {
+    while ((ch = getopt_long(argc, argv, "A:aB:C:DG:g:fhiLlm:nop:QRrSsvVtuUwz", longopts, &opt_index)) != -1) {
         switch (ch) {
             case 'A':
                 opts.after = atoi(optarg);
@@ -307,6 +309,9 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
                 break;
             case 'n':
                 opts.recurse_dirs = 0;
+                break;
+            case 'o':
+                opts.only_matching = 1;
                 break;
             case 'p':
                 opts.path_to_agignore = optarg;

--- a/src/options.h
+++ b/src/options.h
@@ -39,6 +39,7 @@ typedef struct {
     int literal_ends_wordchar;
     int max_matches_per_file;
     int max_search_depth;
+    int only_matching;
     char *path_to_agignore;
     int print_break;
     int print_filename_only;

--- a/src/print.c
+++ b/src/print.c
@@ -155,10 +155,15 @@ void print_file_matches(const char* path, const char* buf, const int buf_len, co
                             }
                             printing_a_match = TRUE;
                         }
-                        fputc(buf[j], out_fd);
+                        if (!opts.only_matching || printing_a_match) {
+                            fputc(buf[j], out_fd);
+                        }
                     }
                     if (printing_a_match && opts.color) {
                         fprintf(out_fd, "%s", color_reset);
+                    }
+                    if (opts.only_matching) {
+                        fputc('\n', out_fd);
                     }
                 }
             } else if (lines_since_last_match <= opts.after) {


### PR DESCRIPTION
As suggested in #231. This still needs some work to handle the case
where the pattern is matched multiple times on one line. Currently this
will print the matched part twice on the same line with no separation.

It also may not play nicely with certain other options, but hopefully
it's a decent start.
