### PR TITLE
Correct FreeBSD pkg instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ or
 
 ### FreeBSD
 
-    pkg add the_silver_searcher
+    pkg install the_silver_searcher
 
 or
 


### PR DESCRIPTION
From pkg(8):

```
 add     Install a package from either a local source or a remote one.

         When installing from remote source you need to specify the proto-
         col to use when fetching the package.

         Currently supported protocols are FTP, HTTP and HTTPS.
```

...

```
 install
         Install a package from a remote package repository.  If a package
         is found in more than one remote repository, then installation
         happens from the first one.  Downloading a package is tried from
         each package repository in turn, until the package is success-
         fully fetched.
```

i.e., add is to install a package with an explicit (local or remote) path, while install uses the repository configuration to install by name
