### PR TITLE
Some shells (e.g. bash) do not expand '\n' to a newline

### DIFF
--- a/tests/ignore_backups.t
+++ b/tests/ignore_backups.t
@@ -18,7 +18,8 @@ Setup:
   $ echo 'whatever14' > ./foo.yml~
   $ echo 'whatever15' > ./.foo.yml.swp
   $ echo 'whatever16' > ./.foo.yml.swo
-  $ echo '*~\n*.sw[po]' > ./.gitignore
+  $ echo '*~'         > ./.gitignore
+  $ echo '*.sw[po]'   >> ./.gitignore
 
 Ignore all files except foo.yml
 

--- a/tests/option_smartcase.t
+++ b/tests/option_smartcase.t
@@ -1,7 +1,8 @@
 Setup:
 
   $ . $TESTDIR/setup.sh
-  $ echo 'asdf\nAsDf' > test.txt
+  $ echo 'asdf' > test.txt
+  $ echo 'AsDf' >> test.txt
 
 Smart case search:
 


### PR DESCRIPTION
Use two separate `echo` statements. While `printf` would also work, it
seems better to stick with `echo` here.

Ref: https://github.com/ggreer/the_silver_searcher/pull/542#issuecomment-65269731
