### PR TITLE
Print WARN messages to stderr instead of stdout

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -53,6 +53,7 @@ void vplog(const unsigned int level, const char *fmt, va_list args) {
             fprintf(stream, "MSG: ");
             break;
         case LOG_LEVEL_WARN:
+            stream = stderr;
             fprintf(stream, "WARN: ");
             break;
         case LOG_LEVEL_ERR:


### PR DESCRIPTION
When running ag on some path, it spits a lot of:

    WARN: Skipping ./long/path. Use the --depth option to search deeper.

I'm use to quiet grep(1) by appending `2>/dev/null`, but it just doesn't
work here because they're printed on standard output.

Move the warning to stderr so that it can be easily silented if
necessary.