### PR TITLE
--vimgrep option added, reporting every match on the line

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ You can use Ag with [ack.vim][] by adding the following line to your `.vimrc`:
 
     let g:ackprg = 'ag --nogroup --nocolor --column'
 
+or:
+
+    let g:ackprg = 'ag --vimgrep'
+
+Which has the same effect but will report every match on the line.
+
 There's also a fork of ack.vim tailored for use with Ag: [ag.vim][]
 [ack.vim]: https://github.com/mileszs/ack.vim
 [ag.vim]: https://github.com/rking/ag.vim

--- a/ag.bashcomp.sh
+++ b/ag.bashcomp.sh
@@ -62,6 +62,7 @@ _ag() {
     --stats
     --unrestricted
     --version
+    --vimgrep
     --word-regexp
     --workers
   '

--- a/doc/ag.1
+++ b/doc/ag.1
@@ -252,7 +252,23 @@ Recursively search for PATTERN in PATH\. Like grep or ack, but faster\.
 .P
 \fB\-v \-\-invert\-match\fR
 .
+.P
+\fB\-\-vimgrep\fR:
+.
 .br
+\~\~\~\~ Output results like vim's :vimgrep /pattern/g would (it reports every match on the line)\.
+.br
+\~\~\~\~ Here's a ~/.vimrc configuration example:
+.P
+\~\~\~\~\~\~\~\~ set grepprg=ag\\\ --vimgrep\\\ $*
+.br
+\~\~\~\~\~\~\~\~ set grepformat=%f:%l:%c:%m
+.P
+\~\~\~\~ Then use :grep to grep for something\.
+.br
+\~\~\~\~ Then use :copen :cn :cp etc.. to navigate through the matches\.
+.
+.P
 \fB\-w \-\-word\-regexp\fR:
 .
 .br

--- a/doc/ag.1.md
+++ b/doc/ag.1.md
@@ -62,7 +62,7 @@ Recursively search for PATTERN in PATH. Like grep or ack, but faster.
     See `FILE TYPES` below.
   * `-m --max-count NUM`:
     Skip the rest of a file after NUM matches. Default is 10,000.
-  * `--no-numbers`:            
+  * `--no-numbers`:
     Don't show line numbers
   * `--null`:
     Separate files output with -l or -L by \0 rather than \n, this allows 'xargs -0 <command>' to correctly process filenames with spaces.
@@ -93,6 +93,13 @@ Recursively search for PATTERN in PATH. Like grep or ack, but faster.
   * `-U --skip-vcs-ignores`:
     Ignore VCS ignore files (.gitignore, .hgignore, svn:ignore), but still use .agignore.
   * `-v --invert-match`
+  * `--vimgrep`:
+    Output results like vim's :vimgrep /pattern/g would (it reports every match on the line).
+    Here's a ~/.vimrc configuration example:
+    set grepprg=ag\ --vimgrep\ $*
+    set grepformat=%f:%l:%c:%m
+    Then use :grep to grep for something.
+    Then use :copen :cn :cp etc.. to navigate through the matches.
   * `-w --word-regexp`:
     Only match whole words.
   * `-z --search-zip`:

--- a/src/options.c
+++ b/src/options.c
@@ -57,6 +57,8 @@ Output Options:\n\
                           don't match\n\
      --silent             Suppress all log messages, including errors\n\
      --stats              Print stats (files scanned, time taken, etc.)\n\
+     --vimgrep            Print results like vim's :vimgrep /pattern/g would\n\
+                          (it reports every match on the line)\n\
 \n\
 Search Options:\n\
   -a --all-types          Search all files (doesn't include hidden files\n\
@@ -232,6 +234,7 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
         { "stats", no_argument, &opts.stats, 1 },
         { "unrestricted", no_argument, NULL, 'u' },
         { "version", no_argument, &version, 1 },
+        { "vimgrep", no_argument, &opts.vimgrep, 1 },
         { "word-regexp", no_argument, NULL, 'w' },
         { "workers", required_argument, NULL, 0 },
     };
@@ -543,6 +546,14 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
         opts.print_break = 1;
         group = 1;
         opts.search_stream = 0;
+    }
+
+    if (opts.vimgrep) {
+        opts.color = 0;
+        opts.print_break = 0;
+        group = 1;
+        opts.search_stream = 0;
+        opts.print_path = PATH_PRINT_NOTHING;
     }
 
     if (opts.parallel) {

--- a/src/options.h
+++ b/src/options.h
@@ -75,6 +75,7 @@ typedef struct {
     char *pager;
     int paths_len;
     int parallel;
+    int vimgrep;
     int word_regexp;
     int workers;
 } cli_options;

--- a/src/print.h
+++ b/src/print.h
@@ -4,9 +4,12 @@
 #include "util.h"
 
 void print_path(const char *path, const char sep);
+void print_line(const char *buf, size_t buf_pos, size_t prev_line_offset);
 void print_binary_file_matches(const char *path);
 void print_file_matches(const char *path, const char *buf, const size_t buf_len, const match_t matches[], const size_t matches_len);
 void print_line_number(size_t line, const char sep);
+void print_column_number(const match_t matches[], size_t last_printed_match,
+                         size_t prev_line_offset, const char sep);
 void print_file_separator(void);
 const char *normalize_path(const char *path);
 

--- a/tests/vimgrep.t
+++ b/tests/vimgrep.t
@@ -1,0 +1,16 @@
+Setup:
+
+  $ . $TESTDIR/setup.sh
+  $ echo 'Hello, "Hello, world" programs output "Hello, world".' > ./test_vimgrep.txt
+  $ echo '"Hello, world" programs are simple programs.' >> ./test_vimgrep.txt
+  $ echo 'They illustrate the most basic syntax of a programming language' >> ./test_vimgrep.txt
+  $ echo 'In javascript: alert("Hello, world!");' >> ./test_vimgrep.txt
+
+Search for lines matching "hello" in test_vimgrep.txt:
+
+  $ ag --vimgrep hello
+  test_vimgrep.txt:1:1:Hello, "Hello, world" programs output "Hello, world".
+  test_vimgrep.txt:1:9:Hello, "Hello, world" programs output "Hello, world".
+  test_vimgrep.txt:1:40:Hello, "Hello, world" programs output "Hello, world".
+  test_vimgrep.txt:2:2:"Hello, world" programs are simple programs.
+  test_vimgrep.txt:4:23:In javascript: alert("Hello, world!");


### PR DESCRIPTION
Output results like vim's :vimgrep /pattern/g would (it reports every match on the line).
Here's a ~/.vimrc configuration example:

```
set grepprg=ag\ --vimgrep\ $*
set grepformat=%f:%l:%c:%m
```

Then use :grep to grep for something.
Then use :copen :cn :cp etc.. to navigate through the matches.

Ag is a good candidate for vim users as an external grepping tool because of its speed and its --column options to get the cursor on the first matching pattern.

But what about reporting every match on the line? The --vimgrep option does that. The matches navigation isn't approximate anymore and matches are easy to locate with :cn and :cp.

Here's an example of the --vimgrep output for a file containing:

```
foo bar baz
bar foo baz foo
bar baz

% ag --vimgrep foo /tmp/a.txt
/tmp/a.txt:1:1:foo bar baz
/tmp/a.txt:2:5:bar foo baz foo
/tmp/a.txt:2:13:bar foo baz foo
```

The format is:

```
"file":"line number":"column number":"line content"
```

Grepping tools I know (git grep, ack-grep) don't support this output. I think Ag would be the first, making it more and more efficient.

Here's an example by image: http://i.imgur.com/dkbCuPr.gif

Let me know what you think.

Regards,
Yann
