### PR TITLE
Quote the $@ variable passed to ./configure

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -17,5 +17,5 @@ aclocal $AC_SEARCH_OPTS && \
 autoconf && \
 autoheader && \
 automake --add-missing && \
-./configure $@ && \
+./configure "$@" && \
 make


### PR DESCRIPTION
Allows `build.sh` to be invoked with complex arguments to be passed to
configure script e.g.
`./build.sh CFLAGS='-O3 -fomit-frame-pointer -s' CC=clang`
