### PR TITLE
Make --version show status of features controlled by compile-time options

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -106,7 +106,23 @@ For a list of supported file types run:\n\
 }
 
 void print_version(void) {
-    printf("ag version %s\n", PACKAGE_VERSION);
+    char jit = '-';
+    char lzma = '-';
+    char zlib = '-';
+
+#ifdef USE_PCRE_JIT
+    jit = '+';
+#endif
+#ifdef HAVE_LZMA_H
+    lzma = '+';
+#endif
+#ifdef HAVE_ZLIB_H
+    zlib = '+';
+#endif
+
+    printf("ag version %s\n\n", PACKAGE_VERSION);
+    printf("Features:\n");
+    printf("  %cjit %clzma %czlib\n", jit, lzma, zlib);
 }
 
 void init_options(void) {


### PR DESCRIPTION
Addresses #629: *Feature request: make --version print compile-time options*

I am not very good at deciphering Autoconf/Automake stuff, so i wasn't sure which options should be printed, but i picked the three that seem the most relevant: PCRE JIT, lzma, and zlib. The result looks like this (i based the +/- thing on the way vim does it):

```
% ./ag --version
ag version 0.29.1

Features:
  +jit -lzma +zlib
```