### PR TITLE
Added support for the Clojure 1.7 common file format

### DIFF
--- a/src/lang.c
+++ b/src/lang.c
@@ -11,7 +11,7 @@ lang_spec_t langs[] = {
     { "batch", { "bat", "cmd" } },
     { "cc", { "c", "h", "xs" } },
     { "cfmx", { "cfc", "cfm", "cfml" } },
-    { "clojure", { "clj", "cljs", "cljx" } },
+    { "clojure", { "clj", "cljs", "cljc", "cljx" } },
     { "coffee", { "coffee" } },
     { "cpp", { "cpp", "cc", "C", "cxx", "m", "hpp", "hh", "h", "H", "hxx" } },
     { "csharp", { "cs" } },

--- a/tests/list_file_types.t
+++ b/tests/list_file_types.t
@@ -25,7 +25,7 @@ Language types are output:
         .cfc  .cfm  .cfml
   
     --clojure
-        .clj  .cljs  .cljx
+        .clj  .cljs  .cljc  .cljx
   
     --coffee
         .coffee


### PR DESCRIPTION
This file extension is used for code common to all Clojure implementations, and will be supported starting with the soon to be released Clojure 1.7.