### PR TITLE
search: Avoid segfault when given an invalid base

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -397,7 +397,9 @@ void search_dir(ignores *ig, const char *base_path, const char *path, const int 
 
     scandir_baton.ig = ig;
     scandir_baton.base_path = base_path;
-    scandir_baton.base_path_len = strlen(base_path);
+    if (base_path) {
+        scandir_baton.base_path_len = strlen(base_path);
+    }
     results = ag_scandir(path, &dir_list, &filename_filter, &scandir_baton);
     if (results == 0) {
         log_debug("No results found in directory %s", path);


### PR DESCRIPTION
This patch avoids an easily reproduced segmentation violation when
base_path is NULL (as a consequence of being an invalid/non-existent)
path.

Signed-off-by: Anton Lofgren anton.lofgren@gmail.com
