### PR TITLE
Fix zero length matches

### DIFF
--- a/src/print.c
+++ b/src/print.c
@@ -91,12 +91,6 @@ void print_file_matches(const char *path, const char *buf, const size_t buf_len,
     context_prev_lines = ag_calloc(sizeof(char *), (opts.before + 1));
 
     for (i = 0; i <= buf_len && (cur_match < matches_len || lines_since_last_match <= opts.after); i++) {
-        if (cur_match < matches_len && i == matches[cur_match].end) {
-            /* We found the end of a match. */
-            cur_match++;
-            in_a_match = FALSE;
-        }
-
         if (cur_match < matches_len && i == matches[cur_match].start) {
             in_a_match = TRUE;
             /* We found the start of a match */
@@ -126,6 +120,12 @@ void print_file_matches(const char *path, const char *buf, const size_t buf_len,
                 }
             }
             lines_since_last_match = 0;
+        }
+
+        if (cur_match < matches_len && i == matches[cur_match].end) {
+            /* We found the end of a match. */
+            cur_match++;
+            in_a_match = FALSE;
         }
 
         /* We found the end of a line. */

--- a/src/search.c
+++ b/src/search.c
@@ -96,6 +96,10 @@ void search_buf(const char *buf, const size_t buf_len,
                (pcre_exec(opts.re, opts.re_extra, buf, buf_len, buf_offset, 0, offset_vector, 3)) >= 0) {
             log_debug("Regex match found. File %s, offset %i bytes.", dir_full_path, offset_vector[0]);
             buf_offset = offset_vector[1];
+            if (offset_vector[0] == offset_vector[1]) {
+                ++buf_offset;
+                log_debug("Regex match is of length zero. Advancing offset one byte.");
+            }
 
             /* TODO: copy-pasted from above. FIXME */
             if (matches_len + matches_spare >= matches_size) {

--- a/tests/empty_match.t
+++ b/tests/empty_match.t
@@ -1,0 +1,13 @@
+Setup.
+  $ . $TESTDIR/setup.sh
+  $ touch empty.txt
+  $ echo foo > nonempty.txt
+
+Zero-length match on an empty file should fail silently with return code 1
+
+  $ ag "^" empty.txt
+  [1]
+
+A genuine zero-length match should succeed:
+  $ ag "^" nonempty.txt
+  1:foo


### PR DESCRIPTION
This fixes issue https://github.com/ggreer/the_silver_searcher/issues/572 , which is caused by an infinite loop when a zero-length match is encountered. Basically, when a zero-length match is found, the input buffer is not advanced, so the same match is found again, over and over. Each time, a new match object is created, eventually filling main memory and causing the program to be killed.

Normally Perl would not match the same zero-length match twice in a row, so this problem is avoided there. But that information is not tracked across calls to `pcre_exec`, so we need to advance the input to prevent it from happening.

An alternative fix would be to allow `pcre_exec` to return multiple matches. I believe (though I haven't tested it) that it would e.g. ignore the first zero-length match, and return the next possible match as the second match. However, this would become complicated if there is more than one possible zero-length match (e.g. if the regex is something like `^|(|a)`). More investigation would be required to determine the behavior of `pcre_exec` here, and design a solution that takes this possibility into account. Thus, I believe the simpler solution of just advancing the input is better.

Some background: http://www.regular-expressions.info/zerolength.html