### PR TITLE
Fix Extension Matching

### DIFF
--- a/src/ignore.c
+++ b/src/ignore.c
@@ -381,7 +381,7 @@ int filename_filter(const char *path, const struct dirent *dir, void *baton) {
     }
     log_debug("path_start %s filename %s", path_start, filename);
 
-    const char *extension = strrchr(filename, '.');
+    const char *extension = strchr(filename, '.');
     if (extension) {
         if (extension[1]) {
             // The dot is not the last character, extension starts at the next one

--- a/tests/ignore_extensions.t
+++ b/tests/ignore_extensions.t
@@ -1,0 +1,42 @@
+Setup:
+
+  $ . $TESTDIR/setup.sh
+  $ echo '*.js' > .gitignore
+  $ echo '\n*.test.txt' >> .gitignore
+  $ echo 'targetA' > something.js
+  $ echo 'targetB' > aFile.test.txt
+  $ echo 'targetC' > aFile.txt
+  $ mkdir -p subdir
+  $ echo 'targetD' > subdir/somethingElse.js
+  $ echo 'targetE' > subdir/anotherFile.test.txt
+  $ echo 'targetF' > subdir/anotherFile.txt
+
+Ignore patterns with single extension in root directory:
+
+  $ ag "targetA"
+  [1]
+
+Ignore patterns with multiple extensions in root directory:
+
+  $ ag "targetB"
+  [1]
+
+Do not ignore patterns with partial extensions in root directory:
+
+  $ ag "targetC"
+  aFile.txt:1:targetC
+
+Ignore patterns with single extension in subdirectory:
+
+  $ ag "targetD"
+  [1]
+
+Ignore patterns with multiple extensions in subdirectory:
+
+  $ ag "targetE"
+  [1]
+
+Do not ignore patterns with partial extensions in subdirectory:
+
+  $ ag "targetF"
+  subdir/anotherFile.txt:1:targetF


### PR DESCRIPTION
Extension ignoring is kind of broken when there are more than one .'s in the ignore pattern. We find the extension by using a `strrchr` to search for the last `.` and then try to match the characters after that. So, for example, *.backup.txt ends up with an extension of "txt", which fails to match any of our patterns. This means that the file is not ignored when it should be (issue #678).

This is a simple fix of just searching forward in the string rather than backward. It's possible that we don't want to include *.ext.otherext patterns in the extensions array, in which case we need a different fix that is probably over my head. I've also included tests for this fix.