### PR TITLE
Fix the test for `clang-format`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -67,7 +67,7 @@ AC_CHECK_PROGS(
     [clang-format-3.7 clang-format-3.6 clang-format],
     [no]
 )
-AM_CONDITIONAL([HAS_CLANG_FORMAT], [test "x$CLANG_FORMAT" != xno])
+AM_CONDITIONAL([HAS_CLANG_FORMAT], [test x$CLANG_FORMAT != xno])
 AM_COND_IF(
     [HAS_CLANG_FORMAT],
     [AC_MSG_NOTICE([clang-format found. 'make test' will detect improperly-formatted files.])],

--- a/format.sh
+++ b/format.sh
@@ -16,6 +16,12 @@ then
     echo "No CLANG_FORMAT set. Using $CLANG_FORMAT"
 fi
 
+if ! type "$CLANG_FORMAT" &> /dev/null
+then
+    echo "The command \"$CLANG_FORMAT\" was not found"
+    exit 1
+fi
+
 SOURCE_FILES=`git ls-files src/`
 
 if [ "$1" == "reformat" ]


### PR DESCRIPTION
This consists of two changes:

1. The syntax in `configure.ac` was incorrect; the effect was that the build script always thought that the `clang-format` command was available, even if `$CLANG_FORMAT` was equal to `no`.
2. `format.sh` did not notice if `$CLANG_FORMAT` was not an actual command; in this case it would actually report that the code was formatted correctly and exit with a 0 status code. (This happened because the result of `clang-format` was being piped through `grep` and so the failure code from the invalid `clang-format` command was silently ignored.)
