### PR TITLE
Add a failing test: should ignore file a/b/c via `a/b`

### DIFF
--- a/tests/ignore_sub_mult.t
+++ b/tests/ignore_sub_mult.t
@@ -1,0 +1,16 @@
+Setup:
+
+  $ . $TESTDIR/setup.sh
+  $ mkdir -p ./a/b
+  $ echo 'needle' > ./a/b/c
+  $ echo 'a/b' > ./.gitignore
+
+Ignore a/b/c:
+
+  $ ag needle .
+
+Dont ignore anything (unrestricted search):
+
+  $ ag -u needle .
+  a/b/c:1:needle
+


### PR DESCRIPTION
Git ignores whole directories for a pattern like `a/b`, but ag requires `a/b/*` (both in .gitignore or .agignore IIRC).
