### PR TITLE
Makefile.w32: using $(GREP) inside VERSION

### DIFF
--- a/Makefile.w32
+++ b/Makefile.w32
@@ -1,4 +1,5 @@
-VERSION=$(shell grep -Po "(?<=\[)([0-9.]+.[0-9]+.[0-9]+)(?=\])" configure.ac)
+GREP=grep
+VERSION:=$(shell $(GREP) -Po "(?<=\[)([0-9.]+.[0-9]+.[0-9]+)(?=\])" configure.ac)
 
 CC=gcc
 


### PR DESCRIPTION
also use := instead of = for VERSION assignment, since that evaluates the VERSION only once
