### PR TITLE
Correct test case for fnmatch

### DIFF
--- a/tests/stupid_fnmatch.t
+++ b/tests/stupid_fnmatch.t
@@ -1,15 +1,20 @@
 Setup:
 
   $ source $TESTDIR/setup.sh
-  $ mkdir -p ./a/bomb
-  $ echo 'whatever' > ./a/bomb/foo.yml
+  $ mkdir -p ./a/bomb ./b ./cab
+  $ echo 'whatever1' > ./a/bomb/foo.yml
+  $ echo 'whatever2' > ./b/foo.yml
+  $ echo 'whatever3' > ./cab/foo.yml
   $ echo '*b/foo.yml' > ./.gitignore
 
-Ignore foo.yml but not blah.yml:
+Ignore b/foo.yml and cab/foo.yml but not a/bomb/foo.yml:
 
   $ ag whatever .
+  a/bomb/foo.yml:1:whatever1
 
 Dont ignore anything (unrestricted search):
 
-  $ ag -u whatever .
-  a/bomb/foo.yml:1:whatever
+  $ ag -u whatever . | sort
+  a/bomb/foo.yml:1:whatever1
+  b/foo.yml:1:whatever2
+  cab/foo.yml:1:whatever3


### PR DESCRIPTION
I think the pattern `*b/foo.yml` should not match a/bomb/foo.yml. Instead, it should match b/foo.yml or cab/foo.yml.
