### PR TITLE
fix compile error with MinGW-w64

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -447,7 +447,7 @@ ssize_t getline(char **lineptr, size_t *n, FILE *stream) {
 #ifndef HAVE_REALPATH
 char *realpath(const char *path, char *resolved_path) {
     char *p;
-    char tmp[MAX_PATH + 1];
+    char tmp[_MAX_PATH + 1];
     strncpy(tmp, path, sizeof(tmp) - 1);
     p = tmp;
     while (*p) {
@@ -456,7 +456,7 @@ char *realpath(const char *path, char *resolved_path) {
         }
         p++;
     }
-    return _fullpath(resolved_path, tmp, MAX_PATH);
+    return _fullpath(resolved_path, tmp, _MAX_PATH);
 }
 #endif
 


### PR DESCRIPTION
Use _MAX_PATH instead of MAX_PATH.
Note that _MAX_MATH is defined in stdlib.h and MAX_PATH is defined in
windef.h which is included from windows.h.
