### PR TITLE
Add a link to the windows wiki page

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ or
 
 
 
+### Windows
+
+See the dedicated [wiki article](https://github.com/ggreer/the_silver_searcher/wiki/Windows)
+
+
 ## Building from source
 
 ### Building master


### PR DESCRIPTION
At the moment there is only one link to the windows in the "build from source" section.
