### PR TITLE
Added OpenBSD instructions to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ To build Ag from source on FreeBSD:
 
     make -C /usr/ports/textproc/the_silver_searcher install clean
 
+OpenBSD:
+
+Use the following command to install from packages:
+
+    pkg_add the_silver_searcher
+
+To build Ag from source on OpenBSD:
+
+    cd /usr/ports/textproc/the_silver_searcher && make install
+
 If you want a CentOS rpm or Ubuntu deb, take a look at [Vikram Dighe's packages](http://swiftsignal.com/packages/).
 
 Debian unstable:


### PR DESCRIPTION
OpenBSD has accepted the_silver_searcher port. So here is an updated README.md to reflect those changes. It details how the_silver_searcher can be installed on OpenBSD either by binary package or by building it from source.
