### PR TITLE
Fixed memory leak and access violation

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -421,6 +421,8 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
         }
     }
 
+    free(longopts);
+
     argc -= optind;
     argv += optind;
 

--- a/src/print.c
+++ b/src/print.c
@@ -141,14 +141,14 @@ void print_file_matches(const char *path, const char *buf, const int buf_len, co
                         fprintf(out_fd, "%s", opts.color_match);
                     }
                     for (j = prev_line_offset; j <= i; j++) {
-                        if (j == matches[last_printed_match].end && last_printed_match < matches_len) {
+                        if (last_printed_match < matches_len && j == matches[last_printed_match].end) {
                             if (opts.color) {
                                 fprintf(out_fd, "%s", color_reset);
                             }
                             printing_a_match = FALSE;
                             last_printed_match++;
                         }
-                        if (j == matches[last_printed_match].start && last_printed_match < matches_len) {
+                        if (last_printed_match < matches_len && j == matches[last_printed_match].start) {
                             if (opts.color) {
                                 fprintf(out_fd, "%s", opts.color_match);
                             }


### PR DESCRIPTION
Changed order of if statements to check requested array index is within bounds before trying to access it in the matches array.
free()d longopts, memuse checking reported it as a leak
