### PR TITLE
Handle '-i' before '-g' or '-G' properly

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -308,7 +308,8 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
                 opts.match_files = 1;
                 /* Fall through and build regex */
             case 'G':
-                compile_study(&opts.file_search_regex, &opts.file_search_regex_extra, optarg, 0, 0);
+                compile_study(&opts.file_search_regex, &opts.file_search_regex_extra, optarg, opts.casing && PCRE_CASELESS, 0);
+                opts.casing = CASE_SENSITIVE;
                 break;
             case 'h':
                 help = 1;


### PR DESCRIPTION
`ag -i -g <filename_pattern>` should perform case insensitive filename search

`ag -i -G <filename_pattern> <needle>` should perform case sensitive search for needle in case insensitive filenames

`ag -G <filename_pattern> -i <needle>` should perform case insensitive search for needle in case sensitive filenames

`ag -i -G <filename_pattern> -i <needle>` should be case insensitive for both

Fix #302
