### PR TITLE
windows colors improvements

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 ACLOCAL_AMFLAGS = ${ACLOCAL_FLAGS}
 
 bin_PROGRAMS = ag
-ag_SOURCES = src/ignore.c src/ignore.h src/log.c src/log.h src/options.c src/options.h src/print.c src/print.h src/scandir.c src/scandir.h src/search.c src/search.h src/lang.c src/lang.h src/util.c src/util.h src/decompress.c src/decompress.h src/uthash.h src/main.c
+ag_SOURCES = src/ignore.c src/ignore.h src/log.c src/log.h src/options.c src/options.h src/print.c src/print_w32.c src/print.h src/scandir.c src/scandir.h src/search.c src/search.h src/lang.c src/lang.h src/util.c src/util.h src/decompress.c src/decompress.h src/uthash.h src/main.c
 ag_LDADD = ${PCRE_LIBS} ${LZMA_LIBS} ${ZLIB_LIBS} $(PTHREAD_LIBS)
 
 dist_man_MANS = doc/ag.1

--- a/src/options.c
+++ b/src/options.c
@@ -14,6 +14,7 @@
 #include "lang.h"
 #include "log.h"
 #include "util.h"
+#include "print.h"
 
 const char *color_line_number = "\033[1;33m"; /* bold yellow */
 const char *color_match = "\033[30;43m";      /* black with yellow background */
@@ -42,6 +43,8 @@ Output Options:\n\
      --color-line-number  Color codes for line numbers (Default: 1;33)\n\
      --color-match        Color codes for result match numbers (Default: 30;43)\n\
      --color-path         Color codes for path names (Default: 1;32)\n\
+     --color-win-ansi     Use ansi colors on Windows even where we can use native\n\
+                          (pager/pipe colors are ansi regardless) (Default: off)\n\
      --column             Print column numbers in results\n\
      --[no]filename       Print file names (Enabled unless searching a single file)\n\
   -H --[no]heading        Print file names before each file's matches\n\
@@ -129,6 +132,7 @@ void init_options(void) {
     memset(&opts, 0, sizeof(opts));
     opts.casing = CASE_DEFAULT;
     opts.color = TRUE;
+    opts.color_win_ansi = FALSE;
     opts.max_matches_per_file = 0;
     opts.max_search_depth = DEFAULT_MAX_SEARCH_DEPTH;
     opts.path_sep = '\n';
@@ -215,6 +219,7 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
         { "color-line-number", required_argument, NULL, 0 },
         { "color-match", required_argument, NULL, 0 },
         { "color-path", required_argument, NULL, 0 },
+        { "color-win-ansi", no_argument, &opts.color_win_ansi, TRUE },
         { "column", no_argument, &opts.column, 1 },
         { "context", optional_argument, NULL, 'C' },
         { "count", no_argument, NULL, 'c' },
@@ -712,4 +717,8 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
     }
     (*paths)[i] = NULL;
     (*base_paths)[i] = NULL;
+
+#ifdef _WIN32
+     windows_use_ansi(opts.color_win_ansi);
+#endif
 }

--- a/src/options.c
+++ b/src/options.c
@@ -15,7 +15,7 @@
 #include "log.h"
 #include "util.h"
 
-const char *color_line_number = "\033[1;33m"; /* yellow with black background */
+const char *color_line_number = "\033[1;33m"; /* bold yellow */
 const char *color_match = "\033[30;43m";      /* black with yellow background */
 const char *color_path = "\033[1;32m";        /* bold green */
 

--- a/src/options.c
+++ b/src/options.c
@@ -43,8 +43,14 @@ Output Options:\n\
      --color-line-number  Color codes for line numbers (Default: 1;33)\n\
      --color-match        Color codes for result match numbers (Default: 30;43)\n\
      --color-path         Color codes for path names (Default: 1;32)\n\
+");
+#ifdef _WIN32
+    printf("\
      --color-win-ansi     Use ansi colors on Windows even where we can use native\n\
                           (pager/pipe colors are ansi regardless) (Default: off)\n\
+");
+#endif
+    printf("\
      --column             Print column numbers in results\n\
      --[no]filename       Print file names (Enabled unless searching a single file)\n\
   -H --[no]heading        Print file names before each file's matches\n\

--- a/src/options.h
+++ b/src/options.h
@@ -41,6 +41,7 @@ typedef struct {
     char *color_line_number;
     char *color_match;
     char *color_path;
+    int color_win_ansi;
     int column;
     int context;
     int follow_symlinks;

--- a/src/print.h
+++ b/src/print.h
@@ -14,4 +14,8 @@ void print_column_number(const match_t matches[], size_t last_printed_match,
 void print_file_separator(void);
 const char *normalize_path(const char *path);
 
+#ifdef _WIN32
+int fprintf_w32(FILE* fp, const char* format, ...);
+#endif
+
 #endif

--- a/src/print.h
+++ b/src/print.h
@@ -15,7 +15,8 @@ void print_file_separator(void);
 const char *normalize_path(const char *path);
 
 #ifdef _WIN32
-int fprintf_w32(FILE* fp, const char* format, ...);
+void windows_use_ansi(int use_ansi);
+int fprintf_w32(FILE *fp, const char *format, ...);
 #endif
 
 #endif

--- a/src/print_w32.c
+++ b/src/print_w32.c
@@ -28,7 +28,8 @@ int fprintf_w32(FILE *fp, const char *format, ...) {
     va_list args;
     char buf[BUF_SIZE] = {0}, *ptr = buf;
     static WORD attr_old;
-    static HANDLE stdo = INVALID_HANDLE_VALUE;
+    static BOOL attr_initialized = FALSE;
+    HANDLE stdo = INVALID_HANDLE_VALUE;
     WORD attr;
     DWORD written, csize;
     CONSOLE_CURSOR_INFO cci;
@@ -58,7 +59,11 @@ int fprintf_w32(FILE *fp, const char *format, ...) {
     va_end(args);
 
     GetConsoleScreenBufferInfo(stdo, &csbi);
-    attr = attr_old = csbi.wAttributes;
+    attr = csbi.wAttributes;
+    if (!attr_initialized) {
+        attr_old = attr;
+        attr_initialized = TRUE;
+    }
 
     while (*ptr) {
         if (*ptr == '\033') {
@@ -179,7 +184,6 @@ int fprintf_w32(FILE *fp, const char *format, ...) {
                     }
                     break;
                 case 'm':
-                    attr = attr_old;
                     for (i = 0; i <= n; i++) {
                         if (v[i] == -1 || v[i] == 0)
                             attr = attr_old;
@@ -312,7 +316,6 @@ int fprintf_w32(FILE *fp, const char *format, ...) {
             ptr++;
         }
     }
-    SetConsoleTextAttribute(stdo, attr_old);
     return ptr - buf;
 }
 

--- a/src/print_w32.c
+++ b/src/print_w32.c
@@ -18,6 +18,12 @@
 // buffer. win32 colored output will be truncated to this length.
 #define BUF_SIZE (16 * 1024)
 
+static int g_use_ansi = 0;
+void windows_use_ansi(int use_ansi)
+{
+    g_use_ansi = use_ansi;
+}
+
 int fprintf_w32(FILE *fp, const char *format, ...) {
     va_list args;
     char buf[BUF_SIZE] = {0}, *ptr = buf;
@@ -30,7 +36,7 @@ int fprintf_w32(FILE *fp, const char *format, ...) {
     COORD coord;
 
     stdo = (HANDLE) _get_osfhandle(fileno(fp));
-    if (!isatty(fileno(fp)) || stdo == INVALID_HANDLE_VALUE) {
+    if (g_use_ansi || !isatty(fileno(fp)) || stdo == INVALID_HANDLE_VALUE) {
         // if not a tty, skip ansi interpretation and just passthrough.
         // colors are disabled for pipe unless --color was used,
         // and a pager is assumed it knows how to handle ansi colors,

--- a/src/print_w32.c
+++ b/src/print_w32.c
@@ -1,5 +1,10 @@
+#ifdef _WIN32
+
 #include <windows.h>
 #include <stdio.h>
+#include <io.h>
+#include <stdarg.h>
+#include "print.h"
 
 #ifndef FOREGROUND_MASK
 #define FOREGROUND_MASK (FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_INTENSITY)
@@ -10,8 +15,7 @@
 
 int fprintf_w32(FILE *fp, const char *format, ...) {
     va_list args;
-    int r;
-    char buf[BUFSIZ], *ptr = buf, *stop;
+    char buf[BUFSIZ], *ptr = buf;
     static WORD attr_old;
     static HANDLE stdo = INVALID_HANDLE_VALUE;
     WORD attr;
@@ -21,7 +25,7 @@ int fprintf_w32(FILE *fp, const char *format, ...) {
     COORD coord;
 
     va_start(args, format);
-    r = vsnprintf(buf, sizeof(buf), format, args);
+    vsnprintf(buf, sizeof(buf), format, args);
     va_end(args);
 
     stdo = (HANDLE)_get_osfhandle(fileno(fp));
@@ -34,7 +38,7 @@ int fprintf_w32(FILE *fp, const char *format, ...) {
     while (*ptr) {
         if (*ptr == '\033') {
             unsigned char c;
-            int i, n = 0, m, v[6], w, h;
+            int i, n = 0, m = '\0', v[6], w, h;
             for (i = 0; i < 6; i++)
                 v[i] = -1;
             ptr++;
@@ -286,3 +290,5 @@ int fprintf_w32(FILE *fp, const char *format, ...) {
     SetConsoleTextAttribute(stdo, attr_old);
     return ptr - buf;
 }
+
+#endif /* _WIN32 */


### PR DESCRIPTION
- can build also without `Makefile.w32`
- fixed pager/pipe colors - fallback to ansi colors for pager/pipe or CLI flag.
- doesn't show bold colors for everything, more compatible implementation.
- can show color also for matches (was only showing for path and line number).
- better includes, removed unused variables and static, initialize others.
- fixed undefined behavior if the print length is more than `BUFSIZ`
- some more stuff - details at the commit messages.