### PR TITLE
Avoid underflow in column count on multiline matches

### DIFF
--- a/src/print.c
+++ b/src/print.c
@@ -259,9 +259,16 @@ void print_line_number(size_t line, const char sep) {
 
 void print_column_number(const match_t matches[], size_t last_printed_match,
                          size_t prev_line_offset, const char sep) {
-    fprintf(out_fd, "%lu%c",
-            (unsigned long)(matches[last_printed_match].start - prev_line_offset) + 1,
-            sep);
+    unsigned long start = matches[last_printed_match].start;
+
+    //check for underflow due to multiline matches
+    if (prev_line_offset <= start + 1) {
+        fprintf(out_fd, "%lu%c",
+                (unsigned long)(start - prev_line_offset) + 1,
+                sep);
+    } else {
+        fprintf(out_fd, "%d%c", 0, sep);
+    }
 }
 
 void print_file_separator(void) {


### PR DESCRIPTION
When --column is enabled, the starting column of a match is stored as an unsigned long. When the match spans multiple lines, the calculated starting column is actually negative, which results in an underflow and a really large column number like #677. This fix changes the behavior to print 0 as the column number rather than calculating and printing an incorrect unsigned long.