### PR TITLE
Add CentOS build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ Ubuntu 13.04:
 
 1. Install dependencies (Automake, pkg-config, PCRE, LZMA):
     * Ubuntu: `apt-get install -y automake pkg-config libpcre3-dev zlib1g-dev liblzma-dev`
+    * CentOS:
+      
+
+              yum -y groupinstall "Development Tools"  
+              yum -y install pcre-devel xz-devel
     * OS X:
         - Install [homebrew](http://mxcl.github.com/homebrew/), then `brew install automake pkg-config pcre`
         - Or install [macports](http://macports.org), then `port install automake pkgconfig pcre`


### PR DESCRIPTION
Just went through the rigamarole of getting this to build on CentOS 5. This is what I had to do.
