### PR TITLE
Add src/win32/config.h to tarballs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,7 +12,7 @@ dist_bashcomp_DATA = ag.bashcomp.sh
 # Uncomment this line to output gprof profiling info. This hurts performance.
 #CFLAGS=-pg
 
-EXTRA_DIST = Makefile.w32 LICENSE NOTICE the_silver_searcher.spec README.md
-
 test:
 	cram -v tests/*.t
+
+EXTRA_DIST = Makefile.w32 LICENSE NOTICE the_silver_searcher.spec README.md src/win32/config.h


### PR DESCRIPTION
This file is needed for Makefile.w32 but hasn't been included in a `make dist`.
