### PR TITLE
Update man page and usage to document all options

### DIFF
--- a/doc/ag.1
+++ b/doc/ag.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "AG" "1" "September 2013" "" ""
+.TH "AG" "1" "October 2013" "" ""
 .
 .SH "NAME"
 \fBag\fR \- The Silver Searcher\. Like ack, but faster\.
@@ -17,6 +17,12 @@ Recursively search for PATTERN in PATH\. Like grep or ack, but faster\.
 .
 .br
 \~\~\~\~ Output results in a format parseable by AckMate \fIhttps://github\.com/protocool/AckMate\fR\.
+.
+.P
+\fB\-\-ackmate\-dir\-filter PATTERN\fR
+.
+.br
+\~\~\~\~ Ignore files/directories matching this pattern\.
 .
 .P
 \fB\-a \-\-all\-types\fR:
@@ -91,7 +97,7 @@ Recursively search for PATTERN in PATH\. Like grep or ack, but faster\.
 \~\~\~\~ Search up to NUM directories deep\. Default is 25\.
 .
 .P
-\fB\-f \-\-follow\fR:
+\fB\-f \-\-[no]follow\fR:
 .
 .br
 \~\~\~\~ Follow symlinks\.
@@ -119,6 +125,12 @@ Recursively search for PATTERN in PATH\. Like grep or ack, but faster\.
 .
 .br
 \~\~\~\~ Search hidden files\. This option obeys ignore files\.
+.
+.P
+\fB\-h \-\-help\fR:
+.
+.br
+\~\~\~\~ Display usage\.
 .
 .P
 \fB\-\-ignore PATTERN\fR:
@@ -151,10 +163,22 @@ Recursively search for PATTERN in PATH\. Like grep or ack, but faster\.
 \~\~\~\~ Only print filenames that don\'t contain matches\.
 .
 .P
+\fB\-\-line\-numbers\fR:
+.
+.br
+\~\~\~\~ Print line numbers even for streams\.
+.
+.P
 \fB\-m \-\-max\-count NUM\fR:
 .
 .br
 \~\~\~\~ Skip the rest of a file after NUM matches\. Default is 10,000\.
+.
+.P
+\fB\-n \-\-no\-recurse\fR:
+.
+.br
+\~\~\~\~ Do not search directories recursively\.
 .
 .P
 \fB\-\-no\-numbers\fR:
@@ -187,10 +211,22 @@ Recursively search for PATTERN in PATH\. Like grep or ack, but faster\.
 \~\~\~\~ Do not parse PATTERN as a regular expression\. Try to match it literally\.
 .
 .P
+\fB\-r \-R \-\-recurse\fR:
+.
+.br
+\~\~\~\~ Search directories recursively\. Enabled by default\.
+.
+.P
 \fB\-s \-\-case\-sensitive\fR:
 .
 .br
 \~\~\~\~ Match case sensitively\. Enabled by default\.
+.
+.P
+\fB\-\-silent\fR:
+.
+.br
+\~\~\~\~ Disable logging\.
 .
 .P
 \fB\-S \-\-smart\-case\fR:
@@ -236,6 +272,24 @@ Recursively search for PATTERN in PATH\. Like grep or ack, but faster\.
 .
 .br
 \~\~\~\~ Only match whole words\.
+.
+.P
+\fB\-\-workers NUM\fR:
+.
+.br
+\~\~\~\~ Set the number of worker threads\.
+.
+.P
+\fB\-V \-\-version\fR:
+.
+.br
+\~\~\~\~ Show version information\.
+.
+.P
+\fB\-z \-\-search\-zip\fR:
+.
+.br
+\~\~\~\~ Search contents of compressed (e\.g\., gzip) files
 .
 .P
 By default, ag will ignore files matched by patterns in \.gitignore, \.hgignore, or \.agignore\. These files can be anywhere in the directories being searched\. Ag also ignores files matched by the svn:ignore property in subversion repositories\. Finally, ag looks in $HOME/\.agignore for ignore patterns\. Binary files are ignored by default as well\.

--- a/doc/ag.1.md
+++ b/doc/ag.1.md
@@ -13,6 +13,8 @@ Recursively search for PATTERN in PATH. Like grep or ack, but faster.
 
   * `--ackmate`:
     Output results in a format parseable by [AckMate](https://github.com/protocool/AckMate).
+  * `--ackmate-dir-filter PATTERN`
+    Ignore files/directories matching this pattern.
   * `-a --all-types`:
     Search all files. This doesn't include hidden files, and also doesn't respect any ignore files
   * `-A --after [LINES]`:
@@ -37,7 +39,7 @@ Recursively search for PATTERN in PATH. Like grep or ack, but faster.
     Output ridiculous amounts of debugging info. Probably not useful.
   * `--depth NUM`:
     Search up to NUM directories deep. Default is 25.
-  * `-f --follow`:
+  * `-f --[no]follow`:
     Follow symlinks.
   * `--[no]group`
   * `-g PATTERN`:
@@ -47,6 +49,8 @@ Recursively search for PATTERN in PATH. Like grep or ack, but faster.
   * `--[no]heading`
   * `--hidden`:
     Search hidden files. This option obeys ignore files.
+  * `-h --help`:
+    Display usage.
   * `--ignore PATTERN`:
     Ignore files/directories matching this pattern. Literal file and directory names are also allowed.
   * `--ignore-dir NAME`:
@@ -57,9 +61,13 @@ Recursively search for PATTERN in PATH. Like grep or ack, but faster.
     Only print filenames containing matches, not matching lines. An empty query will print all files that would be searched.
   * `-L --files-without-matches`:
     Only print filenames that don't contain matches.
+  * `--line-numbers`:
+    Print line numbers even for streams.
   * `-m --max-count NUM`:
     Skip the rest of a file after NUM matches. Default is 10,000.
-  * `--no-numbers`:            
+  * `-n --no-recurse`:
+    Do not search directories recursively.
+  * `--no-numbers`:
     Don't show line numbers
   * `-p --path-to-agignore STRING`:
     Provide a path to a specific .agignore file.
@@ -69,8 +77,12 @@ Recursively search for PATTERN in PATH. Like grep or ack, but faster.
     Print matches on very long lines (> 2k characters by default)
   * `-Q --literal`:
     Do not parse PATTERN as a regular expression. Try to match it literally.
+  * `-r -R --recurse`:
+    Search directories recursively. Enabled by default.
   * `-s --case-sensitive`:
     Match case sensitively. Enabled by default.
+  * `--silent`:
+    Disable logging.
   * `-S --smart-case`:
     Match case sensitively if there are any uppercase letters in PATTERN, or case insensitively otherwise.
   * `--search-binary`:
@@ -86,6 +98,12 @@ Recursively search for PATTERN in PATH. Like grep or ack, but faster.
   * `-v --invert-match`
   * `-w --word-regexp`:
     Only match whole words.
+  * `--workers NUM`:
+    Set the number of worker threads.
+  * `-V --version`:
+    Show version information.
+  * `-z --search-zip`:
+    Search contents of compressed (e.g., gzip) files
 
 ## IGNORING FILES
 

--- a/src/options.c
+++ b/src/options.c
@@ -43,6 +43,7 @@ Example: ag -i foo /bar/\n\
 Search options:\n\
 \n\
 --ackmate               Print results in AckMate-parseable format\n\
+--ackmate-dir-filter PATTERN Ignore files/directories matching this pattern\n\
 -a --all-types          Search all files (doesn't include hidden files\n\
                         or patterns from ignore files)\n\
 -A --after [LINES]      Print lines before match (Default: 2)\n\
@@ -54,30 +55,33 @@ Search options:\n\
 --color-match           Color codes for result match numbers (Default: 30;43)\n\
 --color-path            Color codes for path names (Default: 1;32)\n\
 --column                Print column numbers in results\n\
---line-numbers          Print line numbers even for streams\n\
 -C --context [LINES]    Print lines before and after matches (Default: 2)\n\
 -D --debug              Ridiculous debugging (probably not useful)\n\
 --depth NUM             Search up to NUM directories deep (Default: 25)\n\
--f --follow             Follow symlinks\n\
+-f --[no]follow         Follow symlinks\n\
 --[no]group             Same as --[no]break --[no]heading\n\
 -g PATTERN              Print filenames matching PATTERN\n\
 -G, --file-search-regex PATTERN Limit search to filenames matching PATTERN\n\
 --[no]heading\n\
 --hidden                Search hidden files (obeys .*ignore files)\n\
--i, --ignore-case       Match case insensitively\n\
 --ignore PATTERN        Ignore files/directories matching PATTERN\n\
-                        (literal file/directory names also allowed)\n\
+(literal file/directory names also allowed)\n\
+-i, --ignore-case       Match case insensitively\n\
 --ignore-dir NAME       Alias for --ignore for compatibility with ack.\n\
 -l --files-with-matches Only print filenames that contain matches\n\
                         (don't print the matching lines)\n\
 -L --files-without-matches\n\
                         Only print filenames that don't contain matches\n\
+--line-numbers          Print line numbers even for streams\n\
 -m --max-count NUM      Skip the rest of a file after NUM matches (Default: 10,000)\n\
+-n --no-recurse         Do not search directories recursively\n\
 --no-numbers            Don't show line numbers\n\
 -p --path-to-agignore STRING\n\
                         Use .agignore file at STRING\n\
+--[no]pager COMMAND     Use a pager such as less\n\
 --print-long-lines      Print matches on very long lines (Default: >2k characters)\n\
 -Q --literal            Don't parse PATTERN as a regular expression\n\
+-r -R --recurse         Search directories recursively. Enabled by default\n\
 -s --case-sensitive     Match case sensitively (Enabled by default)\n\
 -S --smart-case         Match case insensitively unless PATTERN contains\n\
                         uppercase characters\n\
@@ -90,6 +94,8 @@ Search options:\n\
                         (.gitignore, .hgignore, .svnignore; still obey .agignore)\n\
 -v --invert-match\n\
 -w --word-regexp        Only match whole words\n\
+--workers NUM           Set the number of worker threads\n\
+-V --version            Show version information\n\
 -z --search-zip         Search contents of compressed (e.g., gzip) files\n\
 \n");
 }


### PR DESCRIPTION
I noticed the usage didn't document `--pager`, and decided to do a bit of doc cleanup.

I'm not sure if I documented `--ackmate-dir-filter` properly, and I left out `--parallel` and `--search-files` since I'm not sure what they do.