### PR TITLE
Add the Velocity file type

### DIFF
--- a/src/lang.c
+++ b/src/lang.c
@@ -71,6 +71,7 @@ lang_spec_t langs[] = {
     { "tt", { "tt", "tt2", "ttml" } },
     { "vala", { "vala", "vapi" } },
     { "vb", { "bas", "cls", "frm", "ctl", "vb", "resx" } },
+    { "velocity", { "vm" } },
     { "verilog", { "v", "vh", "sv" } },
     { "vhdl", { "vhd", "vhdl" } },
     { "vim", { "vim" } },


### PR DESCRIPTION
This adds the `--velocity` file type flag. I'm working in a codebase that makes heavy use of the [Velocity templating language](https://velocity.apache.org), and it would be very useful to search just the `.vm` files.