### PR TITLE
Make --invert-match (-v) behave as in ack/grep.

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -117,7 +117,8 @@ void search_buf(const char *buf, const size_t buf_len,
     }
 
     if (opts.invert_match) {
-        matches_len = invert_matches(matches, matches_len, buf_len);
+        matches_len = invert_matches(buf, buf_len, matches, matches_len);
+        opts.color = FALSE;
     }
 
     if (opts.stats) {

--- a/src/util.h
+++ b/src/util.h
@@ -59,7 +59,7 @@ const char *boyer_moore_strncasestr(const char *s, const char *find, const size_
 
 strncmp_fp get_strstr(enum case_behavior opts);
 
-size_t invert_matches(match matches[], size_t matches_len, const size_t buf_len);
+size_t invert_matches(const char *buf, const size_t buf_len, match matches[], size_t matches_len);
 void compile_study(pcre **re, pcre_extra **re_extra, char *q, const int pcre_opts, const int study_opts);
 
 void *decompress(const ag_compression_type zip_type, const void *buf, const int buf_len, const char *dir_full_path, int *new_buf_len);


### PR DESCRIPTION
Previously, --invert-match (or -v) would output all lines, with the
all characters not part of a match highlighted. This behavior is
arguably not very useful, and means that `ag -v --nocolor X` simply
repeats its input, regardless of whether X matches anything or not.

In ack and grep, -v will print all lines which do not contain any match.
Arguably, this behavior is more useful. It also has the nice side effect
that the outputs of `ag X` and `ag -v X` won't overlap.

This commit makes ag use the ack/grep behavior by changing how
invert_matches works.
