### PR TITLE
Fix 'gitigore' typo in doc

### DIFF
--- a/doc/ag.1
+++ b/doc/ag.1
@@ -238,7 +238,7 @@ Recursively search for PATTERN in PATH\. Like grep or ack, but faster\.
 \fB\-U \-\-skip\-vcs\-ignores\fR:
 .
 .br
-\~\~\~\~ Ignore VCS ignore files (\.gitigore, \.hgignore, svn:ignore), but still use \.agignore\.
+\~\~\~\~ Ignore VCS ignore files (\.gitignore, \.hgignore, svn:ignore), but still use \.agignore\.
 .
 .P
 \fB\-v \-\-invert\-match\fR

--- a/doc/ag.1.md
+++ b/doc/ag.1.md
@@ -86,7 +86,7 @@ Recursively search for PATTERN in PATH. Like grep or ack, but faster.
   * `-u --unrestricted`:
     Search *all* files. This ignores .agignore, .gitignore, etc. It searches binary and hidden files as well.
   * `-U --skip-vcs-ignores`:
-    Ignore VCS ignore files (.gitigore, .hgignore, svn:ignore), but still use .agignore.
+    Ignore VCS ignore files (.gitignore, .hgignore, svn:ignore), but still use .agignore.
   * `-v --invert-match`
   * `-w --word-regexp`:
     Only match whole words.


### PR DESCRIPTION
Typo I noticed in the manpage doc.
