### PR TITLE
Remove NOP option print-long-lines

### DIFF
--- a/ag.bashcomp.sh
+++ b/ag.bashcomp.sh
@@ -68,7 +68,6 @@ _ag() {
     --passthrough
     --passthru
     --path-to-agignore
-    --print-long-lines
     --print0
     --recurse
     --search-binary

--- a/doc/ag.1.md
+++ b/doc/ag.1.md
@@ -118,9 +118,6 @@ Recursively search for PATTERN in PATH. Like grep or ack, but faster.
     Use a pager such as less. Use `--nopager` to override. This option
     is also ignored if output is piped to another program.
 
-  * `--print-long-lines`:
-    Print matches on very long lines (> 2k characters by default).
-
   * `--passthrough`:
     When searching a stream, print all lines even if they don't match.
 

--- a/src/options.c
+++ b/src/options.c
@@ -65,7 +65,6 @@ Output Options:\n\
      --[no]numbers        Print line numbers. Default is to omit line numbers\n\
                           when searching streams\n\
   -o --only-matching      Prints only the matching part of the lines\n\
-     --print-long-lines   Print matches on very long lines (Default: >2k characters)\n\
      --passthrough        When searching a stream, print all lines even if they\n\
                           don't match\n\
      --silent             Suppress all log messages, including errors\n\


### PR DESCRIPTION
The options --print-long-lines do not actually do anything.
The silver searcher's default behavior is to print long lines.
While it would be really nice if by default it did not and this option
was required to turn that on , that has not been implemented. 
(see issue #189 )
Having this option is misleading to folks that are looking for a way
to have ag remove the long lines from the output.
