### PR TITLE
Don't complain if git isn't installed

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -460,7 +460,7 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
         size_t buf_len = 0;
         char *gitconfig_res = NULL;
 
-        gitconfig_file = popen("git config -z --get core.excludesfile", "r");
+        gitconfig_file = popen("git config -z --get core.excludesfile 2>/dev/null", "r");
         if (gitconfig_file != NULL) {
             do {
                 gitconfig_res = ag_realloc(gitconfig_res, buf_len + 65);


### PR DESCRIPTION
Currently, if git isn't installed you get "sh: git: command not found\n" printed to stderr.  A better solution might be to search for git in the PATH and only run it if it is found, but I don't see a reason to reimplement the search sh can already do.  Another option would be to have a --with-git= in the configure script (people without git could pass --with-git=/bin/true), but that would require a recompile if git were to be installed later.  A third, and possibly best, option would be to have a config file where you could specify which executable to run (if at all), but again, that is more code.  I also don't see a need for any error messages git might produce, so discarding stderr for this command is probably the right answer anyway.  If it fails, ag will just search more than intended.
