### PR TITLE
Generate RPM spec on configure

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -11,3 +11,5 @@ bashcomp_DATA = ag.bashcomp.sh
 
 # Uncomment this line to output gprof profiling info. This hurts performance.
 #CFLAGS=-pg
+
+EXTRA_DIST = $(ASSEMBLY_NAME).spec.in

--- a/configure.ac
+++ b/configure.ac
@@ -25,7 +25,7 @@ AC_CHECK_MEMBER([struct dirent.d_type], [AC_DEFINE([HAVE_DIRENT_DTYPE], [], [Hav
 
 AC_CHECK_FUNCS(vasprintf fgetln getline strndup)
 
-AC_CONFIG_FILES([Makefile])
+AC_CONFIG_FILES([Makefile the_silver_searcher.spec])
 AC_CONFIG_HEADERS([src/config.h])
 
 AC_OUTPUT

--- a/the_silver_searcher.spec.in
+++ b/the_silver_searcher.spec.in
@@ -2,7 +2,7 @@
 
 
 Name:		the_silver_searcher
-Version:	0.13.1
+Version:	@VERSION@
 Release:	1%{?dist}
 Summary:	A code-searching tool similar to ack, but faster
 
@@ -10,7 +10,6 @@ Group:		Applications/Utilities
 License:	Apache v2.0
 URL:		https://github.com/ggreer/%{name}
 Source0:	https://github.com/downloads/ggreer/%{name}/%{name}-%{version}.tar.gz
-Source1:	ag.bashcomp.sh
 BuildRoot:	%(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 
 BuildRequires:	pkgconfig, autoconf, pcre-devel, automake
@@ -48,22 +47,26 @@ make %{?_smp_mflags}
 
 
 %install
-rm -rf %{buildroot}
-make install DESTDIR=%{buildroot}
-mkdir -p %{buildroot}%{_bashcompdir}
-cp %{_sourcedir}/ag.bashcomp.sh %{buildroot}%{_bashcompdir}
+rm -rf ${RPM_BUILD_ROOT}
+make install DESTDIR=${RPM_BUILD_ROOT}
+mkdir -p ${RPM_BUILD_ROOT}%{_bashcompdir}
+install -m 644 ag.bashcomp.sh ${RPM_BUILD_ROOT}%{_bashcompdir}
 
 %clean
-rm -rf %{buildroot}
+rm -rf ${RPM_BUILD_ROOT}
 
 
 %files
 %defattr(-,root,root,-)
 %{_bindir}/*
 %{_mandir}/*
-%{_bashcompdir}/*
+%config %{_bashcompdir}/ag.bashcomp.sh
+%config %{_datadir}/%{name}/completions/ag.bashcomp.sh
 
 
 %changelog
+* Fri Aug 16 2013 Andrew Seidl <git@aas.io> - 0.15.0-1
+- Install bash completion file
+
 * Wed Dec 05 2012 Daniel Nelson <packetcollision@gmail.com> - 0.13.1-1
 - Initial Build


### PR DESCRIPTION
This will generate the_silver_searcher.spec when running ./configure, automatically filling in the correct package version.
