### PR TITLE
ignore named pipes

### DIFF
--- a/src/ignore.c
+++ b/src/ignore.c
@@ -271,6 +271,11 @@ int filename_filter(const char *path, const struct dirent *dir, void *baton) {
     const char *path_start = path;
     char *temp;
 
+    if (is_named_pipe(path, dir)) {
+      log_debug("%s ignored because it's a named pipe", path);
+      return 0;
+    }
+
     if (!opts.follow_symlinks && is_symlink(path, dir)) {
         log_debug("File %s ignored becaused it's a symlink", dir->d_name);
         return 0;

--- a/src/util.h
+++ b/src/util.h
@@ -77,6 +77,7 @@ int is_lowercase(const char* s);
 
 int is_directory(const char *path, const struct dirent *d);
 int is_symlink(const char *path, const struct dirent *d);
+int is_named_pipe(const char *path, const struct dirent *d);
 
 void die(const char *fmt, ...);
 


### PR DESCRIPTION
Having named pipes would cause the search to hang when it reached it.

This is my first time coding in C.  I would welcome any feedback on the PR and would not take it badly if it was ignored because I did something wholly bad with this code.
