### PR TITLE
fixed error in bash completion (issue #524)

### DIFF
--- a/ag.bashcomp.sh
+++ b/ag.bashcomp.sh
@@ -78,7 +78,7 @@ _ag() {
   types=$(ag --list-file-types |grep -- '--')
 
   # these options require an argument
-  if [[ "${prev}" == -@(A|B|C|G|g|m) ]] ; then
+  if [[ "${prev}" == -[ABCGgm] ]] ; then
     return 0
   fi
 


### PR DESCRIPTION
This can be fixed without enabling `extglob`, by using basic pattern instead of extended.
