### PR TITLE
Add ag.exe to ignore compiled binary from windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .DS_Store
 aclocal.m4
 ag
+ag.exe
 autom4te.cache
 cachegrind.out.*
 callgrind.out.*


### PR DESCRIPTION
The compiled `ag` binary is ignored when compiled on Linux, but the equivalent `ag.exe` from Windows compile is not ignored. 
