### PR TITLE
Add support for .cjsx files under --coffee

### DIFF
--- a/src/lang.c
+++ b/src/lang.c
@@ -12,7 +12,7 @@ lang_spec_t langs[] = {
     { "cc", { "c", "h", "xs" } },
     { "cfmx", { "cfc", "cfm", "cfml" } },
     { "clojure", { "clj", "cljs", "cljc", "cljx" } },
-    { "coffee", { "coffee" } },
+    { "coffee", { "coffee", "cjsx" } },
     { "cpp", { "cpp", "cc", "C", "cxx", "m", "hpp", "hh", "h", "H", "hxx" } },
     { "csharp", { "cs" } },
     { "css", { "css" } },

--- a/tests/list_file_types.t
+++ b/tests/list_file_types.t
@@ -28,7 +28,7 @@ Language types are output:
         .clj  .cljs  .cljc  .cljx
   
     --coffee
-        .coffee
+        .coffee  .cjsx
   
     --cpp
         .cpp  .cc  .C  .cxx  .m  .hpp  .hh  .h  .H  .hxx


### PR DESCRIPTION
[Coffee-React](https://github.com/jsdf/coffee-react) allows CoffeeScript users to write JSX with more CS-like syntax. Since .jsx is supported under the --js flag, it seems reasonable that .cjsx should be supported under the --coffee flag.