### PR TITLE
Use d_reclen instead of sizeof() magic to determine the size of an entry...

### DIFF
--- a/src/scandir.c
+++ b/src/scandir.c
@@ -38,23 +38,14 @@ int ag_scandir(const char *dirname,
                 goto fail;
             }
         }
-#if defined (__SVR4) && defined (__sun)
-	/*
-	 * The d_name member of the dirent struct is declared as char[1] on
-	 * Solaris, we need to actually allocate enough space for the whole
-	 * string.
-	 */
-        d = malloc(sizeof(struct dirent) + strlen(entry->d_name) + 1);
-#else
-        d = malloc(sizeof(struct dirent));
-#endif
+
+        d = malloc(entry->d_reclen);
+
         if (d == NULL) {
             goto fail;
         }
-        memcpy(d, entry, sizeof(struct dirent));
-#if defined (__SVR4) && defined (__sun)
-        strcpy(d->d_name, entry->d_name);
-#endif
+        memcpy(d, entry, entry->d_reclen);
+
         names[results_len] = d;
         results_len++;
     }


### PR DESCRIPTION
Using d_reclen - which should also be available on Solaris - is a cleaner
way to calculate the size of a dirent structure. This avoids curious sizeof
magic, and avoids a segmentation fault on the OpenBSD implementation
of scandir.
