### PR TITLE
Don't prepend directory name if current directory

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -442,7 +442,13 @@ void search_dir(ignores *ig, const char *base_path, const char *path, const int 
     for (i = 0; i < results; i++) {
         queue_item = NULL;
         dir = dir_list[i];
-        ag_asprintf(&dir_full_path, "%s/%s", path, dir->d_name);
+        
+        // Don't print the directory name if it's the current directory
+        if (strlen(path) == 1 && path[0] == '.') {
+            ag_asprintf(&dir_full_path, "%s", dir->d_name);
+        } else {
+            ag_asprintf(&dir_full_path, "%s/%s", path, dir->d_name);
+        }
 
         /* If a link points to a directory then we need to treat it as a directory. */
         if (!opts.follow_symlinks && is_symlink(path, dir)) {


### PR DESCRIPTION
This allows queries of the form e.g. `ag -g '^s'` to work as expected -- matching all files beginning with `s`.
