### PR TITLE
Use NUL on windows instead of /dev/null

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -514,7 +514,11 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
         size_t buf_len = 0;
         char *gitconfig_res = NULL;
 
+#ifdef _WIN32
+        gitconfig_file = popen("git config -z --get core.excludesfile 2>NUL", "r");
+#else
         gitconfig_file = popen("git config -z --get core.excludesfile 2>/dev/null", "r");
+#endif
         if (gitconfig_file != NULL) {
             do {
                 gitconfig_res = ag_realloc(gitconfig_res, buf_len + 65);


### PR DESCRIPTION
Caused cmd.exe to print an error everytime ag.exe was run.
