### PR TITLE
fix rpm spec

### DIFF
--- a/the_silver_searcher.spec
+++ b/the_silver_searcher.spec
@@ -13,7 +13,7 @@ Source0:	https://github.com/downloads/ggreer/%{name}/%{name}-%{version}.tar.gz
 Source1:	ag.bashcomp.sh
 BuildRoot:	%(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 
-BuildRequires:	pkgconfig, autoconf, pcre-devel
+BuildRequires:	pkgconfig, autoconf, pcre-devel, automake
 Requires:	pcre
 
 %description


### PR DESCRIPTION
Hi.
I was tried rpmbuild the_silver_searcher.spec, but some problems found in my environment. (CentOS-6.4)

Fixed these problems.
- add automake to BuildRequires
- install ag.bashcomp.sh
