### PR TITLE
Smarter word boundaries.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -97,6 +97,10 @@ int main(int argc, char **argv) {
         opts.casing = is_lowercase(opts.query) ? CASE_INSENSITIVE : CASE_SENSITIVE;
     }
 
+    if (opts.word_regexp) {
+        init_wordchar_table();
+    }
+
     if (opts.literal) {
         if (opts.casing == CASE_INSENSITIVE) {
             /* Search routine needs the query to be lowercase */
@@ -109,20 +113,12 @@ int main(int argc, char **argv) {
         find_skip_lookup = NULL;
         generate_find_skip(opts.query, opts.query_len, &find_skip_lookup, opts.casing == CASE_SENSITIVE);
         if (opts.word_regexp) {
-            init_wordchar_table();
             opts.literal_starts_wordchar = is_wordchar(opts.query[0]);
             opts.literal_ends_wordchar = is_wordchar(opts.query[opts.query_len - 1]);
         }
     } else {
         if (opts.casing == CASE_INSENSITIVE) {
             pcre_opts |= PCRE_CASELESS;
-        }
-        if (opts.word_regexp) {
-            char *word_regexp_query;
-            ag_asprintf(&word_regexp_query, "\\b%s\\b", opts.query);
-            free(opts.query);
-            opts.query = word_regexp_query;
-            opts.query_len = strlen(opts.query);
         }
         compile_study(&opts.re, &opts.re_extra, opts.query, pcre_opts, study_opts);
     }

--- a/src/search.c
+++ b/src/search.c
@@ -59,10 +59,8 @@ void search_buf(const char *buf, const size_t buf_len,
                 /* Check whether both start and end of the match lie on a word
                  * boundary
                  */
-                if ((start == buf ||
-                     is_wordchar(*(start - 1)) != opts.literal_starts_wordchar) &&
-                    (end == buf + buf_len ||
-                     is_wordchar(*end) != opts.literal_ends_wordchar)) {
+                if ((start == buf || !opts.literal_starts_wordchar || !is_wordchar(*(start - 1))) &&
+                    (end == buf + buf_len || !opts.literal_ends_wordchar || !is_wordchar(*end))) {
                     /* It's a match */
                 } else {
                     /* It's not a match */
@@ -105,6 +103,18 @@ void search_buf(const char *buf, const size_t buf_len,
             if (matches_len + matches_spare >= matches_size) {
                 matches_size = matches ? matches_size * 2 : 100;
                 matches = ag_realloc(matches, matches_size * sizeof(match_t));
+            }
+
+            if (opts.word_regexp) {
+                const char *start = buf + offset_vector[0];
+                const char *end = buf + offset_vector[1];
+
+                if ((start == buf || !is_wordchar(*start) || !is_wordchar(*(start - 1))) &&
+                    (end == buf + buf_len || !is_wordchar(*(end - 1)) || !is_wordchar(*end))) {
+                    // It's a match.
+                } else {
+                    continue;
+                }
             }
 
             matches[matches_len].start = offset_vector[0];

--- a/tests/word_regexp.t
+++ b/tests/word_regexp.t
@@ -1,0 +1,51 @@
+
+Setup:
+  $ . $TESTDIR/setup.sh
+  $ echo "This should always get recognized #is#a"      >> ./sample
+  $ echo "This# should never get recognized #isit?"     >> ./sample
+  $ echo "Is OK if start with pattern?"                 >> ./sample
+  $ echo "Finishing with pattern also OK is"            >> ./sample
+
+
+Literals work porperly:
+
+  $ ag is sample -Qw
+  1:This should always get recognized #is#a
+  3:Is OK if start with pattern?
+  4:Finishing with pattern also OK is
+
+Works for simple regexes:
+
+  $ ag is sample -w
+  1:This should always get recognized #is#a
+  3:Is OK if start with pattern?
+  4:Finishing with pattern also OK is
+
+  $ ag '\w{2}' sample -w
+  1:This should always get recognized #is#a
+  3:Is OK if start with pattern?
+  4:Finishing with pattern also OK is
+
+Regexes properly recognize partial word boundaries:
+
+  $ ag 'is#' sample -w
+  1:This should always get recognized #is#a
+
+  $ ag '#is' sample -w
+  1:This should always get recognized #is#a
+
+Works on multi-word regexes:
+
+  $ ag 'always g\w{2} recog.*zed' sample
+  1:This should always get recognized #is#a
+
+It fails to match unless on a word boundary:
+
+  $ ag 'sh' sample -w
+  [1]
+
+  $ ag 'ou' sample -w
+  [1]
+
+  $ ag 'ld' sample -w
+  [1]


### PR DESCRIPTION
This fixes #563, where `-w` wasn't properly finding word boundaries.

All the tests pass still, I did my own testing on the command line and that seems to pass, if this PR seems OK to you guys i'll add a test file for this as well.

My issue here is that in order to have this fix work on literal(`-Q`) queries, I needed to change the definition of what counts as a wordchar to any _non-wordchar_ regardless of whether it currently follows a _wordchar_ or not.
