### PR TITLE
fix multiple file types issue

### DIFF
--- a/src/lang.c
+++ b/src/lang.c
@@ -79,17 +79,19 @@ unsigned int get_lang_count() {
     return sizeof(langs) / sizeof(lang_spec_t);
 }
 
-char *make_lang_regex(const char **extensions) {
+char *make_lang_regex(char* ext_array, unsigned int num_exts) {
     int regex_capacity = 100;
     char *regex = ag_malloc(regex_capacity);
     int regex_length = 3;
     int subsequent = 0;
-    const char **extension;
+    char *extension;
+    unsigned int i;
 
     strcpy(regex, "\\.(");
 
-    for (extension = extensions; *extension; ++extension) {
-        int extension_length = strlen(*extension);
+    for (i = 0; i < num_exts; ++i) {
+        extension = ext_array + i * SINGLE_EXT_LEN;
+        int extension_length = strlen(extension);
         while (regex_length + extension_length + 3 + subsequent > regex_capacity) {
             regex_capacity *= 2;
             regex = ag_realloc(regex, regex_capacity);
@@ -99,7 +101,7 @@ char *make_lang_regex(const char **extensions) {
         } else {
             subsequent = 1;
         }
-        strcpy(regex + regex_length, *extension);
+        strcpy(regex + regex_length, extension);
         regex_length += extension_length;
     }
 
@@ -108,3 +110,36 @@ char *make_lang_regex(const char **extensions) {
     regex[regex_length++] = 0;
     return regex;
 }
+
+unsigned int
+combine_file_extensions(unsigned int*   extension_index,
+                        unsigned int    len,
+                        char**          exts)
+{
+    /* Keep it fixed as 100 for the reason that if you have more than 100 
+     * file types to search, you'd better search all the files.
+     * */
+    unsigned int ext_capacity = 100;
+    (*exts) = (char*)ag_malloc(ext_capacity * SINGLE_EXT_LEN);
+    memset((*exts), 0, ext_capacity * SINGLE_EXT_LEN);
+    unsigned int num_of_extensions= 0;
+
+    unsigned int i = 0;
+    for (; i < len; ++i) {
+        unsigned int j = 0;
+        const char* ext = langs[extension_index[i]].extensions[j];
+        do {
+            if (num_of_extensions == ext_capacity) {
+                break;
+            }
+            char* pos = (*exts) + num_of_extensions * SINGLE_EXT_LEN;
+            strncpy(pos, ext, strlen(ext));
+            ++num_of_extensions;
+            ext = langs[extension_index[i]].extensions[++j];
+        } while(ext);
+    }
+
+    return num_of_extensions;
+}
+
+

--- a/src/lang.h
+++ b/src/lang.h
@@ -2,6 +2,7 @@
 #define LANG_H
 
 #define MAX_EXTENSIONS 12
+#define SINGLE_EXT_LEN 20
 
 typedef struct {
     const char *name;
@@ -21,6 +22,18 @@ into a regular expression of the form \.(extension1|extension2...)$
 
 Caller is responsible for freeing the returned string.
 */
-char *make_lang_regex(const char **extensions);
+char *make_lang_regex(char *ext_array, unsigned int num_exts);
 
+
+/**
+Combine multiple file type extensions into one array.
+
+The combined result is returned through *exts*;
+*exts* is one-dimension array, which can contain up to 100 extensions;
+The number of extensions that *exts* actually contain is returned.
+*/
+unsigned int
+combine_file_extensions(unsigned int*   extension_index,
+                        unsigned int    len,
+                        char**          exts);
 #endif

--- a/src/options.c
+++ b/src/options.c
@@ -489,13 +489,15 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
     }
 
 
-    num_exts = combine_file_extensions(ext_index, lang_num, &extensions);
-    lang_regex = make_lang_regex(extensions, num_exts);
-    compile_study(&opts.file_search_regex, &opts.file_search_regex_extra, lang_regex, 0, 0);
+    if (ext_index[0]) {
+        num_exts = combine_file_extensions(ext_index, lang_num, &extensions);
+        lang_regex = make_lang_regex(extensions, num_exts);
+        compile_study(&opts.file_search_regex, &opts.file_search_regex_extra, lang_regex, 0, 0);
+    }
 
-    free(extensions);
+    if (extensions) free(extensions);
     free(ext_index);
-    free(lang_regex);
+    if (lang_regex) free(lang_regex);
     free(longopts);
 
     argc -= optind;

--- a/src/options.c
+++ b/src/options.c
@@ -172,10 +172,14 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
     struct stat statbuf;
     int rv;
     unsigned int lang_count;
+    unsigned int lang_num = 0;
 
     size_t longopts_len, full_len;
     option_t *longopts;
     char *lang_regex = NULL;
+    unsigned int* ext_index = NULL;
+    char* extensions = NULL;
+    unsigned int num_exts = 0;
 
     init_options();
 
@@ -250,6 +254,8 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
     full_len = (longopts_len + lang_count + 1);
     longopts = ag_malloc(full_len * sizeof(option_t));
     memcpy(longopts, base_longopts, sizeof(base_longopts));
+    ext_index = (unsigned int*)ag_malloc(sizeof(unsigned int)*lang_count);
+    memset(ext_index, 0, sizeof(unsigned int)*lang_count);
 
     for (i = 0; i < lang_count; i++) {
         option_t opt = { langs[i].name, no_argument, NULL, 0 };
@@ -467,14 +473,11 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
 
                 for (i = 0; i < lang_count; i++) {
                     if (strcmp(longopts[opt_index].name, langs[i].name) == 0) {
-                        lang_regex = make_lang_regex(langs[i].extensions);
-                        compile_study(&opts.file_search_regex, &opts.file_search_regex_extra, lang_regex, 0, 0);
+                        ext_index[lang_num++] = i;
                         break;
                     }
                 }
-                if (lang_regex) {
-                    free(lang_regex);
-                    lang_regex = NULL;
+                if (i != lang_count) {
                     break;
                 }
 
@@ -485,6 +488,14 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
         }
     }
 
+
+    num_exts = combine_file_extensions(ext_index, lang_num, &extensions);
+    lang_regex = make_lang_regex(extensions, num_exts);
+    compile_study(&opts.file_search_regex, &opts.file_search_regex_extra, lang_regex, 0, 0);
+
+    free(extensions);
+    free(ext_index);
+    free(lang_regex);
     free(longopts);
 
     argc -= optind;


### PR DESCRIPTION
Originally, when there are multiple file types presented, ag only takes
the last one as its file type.
But the user want to search all the file types.
e.g. when i type `ag --cpp --cc what_i_want`, ag only searches for c
files.
But the user wants to seach both c and cpp files.

This change fixes this.