### PR TITLE
Stop interspersing stream output with blank lines.

### DIFF
--- a/src/print.c
+++ b/src/print.c
@@ -181,7 +181,7 @@ void print_file_matches(const char *path, const char *buf, const size_t buf_len,
                 lines_since_last_match++;
             }
             /* File doesn't end with a newline. Print one so the output is pretty. */
-            if (i == buf_len && buf[i] != '\n') {
+            if (i == buf_len && buf[i] != '\n' && !opts.search_stream) {
                 fputc('\n', out_fd);
             }
         }


### PR DESCRIPTION
Previously, the output would be interspersed with blank lines when
piping input to ag, i.e. `echo "a\nb" | ag .` would output `a\n\nb\n`
instead of `a\nb`. This commit fixes this issue.
