### PR TITLE
Fix for ignore files not matching when absolute path specified

### DIFF
--- a/src/ignore.c
+++ b/src/ignore.c
@@ -253,7 +253,11 @@ static int path_ignore_search(const ignores *ig, const char *path, const char *f
         return 1;
     }
 
-    ag_asprintf(&temp, "%s/%s", path[0] == '.' ? path + 1 : path, filename);
+    if(path[0] != '.' && path[0] != '/') {
+        ag_asprintf(&temp, "/%s/%s", path, filename);
+    } else {
+        ag_asprintf(&temp, "%s/%s", path[0] == '.' ? path + 1 : path, filename);
+    }
 
     if (filename_ignore_search(ig, temp)) {
         free(temp);


### PR DESCRIPTION
Fix for: https://github.com/ggreer/the_silver_searcher/issues/448

This issue is caused by '/' is prepended to any regexes in ignore.c, which results in a mismatch when using relative paths. Fixed by prepending '/' to paths before matching. 
