### PR TITLE
Add number of files matched to --stats output

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -186,7 +186,7 @@ int main(int argc, char **argv) {
                     ((long)stats.time_start.tv_sec * 1000000 + stats.time_start.tv_usec);
         time_diff /= 1000000;
 
-        printf("%ld matches\n%ld files searched\n%ld bytes searched\n%f seconds\n", stats.total_matches, stats.total_files, stats.total_bytes, time_diff);
+        printf("%ld matches\n%ld files contained matches\n%ld files searched\n%ld bytes searched\n%f seconds\n", stats.total_matches, stats.total_file_matches, stats.total_files, stats.total_bytes, time_diff);
     }
 
     if (opts.pager) {

--- a/src/search.c
+++ b/src/search.c
@@ -127,6 +127,9 @@ void search_buf(const char *buf, const size_t buf_len,
         stats.total_bytes += buf_len;
         stats.total_files++;
         stats.total_matches += matches_len;
+        if (matches_len > 0) {
+            stats.total_file_matches++;
+        }
         pthread_mutex_unlock(&stats_mtx);
     }
 

--- a/src/util.h
+++ b/src/util.h
@@ -37,6 +37,7 @@ typedef struct {
     long total_bytes;
     long total_files;
     long total_matches;
+    long total_file_matches;
     struct timeval time_start;
     struct timeval time_end;
 } ag_stats;


### PR DESCRIPTION
As requested in issue #653, this adds the number of matched files to the output for --stats.