### PR TITLE
Add Debian and Ubuntu install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,21 @@ To build Ag from source on FreeBSD:
 
 If you want a CentOS rpm or Ubuntu deb, take a look at [Vikram Dighe's packages](http://swiftsignal.com/packages/).
 
+Debian unstable:
+
+    apt-get install silversearcher-ag
+
+Ubuntu 13.10 or later:
+
+    apt-get install silversearcher-ag
+
+Ubuntu 13.04:
+
+    apt-get install python-software-properties (if required)
+    apt-add-repository ppa:mizuno-as/silversearcher-ag
+    apt-get update
+    apt-get install silversearcher-ag
+
 ## Building from source ##
 
 1. Install dependencies (Automake, pkg-config, PCRE, LZMA):


### PR DESCRIPTION
Hi
I'm The Silver Searcher package maintainer of Debian.
In Debian unstable/testing and Ubuntu 13.10, package is now available.
I added the installation procedure to README.md.

P.S.
For Ubuntu 13.04, I have prepared the my PPA. (https://launchpad.net/~mizuno-as/+archive/silversearcher-ag)
I also added procedures.

Thanks.
