### PR TITLE
Wrong comma in configure.ac.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -17,7 +17,7 @@ PKG_CHECK_MODULES([LZMA], [liblzma])
 CFLAGS="$CFLAGS $PCRE_CFLAGS -Wall -Wextra -std=c89 -D_GNU_SOURCE"
 LDFLAGS="$LDFLAGS"
 
-AC_CHECK_HEADERS([pthread.h, zlib.h lzma.h])
+AC_CHECK_HEADERS([pthread.h zlib.h lzma.h])
 
 AC_CHECK_DECL([PCRE_CONFIG_JIT], [AC_DEFINE([USE_PCRE_JIT], [], [Use PCRE JIT])], [], [#include <pcre.h>])
 


### PR DESCRIPTION
The comma appears to be wrong and results in a configure script that doesn't find pthread.h. It still compiles fine but it's not correct.
