### PR TITLE
Add tests for funky gitignore negations

### DIFF
--- a/tests/ignore_subcontent_except_onefile.t
+++ b/tests/ignore_subcontent_except_onefile.t
@@ -1,0 +1,28 @@
+Setup:
+
+# This is a test for gitignores, where you can ignore all subcontent
+# of a dir, but add exception to that.
+
+$ . $TESTDIR/setup.sh
+$ mkdir -p ./a/b
+$ mkdir -p ./a/c
+$ echo 'whatever1' > ./a/foo.txt
+$ echo 'whatever2' > ./a/important.txt
+$ echo 'whatever3' > ./a/b/bar.txt
+$ echo 'whatever4' > ./a/c/baz.txt
+$ echo 'a/*' >> ./.gitignore
+$ echo '!a/important.txt' >> ./.gitignore
+
+Ignore all but /a/important.txt.
+
+  $ ag whatever . | sort
+  a/important.txt:1:whatever2
+
+
+Dont ignore anything (unrestricted search):
+
+  $ ag -u whatever . | sort
+  a/b/bar.txt:1:whatever3
+  a/c/baz.txt:1:whatever4
+  a/foo.txt:1:whatever1
+  a/important.txt:1:whatever2

--- a/tests/ignore_subcontent_except_subdirs.t
+++ b/tests/ignore_subcontent_except_subdirs.t
@@ -1,0 +1,32 @@
+Setup:
+
+# This is a test for gitignores, where you can ignore all subcontent
+# of a dir, but add exception to that.
+
+$ . $TESTDIR/setup.sh
+$ mkdir -p ./a/b
+$ mkdir -p ./a/c
+$ echo 'whatever1' > ./a/foo.txt
+$ echo 'whatever2' > ./a/important.txt
+$ echo 'whatever3' > ./a/b/bar.txt
+$ echo 'whatever4' > ./a/c/baz.txt
+$ echo 'a/*' >> ./.gitignore
+$ echo '!a/important.txt' >> ./.gitignore
+$ echo '!a/*/' >> ./.gitignore
+$ echo 'a/c/' >> ./.gitignore
+$ echo '!a/c/baz.txt' >> ./.gitignore
+
+Do not ignore a/b/bar.txt or /a/important.txt. Notice we ignore a/c/baz.txt (if a parent dir is ignored in a gitignore, never look at its content).
+
+  $ ag whatever . | sort
+  a/b/bar.txt:1:whatever3
+  a/important.txt:1:whatever2
+
+
+Dont ignore anything (unrestricted search):
+
+  $ ag -u whatever . | sort
+  a/b/bar.txt:1:whatever3
+  a/c/baz.txt:1:whatever4
+  a/foo.txt:1:whatever1
+  a/important.txt:1:whatever2


### PR DESCRIPTION
Git has some funky features of [gitignore](https://git-scm.herokuapp.com/docs/gitignore)

```
dir/*
!dir/*/
```

The above gitignore means to ignore everything in `dir` except subdirs. However, if your parentdir is already ignored, no negation will change that fact.

This is a bit of a problem, as `fnmatch("dir/", "dir/*")` says there is a match, meaning `ag` will completely ignore that folder.

Handling gitignore negations as git does would really be awesome. I tried to implement this myself by adding a `char **noignore_regexes` to the `ignores` structure, and avoiding a match if one of these where valid, but that turned out to be harder than I thought. 

If your license is compatible, maybe you could just use the code from [`git-ls-files`](https://git-scm.herokuapp.com/docs/git-ls-files) or even libgit2 to get the files git cares about?

---

ps. Why are the patterns that need `fnmatch`  called `regexes`? I was a bit confused by this, as I thought the array would actually hold a regular expression.
