### PR TITLE
Fixed description for --after and --before flags

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -32,8 +32,8 @@ void usage(void) {
     printf("\
 Output Options:\n\
      --ackmate            Print results in AckMate-parseable format\n\
-  -A --after [LINES]      Print lines before match (Default: 2)\n\
-  -B --before [LINES]     Print lines after match (Default: 2)\n\
+  -A --after [LINES]      Print lines after match (Default: 2)\n\
+  -B --before [LINES]     Print lines before match (Default: 2)\n\
      --[no]break          Print newlines between matches in different files\n\
                           (Enabled by default)\n\
      --[no]color          Print color codes in results (Enabled by default)\n\


### PR DESCRIPTION
Someone may have trolled, descriptions were switched.
