### PR TITLE
Separate is_binary and is_printable

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -132,7 +132,7 @@ void search_buf(const char *buf, const int buf_len,
 
     if (matches_len > 0) {
         if (binary == -1 && !opts.print_filename_only) {
-            binary = is_binary((void*) buf, buf_len);
+            binary = is_printable((void*) buf, buf_len);
         }
         pthread_mutex_lock(&print_mtx);
         if (opts.print_filename_only) {

--- a/src/util.h
+++ b/src/util.h
@@ -66,6 +66,7 @@ void* decompress(const ag_compression_type zip_type, const void* buf, const int 
 ag_compression_type is_zipped(const void* buf, const int buf_len);
 
 int is_binary(const void* buf, const int buf_len);
+int is_printable(const void* buf, const int buf_len);
 int is_regex(const char* query);
 int is_fnmatch(const char* filename);
 int binary_search(const char* needle, char **haystack, int start, int end);


### PR DESCRIPTION
Separate is_binary and is_printable. is_binary should be used for checking whether the file is binary or not, is_printable should be used for checking whether it's possible to output a match results safety.
