### PR TITLE
Detect utf8 files correctly

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -187,12 +187,12 @@ int is_binary(const void* buf, const int buf_len) {
             /* UTF-8 detection */
             if (buf_c[i] > 193 && buf_c[i] < 224 && i + 1 < total_bytes) {
                 i++;
-                if (buf_c[i] < 192) {
+                if (buf_c[i] > 127 && buf_c[i] < 192) {
                     continue;
                 }
             } else if (buf_c[i] > 223 && buf_c[i] < 240 && i + 2 < total_bytes) {
                 i++;
-                if (buf_c[i] < 192 && buf_c[i + 1] < 192) {
+                if (buf_c[i] > 127 && buf_c[i] < 192 && buf_c[i + 1] > 127 && buf_c[i + 1] < 192) {
                     i++;
                     continue;
                 }


### PR DESCRIPTION
94ae1ae : C0(192) and C1(193) must never appear in initial bytes of 2 byte code.
581af6b : Initial bytes of 3 byte code are E0-EF(224-239). 
f9a2563 : Non-initial bytes of multibyte code are 80-BF(128-191).

see: [RFC3629 UTF-8, a transformation format of ISO 10646](http://tools.ietf.org/html/rfc3629)
