### PR TITLE
make log output be MT-safe

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -43,26 +43,27 @@ void vplog(const unsigned int level, const char *fmt, va_list args) {
         return;
     }
 
+    char *heading;
     FILE *stream = out_fd;
 
     switch (level) {
         case LOG_LEVEL_DEBUG:
-            fprintf(stream, "DEBUG: ");
+            heading = "DEBUG: ";
             break;
         case LOG_LEVEL_MSG:
-            fprintf(stream, "MSG: ");
+            heading = "MSG: ";
             break;
         case LOG_LEVEL_WARN:
-            fprintf(stream, "WARN: ");
+            heading = "WARN: ";
             break;
         case LOG_LEVEL_ERR:
             stream = stderr;
-            fprintf(stream, "ERR: ");
+            heading = "ERR: ";
             break;
     }
-
-    vfprintf(stream, fmt, args);
-    fprintf(stream, "\n");
+    char full_fmt[strlen(heading) + strlen(fmt) + 2];
+    sprintf(full_fmt, "%s%s\n", heading, fmt);
+    vfprintf(stream, full_fmt, args);
 }
 
 void plog(const unsigned int level, const char *fmt, ...) {


### PR DESCRIPTION
Hi, While I am using ag for my projects I see a strange behavior on ignore file and -t option, and started investing.
During that investigation I used `ag -D` and found that the debug output is not MT-safe(a log from a worker thread may be put in the middle of another worker log output), thus I saw the debug output like below,

```
DEBUG: DEBUG: DEBUG: DEBUG: DEBUG: DEBUG: DEBUG: No match in ./t/internal/ganesha/stamp/create.tDEBUG: No match in ./t/internal/ganesha/stamp/delete.tNo match in ./t/internal/ganesha/stamp/update.tNo match in ./t/internal/ganesha/stamp/fetch.tNo match in ./t/internal/ganesha/stampcategory/create.tNo match in ./t/internal/ganesha/stampcategory/delete.tNo match in ./t/internal/ganesha/stampcategory/fetch.t
Skipping ignore file ./t/restful/v2/.git/info/exclude: not readable
```
 So I made a quick patch to fix this problem.

Confirmed this worked on my OS X (10.9 and 10.10) and this passed crum test too.
Please review!

