### PR TITLE
Add -x and --files-from options.

### DIFF
--- a/src/options.h
+++ b/src/options.h
@@ -78,6 +78,7 @@ typedef struct {
     int vimgrep;
     int word_regexp;
     int workers;
+    char *files_from;
 } cli_options;
 
 /* global options. parse_options gives it sane values, everything else reads from it */

--- a/tests/files_from.t
+++ b/tests/files_from.t
@@ -1,0 +1,33 @@
+Setup:
+
+  $ . $TESTDIR/setup.sh
+  $ echo "foo bar" > files_from_test_1.txt
+  $ echo "zoo zar" >> files_from_test_2.txt
+  $ echo "foo test zoo" >> files_from_test_3.a
+  $ echo "zoo zoo" >> files_from_test_4.txt
+  $ echo "files_from_test_1.txt" > files.txt
+  $ echo "files_from_test_2.txt" >> files.txt
+  $ echo "files_from_test_3.a" >> files.txt
+  $ echo "*.txt" > agignore
+
+test files-from on command line, and make sure ignore files are, well, ignored:
+
+  $ ag --path-to-agignore agignore --files-from files.txt zoo 
+  files_from_test_2.txt:1:zoo zar
+  files_from_test_3.a:1:foo test zoo
+
+Just to make sure the ignore file works normally:
+
+  $ ag --path-to-agignore agignore zoo
+  files_from_test_3.a:1:foo test zoo
+
+Test from stdin via cat:
+
+  $ cat files.txt | ag -x zoo
+  files_from_test_2.txt:1:zoo zar
+  files_from_test_3.a:1:foo test zoo
+
+Test from stdin via shell redirection:
+
+  $ ag -x zar < files.txt
+  files_from_test_2.txt:1:zoo zar


### PR DESCRIPTION
Take 2: Not sure if you're interested but these options mimic the 'ack' options which enable using another program to generate the list of paths to search.

I had a typo in the first pull request where the paths and base_paths arguments to the add_paths function was reversed, but I also added a test for the files-from option specifically.
