### PR TITLE
Move AM_INIT_AUTOMAKE above AC_PROG_CC

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,11 +5,11 @@ AC_INIT(
     [the_silver_searcher],
     [https://github.com/ggreer/the_silver_searcher])
 
+AM_INIT_AUTOMAKE([no-define foreign subdir-objects])
+
 AC_PROG_CC
 AM_PROG_CC_C_O
 AC_PREREQ([2.59])
-
-AM_INIT_AUTOMAKE([no-define foreign subdir-objects])
 
 m4_ifdef(
     [AM_SILENT_RULES],


### PR DESCRIPTION
Compiling on Cygwin x64 gives following warning:

```
...
checking whether build environment is sane... yes
/bin/sh: /home/ljani/missing: No such file or directory
configure: WARNING: 'missing' script is too old or missing
checking for a thread-safe mkdir -p... /usr/bin/mkdir -p
...
```

This PR fixes the problem by moving `AM_INIT_AUTOMAKE` above `AC_PROG_CC`.

Warning: this PR is only tested on Cygwin, but afaik this is the correct order. For example, the [amhello's `configure.ac`](https://www.gnu.org/software/automake/manual/html_node/amhello_0027s-configure_002eac-Setup-Explained.html) uses this order.
