### PR TITLE
Add option to skip holes in sparse files.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -44,6 +44,8 @@ AS_IF([test "x$enable_lzma" != "xno"], [
     PKG_CHECK_MODULES([LZMA], [liblzma])
 ])
 
+AC_CHECK_DECL([SEEK_HOLE], [AC_DEFINE([USE_SEEK_HOLE], [], [Enable seeking to hole/data sections of files])], [], [#include <unistd.h>])
+
 AC_CHECK_DECL([PCRE_CONFIG_JIT], [AC_DEFINE([USE_PCRE_JIT], [], [Use PCRE JIT])], [], [#include <pcre.h>])
 
 AC_CHECK_DECL([CPU_ZERO, CPU_SET], [AC_DEFINE([USE_CPU_SET], [], [Use CPU_SET macros])] , [], [#include <sched.h>])

--- a/src/options.h
+++ b/src/options.h
@@ -82,6 +82,7 @@ typedef struct {
     int vimgrep;
     int word_regexp;
     int workers;
+    int skip_holes;
 } cli_options;
 
 /* global options. parse_options gives it sane values, everything else reads from it */

--- a/src/search.c
+++ b/src/search.c
@@ -336,19 +336,17 @@ void search_file(const char *file_full_path) {
         }
     }
 
-    else {
-        struct ds_link *curr = ds_list_head;
-        while (curr) {
-            char *start = buf + curr->start;
-            if (curr->end <= f_len) {
-                log_debug("curr->start is %ld", curr->start);
-                log_debug("search_buf(%ld, %ld, %s)", start, curr->end - curr->start, file_full_path);
-                search_buf(start, curr->end - curr->start,
-                           file_full_path);
-                curr = curr->next;
-            } else {
-                curr = NULL;
-            }
+    struct ds_link *curr = ds_list_head;
+    while (curr) {
+        char *start = buf + curr->start;
+        if (curr->end <= f_len) {
+            log_debug("curr->start is %ld", curr->start);
+            log_debug("search_buf(%ld, %ld, %s)", start, curr->end - curr->start, file_full_path);
+            search_buf(start, curr->end - curr->start,
+                       file_full_path);
+            curr = curr->next;
+        } else {
+            curr = NULL;
         }
     }
 


### PR DESCRIPTION
Hi and thanks for making "ag", one of the most invaluable tools that I use daily!

Previously "ag -u asdfasdfasdfadsf /root_partition" was taking nearly ten minutes, due to gobblying gigabytes of zeros in sparse files, notably /var/log/lastlog, which is nominally 400+ GB on my system but actually occupies less than 100 KB

The behavior witnessed is the worker thread pegging its core to 100%, as well as the kernel swapper thread getting its core to 40% dutifully discarding those pages of zeros as ag faults in ever more of them.

This adds a --skip-holes option that jumps over holes in sparse files, using the SEEK_HOLE and SEEK_DATA API described here: https://blogs.oracle.com/bonwick/entry/seek_hole_and_seek_data (and in the years since, implemented on more OSes than Solaris)

Now with --skip-holes I can do ag -u of my root partition in something like 1:30 instead of 9:30, and ag -u of /var/log/lastlog takes seconds.