### PR TITLE
Auto enable color when CMDER is running

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -104,7 +104,7 @@ void init_options(void) {
     memset(&opts, 0, sizeof(opts));
     opts.casing = CASE_SMART;
 #ifdef _WIN32
-    opts.color = getenv("ANSICON") ? TRUE : FALSE;
+    opts.color = (getenv("ANSICON") || getenv("CMDER_ROOT")) ? TRUE : FALSE;
 #else
     opts.color = TRUE;
 #endif


### PR DESCRIPTION
Another little hack. CMDER has built-in support for ANSI colors.
