### PR TITLE
More subtle default color scheme

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -15,9 +15,9 @@
 #include "log.h"
 #include "util.h"
 
-const char *color_line_number = "\033[1;32m"; /* green on black background */
-const char *color_match = "\033[1;37m";       /* white on black background */
-const char *color_path = "\033[1;34m";        /* blue on black background */
+const char *color_line_number = "\033[1;32m"; /* green */
+const char *color_match = "\033[1;31m";       /* red */
+const char *color_path = "\033[1;34m";        /* blue */
 
 /* TODO: try to obey out_fd? */
 void usage(void) {
@@ -38,7 +38,7 @@ Output Options:\n\
                           (Enabled by default)\n\
      --[no]color          Print color codes in results (Enabled by default)\n\
      --color-line-number  Color codes for line numbers (Default: 1;32)\n\
-     --color-match        Color codes for result match numbers (Default: 1;37)\n\
+     --color-match        Color codes for result match numbers (Default: 1;31)\n\
      --color-path         Color codes for path names (Default: 1;34)\n\
      --column             Print column numbers in results\n\
   -H --[no]heading        Print file names (Enabled unless searching a single file)\n\


### PR DESCRIPTION
While the bright yellow marker, green paths and yellow line number are well intentioned and work well when there is one or two matches, a screenfull of those makes it harder to read the text and spot what one was looking for, at least for me. Also, to me, the bright yellow feels abrasive.

The proposed changes are for making the color scheme more subtle and making the overall text easier to read.

People can still "--color-match '30;43'" if they like to be punched in the eye, colorwise.
