### PR TITLE
Support for -o (--only-matching), which prints only the matching part of the line

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -53,6 +53,7 @@ Output Options:\n\
   -L --files-without-matches\n\
                           Only print filenames that don't contain matches\n\
      --no-numbers         Don't print line numbers\n\
+  -o --only-matching      Prints only the matching part of the lines\n\
      --print-long-lines   Print matches on very long lines (Default: >2k characters)\n\
      --passthrough        When searching a stream, print all lines even if they\n\
                           don't match\n\
@@ -223,6 +224,7 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
         { "noheading", no_argument, &opts.print_path, PATH_PRINT_EACH_LINE },
         { "nopager", no_argument, NULL, 0 },
         { "null", no_argument, NULL, '0' },
+        { "only-matching", no_argument, NULL, 'o' },
         { "pager", required_argument, NULL, 0 },
         { "parallel", no_argument, &opts.parallel, 1 },
         { "passthrough", no_argument, &opts.passthrough, 1 },
@@ -288,7 +290,7 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
     }
 
     int pcre_opts = 0;
-    while ((ch = getopt_long(argc, argv, "A:aB:C:cDG:g:fHhiLlm:np:QRrSsvVtuUwz0", longopts, &opt_index)) != -1) {
+    while ((ch = getopt_long(argc, argv, "A:aB:C:cDG:g:fHhiLlm:nop:QRrSsvVtuUwz0", longopts, &opt_index)) != -1) {
         switch (ch) {
             case 'A':
                 if (optarg) {
@@ -377,6 +379,9 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
                 break;
             case 'p':
                 opts.path_to_agignore = optarg;
+                break;
+            case 'o':
+                opts.only_matching = 1;
                 break;
             case 'Q':
                 opts.literal = 1;

--- a/src/options.h
+++ b/src/options.h
@@ -50,6 +50,7 @@ typedef struct {
     int literal_ends_wordchar;
     size_t max_matches_per_file;
     int max_search_depth;
+    int only_matching;
     char path_sep;
     char *path_to_agignore;
     int print_break;

--- a/src/print.c
+++ b/src/print.c
@@ -186,7 +186,10 @@ void print_file_matches(const char *path, const char *buf, const size_t buf_len,
                         }
                         /* Don't print the null terminator */
                         if (j < buf_len) {
-                            fputc(buf[j], out_fd);
+                            /* if only_matching is set, print only matches and newlines */
+                            if (!opts.only_matching || printing_a_match || buf[j] == '\n') {
+                                fputc(buf[j], out_fd);
+                            }
                         }
                     }
                     if (printing_a_match && opts.color) {

--- a/tests/only_matching.t
+++ b/tests/only_matching.t
@@ -1,0 +1,12 @@
+Setup:
+
+  $ . $TESTDIR/setup.sh
+  $ echo "the quick brown foxy" > blah.txt
+  $ echo "another foxlike word" >> blah.txt
+  $ echo "no matches here" >> blah.txt
+
+Only print matches:
+
+  $ ag -o "fox\w+"
+  blah.txt:1:foxy
+  blah.txt:2:foxlike


### PR DESCRIPTION
This is based on the earlier pull request from @JSmith-BitFlipper in #454. Thanks Geoff.
