### PR TITLE
use $(CC) instead of gcc

### DIFF
--- a/Makefile.w32
+++ b/Makefile.w32
@@ -1,5 +1,7 @@
 VERSION=$(shell grep -Po "(?<=\[)([0-9.]+.[0-9]+.[0-9]+)(?=\])" configure.ac)
 
+CC=gcc
+
 SRCS = \
 	src/decompress.c \
 	src/ignore.c \
@@ -20,10 +22,10 @@ TARGET = ag.exe
 all : $(TARGET)
 
 $(TARGET) : $(OBJS)
-	gcc -o $@ $(OBJS) $(LIBS)
+	$(CC) -o $@ $(OBJS) $(LIBS)
 
 .c.o :
-	gcc -c $(CFLAGS) -Isrc $< -o $@
+	$(CC) -c $(CFLAGS) -Isrc $< -o $@
 
 clean :
 	rm -f src/*.o $(TARGET)


### PR DESCRIPTION
MinGW has various gcc aliases:
mingw32-gcc, i686-pc-mingw32-gcc, i686-w64-mingw32-gcc, x86_64-w64-mingw32-gcc, etc.
This change enables to use them.
