### PR TITLE
A very simple "make test" that uses cram and contains one test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,5 @@ Makefile.in
 missing
 src/config.h*
 stamp-h1
+tests/*.err
 the_silver_searcher.spec

--- a/Makefile.am
+++ b/Makefile.am
@@ -13,3 +13,6 @@ dist_bashcomp_DATA = ag.bashcomp.sh
 #CFLAGS=-pg
 
 EXTRA_DIST = Makefile.w32 LICENSE NOTICE the_silver_searcher.spec README.md
+
+test:
+	cram -v tests/*.t

--- a/tests/case_sensitivity.t
+++ b/tests/case_sensitivity.t
@@ -1,0 +1,24 @@
+Setup:
+
+  $ source $TESTDIR/setup.sh
+  $ echo Foo >> ./sample
+  $ echo bar >> ./sample
+
+Case sensitive by default:
+
+  $ ag foo sample
+  $ ag FOO sample
+  $ ag 'f.o' sample
+  $ ag Foo sample
+  Foo
+  $ ag 'F.o' sample
+  Foo
+
+Case insensitive mode:
+
+  $ ag foo -i sample
+  Foo
+  $ ag foo --ignore-case sample
+  Foo
+  $ ag 'f.o' -i sample
+  Foo

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -1,0 +1,4 @@
+# All cram tests should use this. Make sure that "ag" runs the version
+# of ag we just built, and make the output really simple.
+
+alias ag="$TESTDIR/../ag --nocolor --noheading --unrestricted"


### PR DESCRIPTION
Based on the fine work by @sjl a year ago:

https://github.com/sjl/the_silver_searcher/tree/958b693a2b830fa2f6bf31b4ae76bfcae5a6d3fc

To use:

``` bash
$ sudo easy_install cram
$ ./build.sh
$ make test
```

Might be a way forward with #73 and #281.

Cram seems easy to use and gets the job done. Note that it runs tests in a tmp dir. You have to alias ag so that it runs your development ag instead of the system one. That's what `source setup.sh` is doing... Again, this is all originally from @sjl.

One caveat - I had to specify the name of the input file ("sample") in order to make the tests work. Perhaps some enterprising soul can figure out why?

Pardon my incompetence. I don't really know anything about automake, cram, python, etc. :)
