### PR TITLE
Add support for Markdown.

### DIFF
--- a/src/lang.c
+++ b/src/lang.c
@@ -38,6 +38,7 @@ lang_spec_t langs[] = {
     { "lua", { "lua" } },
     { "m4", { "m4" } },
     { "make", { "Makefiles", "mk", "mak" } },
+    { "markdown", { "markdown", "mdown", "mdwn", "mkdn", "mkd", "md" } },
     { "mason", { "mas", "mhtml", "mpl", "mtxt" } },
     { "matlab", { "m" } },
     { "objc", { "m", "h" } },

--- a/tests/list_file_types.t
+++ b/tests/list_file_types.t
@@ -105,6 +105,9 @@ Language types are output:
     --make
         .Makefiles  .mk  .mak
   
+    --markdown
+        .markdown  .mdown  .mdwn  .mkdn  .mkd  .md
+  
     --mason
         .mas  .mhtml  .mpl  .mtxt
   


### PR DESCRIPTION
I often use `ag` to sift through google/WebFundamentals (a huge pile of Markdown files), but having to do `ag -G '.+\.markdown'` makes me sad. I'd much rather use `--markdown`, which is why I'm submitting this patch.

Tests appear to pass:

```
~/Code/the_silver_searcher[add-markdown-support]% make test
cram -v tests/*.t
tests/bad_path.t: passed
tests/case_sensitivity.t: passed
tests/exitcodes.t: passed
tests/hidden_option.t: passed
tests/ignore_abs_path.t: passed
tests/ignore_absolute_search_path_with_glob.t: passed
tests/ignore_backups.t: passed
tests/ignore_examine_parent_ignorefiles.t: passed
tests/ignore_pattern_in_subdirectory.t: passed
tests/ignore_subdir.t: passed
tests/invert_match.t: passed
tests/list_file_types.t: passed
tests/passthrough.t: passed
tests/vimgrep.t: passed
# Ran 14 tests, 0 skipped, 0 failed.
```
