### PR TITLE
Fix for literal pattern containing slash

### DIFF
--- a/tests/contain_slash.t
+++ b/tests/contain_slash.t
@@ -1,0 +1,23 @@
+Setup:
+
+  $ . $TESTDIR/setup.sh
+  $ mkdir -p ./a/b/c ./d/e/f ./g/a/b ./h/d/e
+  $ echo 'whatever1' > ./a/b/c/foo.yml
+  $ echo 'whatever2' > ./d/e/f/foo.yml
+  $ echo 'whatever3' > ./g/a/b/foo.yml
+  $ echo 'whatever4' > ./h/d/e/foo.yml
+  $ echo 'a/b\n/d/e' > ./.gitignore
+
+Ignore files in ./a/b or ./d/e
+
+  $ ag whatever . | sort
+  g/a/b/foo.yml:1:whatever3
+  h/d/e/foo.yml:1:whatever4
+
+Dont ignore anything (unrestricted search):
+
+  $ ag -u whatever . | sort
+  a/b/c/foo.yml:1:whatever1
+  d/e/f/foo.yml:1:whatever2
+  g/a/b/foo.yml:1:whatever3
+  h/d/e/foo.yml:1:whatever4


### PR DESCRIPTION
If a literal ignore pattern contains slash but doesn't have the leading slash, it doesn't work properly. This patch will fix the issue (#367).
