### PR TITLE
skip FIFO mode check if stdin doesn't exist

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -236,7 +236,7 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
     }
 
     rv = fstat(fileno(stdin), &statbuf);
-    if (rv != 0) {
+    if (rv == 0) {
         if (S_ISFIFO(statbuf.st_mode)) {
             opts.search_stream = 1;
         }


### PR DESCRIPTION
The creating pipe can make pipe no stdin, so I support no stdin.
