### PR TITLE
Fix exit code for `ag -g`

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -464,6 +464,7 @@ void search_dir(ignores *ig, const char *base_path, const char *path, const int 
                     pthread_mutex_lock(&print_mtx);
                     print_path(dir_full_path, opts.path_sep);
                     pthread_mutex_unlock(&print_mtx);
+                    opts.match_found = 1;
                     goto cleanup;
                 }
             }

--- a/tests/option_g.t
+++ b/tests/option_g.t
@@ -1,0 +1,11 @@
+Setup:
+
+  $ . $TESTDIR/setup.sh
+  $ touch foobar
+
+Search for lines matching "hello" in test_vimgrep.txt:
+
+  $ ag -g foobar
+  foobar
+  $ ag -g baz
+  [1]


### PR DESCRIPTION
Return -1 only for no matches, 0 if files have been found.
