### PR TITLE
Add support for Liquid templates.

### DIFF
--- a/src/lang.c
+++ b/src/lang.c
@@ -34,6 +34,7 @@ lang_spec_t langs[] = {
     { "json", { "json" } },
     { "jsp", { "jsp", "jspx", "jhtm", "jhtml" } },
     { "less", { "less" } },
+    { "liquid", { "liquid" } },
     { "lisp", { "lisp", "lsp" } },
     { "lua", { "lua" } },
     { "m4", { "m4" } },

--- a/tests/list_file_types.t
+++ b/tests/list_file_types.t
@@ -93,6 +93,9 @@ Language types are output:
     --less
         .less
   
+    --liquid
+        .liquid
+  
     --lisp
         .lisp  .lsp
   


### PR DESCRIPTION
Same reasons as PR #518: when sifting through Liquid templates I'd much rather use `--liquid` instead of a filename regex.
