### PR TITLE
bump version in `Makefile.w32`

### DIFF
--- a/Makefile.w32
+++ b/Makefile.w32
@@ -11,7 +11,7 @@ SRCS = \
 OBJS = $(subst .c,.o,$(SRCS))
 
 VERSION=
-CFLAGS = -O2 -Isrc/win32 -DPACKAGE_VERSION=\"0.15pre\"
+CFLAGS = -O2 -Isrc/win32 -DPACKAGE_VERSION=\"0.15\"
 LIBS = -lz -lpthread -lpcre -llzma -lshlwapi
 TARGET = ag.exe
 


### PR DESCRIPTION
A version number remains `0.15pre` in `Makefile.w32`.
