### PR TITLE
Add check for EOF to prevent infinite loop

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -478,7 +478,7 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
             do {
                 gitconfig_res = ag_realloc(gitconfig_res, buf_len + 65);
                 buf_len += fread(gitconfig_res + buf_len, 1, 64, gitconfig_file);
-            } while (buf_len > 0 && buf_len % 64 == 0);
+            } while (!feof(gitconfig_file) && buf_len > 0 && buf_len % 64 == 0);
             gitconfig_res[buf_len] = '\0';
             load_ignore_patterns(root_ignores, gitconfig_res);
             free(gitconfig_res);


### PR DESCRIPTION
Tested on my machine with both a 64-character and 65-character `core.excludesfile` value.
