### PR TITLE
Default options via environment variable

### DIFF
--- a/src/options.h
+++ b/src/options.h
@@ -92,7 +92,10 @@ typedef struct option option_t;
 void usage(void);
 void print_version(void);
 
+void free_str_array(int len, char ***arr);
+
 void init_options(void);
+int append_env_options(int argc, char **argv, char ***opts);
 void parse_options(int argc, char **argv, char **base_paths[], char **paths[]);
 void cleanup_options(void);
 


### PR DESCRIPTION
ag can now read options from an environment variable 'AG_OPTIONS' as well as command line parameters.
This can be used to set default values for calls to ag, without the need for aliases or additional config files.

Implemented as a response to Issue #574