### PR TITLE
POC fix for gitignore

### DIFF
--- a/src/ignore.c
+++ b/src/ignore.c
@@ -186,6 +186,27 @@ void load_ignore_patterns(ignores *ig, const char *path) {
     fclose(fp);
 }
 
+void load_ignored_git(ignores *ig, FILE *stdout_fp) {
+    char *line = NULL;
+    ssize_t line_len = 0;
+    size_t line_cap = 0;
+
+    while ((line_len = getline(&line, &line_cap, stdout_fp)) > 0) {
+        if (line_len <= 3 || strncmp(line, "!! ", 3) != 0) {
+          log_err("Error: Failed to parse ignored files. Is git installed?");
+          continue;
+        }
+
+        if (line[line_len - 1] == '\n') {
+            line[line_len - 1] = '\0'; /* kill the \n */
+        }
+
+        // strip off the leading "!! "
+        add_ignore_pattern(ig, line + 3);
+    }
+    free(line);
+}
+
 void load_svn_ignore_patterns(ignores *ig, const char *path) {
     FILE *fp = NULL;
     char *dir_prop_base;

--- a/src/ignore.h
+++ b/src/ignore.h
@@ -3,6 +3,7 @@
 
 #include <dirent.h>
 #include <sys/types.h>
+#include <stdio.h>
 
 #define SVN_DIR_PROP_BASE "dir-prop-base"
 #define SVN_DIR ".svn"
@@ -40,6 +41,7 @@ ignores *init_ignore(ignores *parent, const char *dirname, const size_t dirname_
 void cleanup_ignore(ignores *ig);
 
 void add_ignore_pattern(ignores *ig, const char *pattern);
+void load_ignored_git(ignores *ig, FILE *stdout_fp);
 
 void load_ignore_patterns(ignores *ig, const char *path);
 void load_svn_ignore_patterns(ignores *ig, const char *path);

--- a/src/options.c
+++ b/src/options.c
@@ -628,6 +628,9 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
             free(gitconfig_res);
             pclose(gitconfig_file);
         }
+        
+        FILE *ignored_files = gitconfig_file = popen("git status --ignored --porcelain", "r");
+        load_ignored_git(root_ignores, ignored_files);
     }
 
     if (opts.context > 0) {

--- a/src/search.c
+++ b/src/search.c
@@ -405,7 +405,7 @@ void search_dir(ignores *ig, const char *base_path, const char *path, const int 
         return;
     }
 
-    /* find agignore/gitignore/hgignore/etc files to load ignore patterns from */
+    /* find agignore/gitignore/hgignore/etc files to load ignore patterns from 
     for (i = 0; opts.skip_vcs_ignores ? (i == 0) : (ignore_pattern_files[i] != NULL); i++) {
         ignore_file = ignore_pattern_files[i];
         ag_asprintf(&dir_full_path, "%s/%s", path, ignore_file);
@@ -416,7 +416,7 @@ void search_dir(ignores *ig, const char *base_path, const char *path, const int 
         }
         free(dir_full_path);
         dir_full_path = NULL;
-    }
+    }*/
 
     if (opts.path_to_agignore) {
         load_ignore_patterns(ig, opts.path_to_agignore);


### PR DESCRIPTION
This patch isn't in a usable state, but it functions as a proof of concept fix for the gitignore problems. It is absolutely not in a mergable state, reviewing the code is pointless at this point in time.

It works by asking git what files should be ignored, using the `git status --ignored --porcelain` command. I can confirm it fixes at least #168.

Possible objections:

- the dependency on git might not be wanted, although there isn't much point to searching a git repo without git installed.
- potential performance issues

-------

If this is an acceptable way of solving these issues, I'd be happy to properly recreate this PR.