### PR TITLE
Fix a warning about an assignment discarding qualifiers

### DIFF
--- a/src/decompress.c
+++ b/src/decompress.c
@@ -48,7 +48,8 @@ static void *decompress_zlib(const void *buf, const int buf_len,
     }
 
     stream.avail_in = buf_len;
-    stream.next_in = buf;
+    /* Explicitly cast away the const-ness of buf */
+    stream.next_in = (Bytef *)buf;
 
     pagesize = getpagesize();
     result_size = ((buf_len + pagesize - 1) & ~(pagesize - 1));


### PR DESCRIPTION
By explicitly casting a `const void *` to a `Bytef *`, we get rid of this warning from Clang:

    src/decompress.c:51:20: warning: assigning to 'Bytef *' (aka
          'unsigned char *') from 'const void *' discards qualifiers
          [-Wincompatible-pointer-types-discards-qualifiers]
        stream.next_in = buf;
                       ^ ~~~