### PR TITLE
Treat literal '.' literally (fixes #627)

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -36,7 +36,7 @@ void search_buf(const char *buf, const size_t buf_len,
         matches_spare = 0;
     }
 
-    if (opts.query_len == 1 && opts.query[0] == '.') {
+    if (!opts.literal && opts.query_len == 1 && opts.query[0] == '.') {
         matches_size = 1;
         matches = ag_malloc(matches_size * sizeof(match_t));
         matches[0].start = 0;


### PR DESCRIPTION
Fixes #627: *Bug: Literal pattern '.' is not treated literally*