### PR TITLE
search: Adjust log levels for max search depth

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -98,7 +98,7 @@ void init_options(void) {
     opts.color = TRUE;
 #endif
     opts.max_matches_per_file = 10000;
-    opts.max_search_depth = 25;
+    opts.max_search_depth = DEFAULT_MAX_SEARCH_DEPTH;
     opts.print_break = TRUE;
     opts.print_heading = TRUE;
     opts.print_line_numbers = TRUE;

--- a/src/options.h
+++ b/src/options.h
@@ -7,7 +7,7 @@
 #include <pcre.h>
 
 #define DEFAULT_CONTEXT_LEN 2
-
+#define DEFAULT_MAX_SEARCH_DEPTH 25
 enum case_behavior {
     CASE_SENSITIVE,
     CASE_INSENSITIVE,

--- a/src/search.c
+++ b/src/search.c
@@ -467,7 +467,16 @@ void search_dir(ignores *ig, const char *base_path, const char *path, const int 
                 search_dir(child_ig, base_path, dir_full_path, depth + 1);
                 cleanup_ignore(child_ig);
             } else {
-                log_err("Skipping %s. Use the --depth option to search deeper.", dir_full_path);
+                if (opts.max_search_depth == DEFAULT_MAX_SEARCH_DEPTH) {
+                    /*
+                     * If the user didn't intentionally specify a particular depth,
+                     * this is a warning...
+                     */
+                    log_warn("Skipping %s. Use the --depth option to search deeper.", dir_full_path);
+                } else {
+                    /* ... if they did, let's settle for debug. */
+                    log_debug("Skipping %s. Use the --depth option to search deeper.", dir_full_path);
+                }
             }
         }
 


### PR DESCRIPTION
When a user has specified a specific max search depth (--depth), it is
reasonable to assume that they are aware of it. In this case, it should
suffice to output this information on the debug level.

Relatedly, it is not (in my opinion) an error to exceed the max search
depth, since the program is designed that way. I've lowered it to a
warning.

This increases, in my experience, the user friendliness of the --depth
option, since it outputs a lot less noise in the general case.
