### PR TITLE
Add support for a --one-device flag

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -157,7 +157,14 @@ int main(int argc, char **argv) {
             log_debug("searching path %s for %s", paths[i], opts.query);
             symhash = NULL;
             ignores *ig = init_ignore(root_ignores, "", 0);
-            search_dir(ig, base_paths[i], paths[i], 0);
+            struct stat s = {.st_dev = 0};
+            /* The device is ignored if opts.one_dev is false, so it's fine
+             * to leave it at the default 0
+             */
+            if (opts.one_dev && lstat(paths[i], &s) == -1) {
+                log_err("Failed to get device information for path %s. Skipping...", paths[i]);
+            }
+            search_dir(ig, base_paths[i], paths[i], 0, s.st_dev);
             cleanup_ignore(ig);
         }
         pthread_mutex_lock(&work_queue_mtx);

--- a/src/options.c
+++ b/src/options.c
@@ -126,7 +126,6 @@ void init_options(void) {
     opts.color_match = ag_strdup(color_match);
     opts.color_line_number = ag_strdup(color_line_number);
     opts.use_thread_affinity = TRUE;
-    opts.one_dev = FALSE;
 }
 
 void cleanup_options(void) {

--- a/src/options.c
+++ b/src/options.c
@@ -77,6 +77,7 @@ Search Options:\n\
                           (literal file/directory names also allowed)\n\
      --ignore-dir NAME    Alias for --ignore for compatibility with ack.\n\
   -m --max-count NUM      Skip the rest of a file after NUM matches (Default: 10,000)\n\
+     --one-device         Don't follow links to other devices.\n\
   -p --path-to-agignore STRING\n\
                           Use .agignore file at STRING\n\
   -Q --literal            Don't parse PATTERN as a regular expression\n\
@@ -125,6 +126,7 @@ void init_options(void) {
     opts.color_match = ag_strdup(color_match);
     opts.color_line_number = ag_strdup(color_line_number);
     opts.use_thread_affinity = TRUE;
+    opts.one_dev = FALSE;
 }
 
 void cleanup_options(void) {
@@ -230,6 +232,7 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
         { "nopager", no_argument, NULL, 0 },
         { "null", no_argument, NULL, '0' },
         { "only-matching", no_argument, NULL, 'o' },
+        { "one-device", no_argument, &opts.one_dev, 1 },
         { "pager", required_argument, NULL, 0 },
         { "parallel", no_argument, &opts.parallel, 1 },
         { "passthrough", no_argument, &opts.passthrough, 1 },

--- a/src/options.h
+++ b/src/options.h
@@ -50,6 +50,7 @@ typedef struct {
     int literal_ends_wordchar;
     size_t max_matches_per_file;
     int max_search_depth;
+    int one_dev;
     int only_matching;
     char path_sep;
     char *path_to_agignore;

--- a/src/search.h
+++ b/src/search.h
@@ -72,6 +72,6 @@ void search_file(const char *file_full_path);
 
 void *search_file_worker(void *i);
 
-void search_dir(ignores *ig, const char *base_path, const char *path, const int depth);
+void search_dir(ignores *ig, const char *base_path, const char *path, const int depth, dev_t original_dev);
 
 #endif

--- a/tests/one_device.t
+++ b/tests/one_device.t
@@ -1,0 +1,19 @@
+Setup:
+
+  $ . $TESTDIR/setup.sh
+  $ TEST_TMPDIR=`mktemp -d --tmpdir=/dev/shm ag_test.XXX`
+  $ echo "blah" > $TEST_TMPDIR/blah.txt
+  $ ln -s $TEST_TMPDIR other_device
+
+Should not descend into /dev/shm symlink when --one-device specified:
+
+  $ ag -f --one-device blah .
+  [1]
+
+Files on other devices work the same way as anything else without --one-device:
+
+  $ ag -f blah .
+  other_device/blah.txt:1:blah
+
+Cleanup:
+  $ rm -r $TEST_TMPDIR


### PR DESCRIPTION
Add a flag that will cause `ag` not to descend into mount points.