### PR TITLE
Improve instructions for ack.vim integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ TextMate users can use Ag with [my fork](https://github.com/ggreer/AckMate) of t
 You can use Ag with [ack.vim][] by adding the following line to your `.vimrc`:
 
     let g:ackprg = 'ag --nogroup --nocolor --column'
+    let g:ack_wildignore = 0
 
 There's also a fork of ack.vim tailored for use with Ag: [ag.vim][]
 [ack.vim]: https://github.com/mileszs/ack.vim


### PR DESCRIPTION
To use ag with ack.vim you have to disable the wildignore feature of ack.vim.
