### PR TITLE
docs: Add documentation for --color-* options in markdown and manpage

### DIFF
--- a/doc/ag.1
+++ b/doc/ag.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "AG" "1" "April 2013" "" ""
+.TH "AG" "1" "September 2013" "" ""
 .
 .SH "NAME"
 \fBag\fR \- The Silver Searcher\. Like ack, but faster\.
@@ -47,6 +47,24 @@ Recursively search for PATTERN in PATH\. Like grep or ack, but faster\.
 .
 .br
 \~\~\~\~ Print color codes in results\. Enabled by default\.
+.
+.P
+\fB\-\-color\-line\-number\fR:
+.
+.br
+\~\~\~\~ Color codes for line numbers\. Defaults to 1;33\.
+.
+.P
+\fB\-\-color\-match\fR:
+.
+.br
+\~\~\~\~ Color codes for result match numbers\. Defaults to 30;43\.
+.
+.P
+\fB\-\-color\-path\fR:
+.
+.br
+\~\~\~\~ Color codes for path names\. Defaults to 1;32\.
 .
 .P
 \fB\-\-column\fR:

--- a/doc/ag.1.md
+++ b/doc/ag.1.md
@@ -23,6 +23,12 @@ Recursively search for PATTERN in PATH. Like grep or ack, but faster.
     Print a newline between matches in different files. Enabled by default.
   * `--[no]color`:
     Print color codes in results. Enabled by default.
+  * `--color-line-number`:
+    Color codes for line numbers. Defaults to 1;33.
+  * `--color-match`:
+    Color codes for result match numbers. Defaults to 30;43.
+  * `--color-path`:
+    Color codes for path names. Defaults to 1;32.
   * `--column`:
     Print column numbers in results.
   * `-C --context [LINES]`:


### PR DESCRIPTION
It took me way too long to find these options, and I was seriously
considering implementing them myself when I found the issue on GH and
the commit closing it.

I just copied the texts from the built-in usage function and modified the
format somewhat to conform to that used in the man page/MD.
