### PR TITLE
Added support for ClojureScript extensions to --clojure

### DIFF
--- a/src/lang.c
+++ b/src/lang.c
@@ -11,7 +11,7 @@ lang_spec_t langs[] = {
     { "batch", { "bat", "cmd" } },
     { "cc", { "c", "h", "xs" } },
     { "cfmx", { "cfc", "cfm", "cfml" } },
-    { "clojure", { "clj" } },
+    { "clojure", { "clj", "cljs", "cljx" } },
     { "coffee", { "coffee" } },
     { "cpp", { "cpp", "cc", "C", "cxx", "m", "hpp", "hh", "h", "H", "hxx" } },
     { "csharp", { "cs" } },

--- a/tests/list_file_types.t
+++ b/tests/list_file_types.t
@@ -25,7 +25,7 @@ Language types are output:
         .cfc  .cfm  .cfml
   
     --clojure
-        .clj
+        .clj  .cljs  .cljx
   
     --coffee
         .coffee


### PR DESCRIPTION
Added support for ClojureScript (.cljs) and Leniningen's cljx cross-compiler (.cljx) to --clojure option.

I ran `make test` and everything passed.

I also considered breaking Clojurescript into a separate option, but they're still fairly tied together (e.g., Clojurescript macros are still written in Clojure, likely to have back-ends written in Clojure, etc) so I figured this was more useful.

Let me know if you have any questions! 
