### PR TITLE
Use strrchr() to find the extension in a filename.

### DIFF
--- a/src/ignore.c
+++ b/src/ignore.c
@@ -381,15 +381,15 @@ int filename_filter(const char *path, const struct dirent *dir, void *baton) {
     }
     log_debug("path_start %s filename %s", path_start, filename);
 
-    const char *extension = NULL;
-    for (i = filename_len - 1; i > 0; i--) {
-        if (filename[i] == '.') {
-            extension = filename + i + 1;
-            break;
+    const char *extension = strrchr(filename, '.');
+    if (extension) {
+        if (extension[1]) {
+            // The dot is not the last character, extension starts at the next one
+            ++extension;
+        } else {
+            // No extension
+            extension = NULL;
         }
-    }
-    if (extension && extension[0] == '\0') {
-        extension = NULL;
     }
 
     while (ig != NULL) {


### PR DESCRIPTION
Use strrchr() to locate the last dot in a filename instead of a homemade loop.