### PR TITLE
Fix literal patterns containing slashes.

### DIFF
--- a/src/ignore.h
+++ b/src/ignore.h
@@ -26,6 +26,7 @@ ignores *init_ignore(ignores *parent);
 void cleanup_ignore(ignores *ig);
 
 void add_ignore_pattern(ignores *ig, const char *pattern);
+void sort_ignore_patterns(ignores *ig);
 
 void load_ignore_patterns(ignores *ig, const char *path);
 void load_svn_ignore_patterns(ignores *ig, const char *path);

--- a/src/options.c
+++ b/src/options.c
@@ -531,6 +531,8 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
         }
     }
 
+    sort_ignore_patterns(root_ignores);
+
     if (opts.context > 0) {
         opts.before = opts.context;
         opts.after = opts.context;

--- a/tests/ignore_backups.t
+++ b/tests/ignore_backups.t
@@ -18,7 +18,7 @@ Setup:
   $ echo 'whatever14' > ./foo.yml~
   $ echo 'whatever15' > ./.foo.yml.swp
   $ echo 'whatever16' > ./.foo.yml.swo
-  $ echo '*~\n*.sw[po]' > ./.gitignore
+  $ ( echo '*~'; echo '*.sw[po]' ) > ./.gitignore
 
 Ignore all files except foo.yml
 

--- a/tests/ignore_subdir_cmdline.t
+++ b/tests/ignore_subdir_cmdline.t
@@ -1,0 +1,37 @@
+Setup:
+
+  $ . $TESTDIR/setup.sh
+  $ mkdir -p foo/bar/baz
+  $ echo needle > foo/quux
+  $ echo needle > foo/bar/quux
+  $ echo needle > foo/bar/baz/quux
+
+Ignore foo:
+
+  $ ag needle --ignore foo
+  [1]
+
+Ignore foo/bar:
+
+  $ ag needle --ignore foo/bar
+  foo/quux:1:needle
+
+Ignore foo/bar/baz:
+
+  $ ag needle --ignore foo/bar/baz
+  foo/quux:1:needle
+  foo/bar/quux:1:needle
+
+Ignore nonexistent dir:
+
+  $ ag needle --ignore nothing
+  foo/quux:1:needle
+  foo/bar/quux:1:needle
+  foo/bar/baz/quux:1:needle
+
+Ignore nothing:
+
+  $ ag needle
+  foo/quux:1:needle
+  foo/bar/quux:1:needle
+  foo/bar/baz/quux:1:needle

--- a/tests/ignore_subdir_cmdline.t
+++ b/tests/ignore_subdir_cmdline.t
@@ -18,20 +18,20 @@ Ignore foo/bar:
 
 Ignore foo/bar/baz:
 
-  $ ag needle --ignore foo/bar/baz
-  foo/quux:1:needle
+  $ ag needle --ignore foo/bar/baz | sort
   foo/bar/quux:1:needle
+  foo/quux:1:needle
 
 Ignore nonexistent dir:
 
-  $ ag needle --ignore nothing
-  foo/quux:1:needle
-  foo/bar/quux:1:needle
+  $ ag needle --ignore nothing | sort
   foo/bar/baz/quux:1:needle
+  foo/bar/quux:1:needle
+  foo/quux:1:needle
 
 Ignore nothing:
 
-  $ ag needle
-  foo/quux:1:needle
-  foo/bar/quux:1:needle
+  $ ag needle | sort
   foo/bar/baz/quux:1:needle
+  foo/bar/quux:1:needle
+  foo/quux:1:needle

--- a/tests/ignore_subdir_cmdline.t
+++ b/tests/ignore_subdir_cmdline.t
@@ -35,3 +35,8 @@ Ignore nothing:
   foo/bar/baz/quux:1:needle
   foo/bar/quux:1:needle
   foo/quux:1:needle
+
+Ignore foo/bar and build/:
+
+  $ ag needle --ignore foo/bar --ignore build/
+  foo/quux:1:needle


### PR DESCRIPTION
This fixes both `--ignore foo/bar` on the command line and `foo/bar` inside a VCS ignore file.  Both of which I've tripped over.  :)