### PR TITLE
docs: Update svn:ignore documentation to reflect current status.

### DIFF
--- a/doc/ag.1.md
+++ b/doc/ag.1.md
@@ -89,7 +89,11 @@ Recursively search for PATTERN in PATH. Like grep or ack, but faster.
 
 ## IGNORING FILES
 
-By default, ag will ignore files matched by patterns in .gitignore, .hgignore, or .agignore. These files can be anywhere in the directories being searched. Ag also ignores files matched by the svn:ignore property in subversion repositories. Finally, ag looks in $HOME/.agignore for ignore patterns. Binary files are ignored by default as well.
+By default, ag will ignore files matched by patterns in .gitignore, .hgignore,
+or .agignore. These files can be anywhere in the directories being searched. Ag
+also ignores files matched by the svn:ignore property if `svn --version` is 1.6
+or older.  Finally, ag looks in $HOME/.agignore for
+ignore patterns. Binary files are ignored by default as well.
 
 If you want to ignore .gitignore, .hgignore, and svn:ignore but still take .agignore into account, use `-U`.
 


### PR DESCRIPTION
Hi,

The code that parses svn:ignore properties looks in .svn/dir-prop-base/, which doesn't exist any more (as of 1.7.0, released in 2011).  This patch updates README to reflect this.

All Subversion versions that have a dir-prop-base directory will go out of security support by upstream within a few months, when 1.9.0 is released.  1.7 and later store svn:ignore differently than 1.6 and earlier did; the exact storage format is (and has always been) considered an implementation detail.  I'm happy to provide additional details if interested.
