### PR TITLE
suppress warnings with Cygwin

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,7 +14,7 @@ PKG_CHECK_MODULES([PCRE], [libpcre])
 PKG_CHECK_MODULES([LZMA], [liblzma])
 
 # Run CFLAGS="-g" ./configure if you want debug symbols
-CFLAGS="$CFLAGS $PCRE_CFLAGS -Wall -Wextra -std=c89 -D_GNU_SOURCE"
+CFLAGS="$CFLAGS $PCRE_CFLAGS -Wall -Wextra -std=gnu89 -D_GNU_SOURCE"
 LDFLAGS="$LDFLAGS"
 
 AC_CHECK_HEADERS([pthread.h zlib.h lzma.h])


### PR DESCRIPTION
Many warnings occurs when compiling with Cygwin. E.g.:

```
  CC       src/options.o
src/options.c: In function 'parse_options':
src/options.c:252:5: warning: implicit declaration of function 'fileno' [-Wimplicit-function-declaration]
     rv = fstat(fileno(stdin), &statbuf);
     ^
src/options.c:443:9: warning: implicit declaration of function 'popen' [-Wimplicit-function-declaration]
         out_fd = popen(opts.pager, "w");
         ^
src/options.c:443:16: warning: assignment makes pointer from integer without a cast [enabled by default]
         out_fd = popen(opts.pager, "w");
                ^
src/options.c:477:24: warning: assignment makes pointer from integer without a cast [enabled by default]
         gitconfig_file = popen("git config -z --get core.excludesfile", "r");
                        ^
         (snip)
```

These warnings are caused by the option `-std=c89`, because `fileno`, `popen` and some other functions are not defined by ANSI C89. Using `-std=gnu89` instead of `-std=c89` fixes this issue.
