### PR TITLE
src/options.c: Enable colors on Windows when ANSICON is installed

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -102,7 +102,7 @@ void init_options() {
     memset(&opts, 0, sizeof(opts));
     opts.casing = CASE_SENSITIVE;
 #ifdef _WIN32
-    opts.color = FALSE;
+    opts.color = getenv("ANSICON") ? TRUE : FALSE;
 #else
     opts.color = TRUE;
 #endif


### PR DESCRIPTION
Patch to automatically enable colors on Windows when ANSICON is installed (https://github.com/adoxa/ansicon)
