### PR TITLE
Added an option to truncate long lines with -W NUM

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -103,6 +103,7 @@ Search Options:\n\
                           (.gitignore, .hgignore, .svnignore; still obey .agignore)\n\
   -v --invert-match\n\
   -w --word-regexp        Only match whole words\n\
+  -W --width NUM          Truncate match lines after NUM characters\n\
   -z --search-zip         Search contents of compressed (e.g., gzip) files\n\
 \n");
     printf("File Types:\n\
@@ -141,6 +142,7 @@ void init_options(void) {
     opts.color_win_ansi = FALSE;
     opts.max_matches_per_file = 0;
     opts.max_search_depth = DEFAULT_MAX_SEARCH_DEPTH;
+    opts.width = 0;
     opts.path_sep = '\n';
     opts.print_break = TRUE;
     opts.print_path = PATH_PRINT_DEFAULT;
@@ -335,7 +337,7 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
     }
 
     int pcre_opts = 0;
-    while ((ch = getopt_long(argc, argv, "A:aB:C:cDG:g:FfHhiLlm:nop:QRrSsvVtuUwz0", longopts, &opt_index)) != -1) {
+    while ((ch = getopt_long(argc, argv, "A:aB:C:cDG:g:FfHhiLlm:nop:QRrSsvVtuUwW:z0", longopts, &opt_index)) != -1) {
         switch (ch) {
             case 'A':
                 if (optarg) {
@@ -463,6 +465,12 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
                 break;
             case 'w':
                 opts.word_regexp = 1;
+                break;
+            case 'W':
+                opts.width = strtol(optarg, &num_end, 10);
+                if (num_end == optarg || *num_end != '\0' || errno == ERANGE) {
+                    die("Invalid width\n");
+                }
                 break;
             case 'z':
                 opts.search_zip_files = 1;

--- a/src/options.c
+++ b/src/options.c
@@ -288,6 +288,7 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
         { "unrestricted", no_argument, NULL, 'u' },
         { "version", no_argument, &version, 1 },
         { "vimgrep", no_argument, &opts.vimgrep, 1 },
+        { "width", required_argument, NULL, 'W' },
         { "word-regexp", no_argument, NULL, 'w' },
         { "workers", required_argument, NULL, 0 },
     };

--- a/src/options.h
+++ b/src/options.h
@@ -82,6 +82,7 @@ typedef struct {
     int parallel;
     int use_thread_affinity;
     int vimgrep;
+    size_t width;
     int word_regexp;
     int workers;
 } cli_options;

--- a/src/print.c
+++ b/src/print.c
@@ -17,6 +17,8 @@ int first_file_match = 1;
 
 const char *color_reset = "\033[0m\033[K";
 
+const char *truncate_marker = " [...]";
+
 void print_path(const char *path, const char sep) {
     path = normalize_path(path);
 
@@ -45,7 +47,12 @@ void print_path_count(const char *path, const char sep, const size_t count) {
 }
 
 void print_line(const char *buf, size_t buf_pos, size_t prev_line_offset) {
-    fwrite(buf + prev_line_offset, 1, buf_pos - prev_line_offset + 1, out_fd);
+    size_t write_chars = buf_pos - prev_line_offset + 1;
+    if (opts.width > 0 && opts.width < write_chars) {
+        write_chars = opts.width;
+    }
+
+    fwrite(buf + prev_line_offset, 1, write_chars, out_fd);
 }
 
 void print_binary_file_matches(const char *path) {
@@ -177,6 +184,7 @@ void print_file_matches(const char *path, const char *buf, const size_t buf_len,
                         fprintf(out_fd, "%s", opts.color_match);
                     }
                     for (j = prev_line_offset; j <= i; j++) {
+                        /* close highlight of match term */
                         if (last_printed_match < matches_len && j == matches[last_printed_match].end) {
                             if (opts.color) {
                                 fprintf(out_fd, "%s", color_reset);
@@ -188,6 +196,19 @@ void print_file_matches(const char *path, const char *buf, const size_t buf_len,
                                 fputc('\n', out_fd);
                             }
                         }
+                        /* skip remaining characters if truncation width exceeded, needs to be done
+                         * before highlight opening */
+                        if (j < buf_len && opts.width > 0 && j - prev_line_offset >= opts.width) {
+                            if (j < i) {
+                                fputs(truncate_marker, out_fd);
+                            }
+                            fputc('\n', out_fd);
+
+                            /* prevent any more characters or highlights */
+                            j = i;
+                            last_printed_match = matches_len;
+                        }
+                        /* open highlight of match term */
                         if (last_printed_match < matches_len && j == matches[last_printed_match].start) {
                             if (opts.only_matching && printed_match) {
                                 if (opts.print_path == PATH_PRINT_EACH_LINE) {
@@ -207,7 +228,9 @@ void print_file_matches(const char *path, const char *buf, const size_t buf_len,
                         if (j < buf_len) {
                             /* if only_matching is set, print only matches and newlines */
                             if (!opts.only_matching || printing_a_match) {
-                                fputc(buf[j], out_fd);
+                                if (opts.width == 0 || j - prev_line_offset < opts.width) {
+                                    fputc(buf[j], out_fd);
+                                }
                             }
                         }
                     }

--- a/tests/line_width.t
+++ b/tests/line_width.t
@@ -8,10 +8,20 @@ Truncate to width inside input line length:
   $ ag -W 20 1 < ./blah.txt
   blah.txt:1:12345678901234567890 [...]
 
+Truncate to width inside input line length, long-form:
+
+  $ ag --width 20 1 < ./blah.txt
+  blah.txt:1:12345678901234567890 [...]
+
 Truncate to width outside input line length:
 
   $ ag -W 60 1 < ./blah.txt
   blah.txt:1:12345678901234567890123456789012345678901234567890
+
+Truncate to width one less than input line length:
+
+  $ ag -W 49 1 < ./blah.txt
+  blah.txt:1:1234567890123456789012345678901234567890123456789 [...]
 
 Truncate to width exactly input line length:
 

--- a/tests/line_width.t
+++ b/tests/line_width.t
@@ -1,0 +1,20 @@
+Setup:
+
+  $ . $TESTDIR/setup.sh
+  $ echo "12345678901234567890123456789012345678901234567890" >> ./blah.txt
+
+Truncate to width inside input line length:
+
+  $ ag -W 20 1 < ./blah.txt
+  blah.txt:1:12345678901234567890 [...]
+
+Truncate to width outside input line length:
+
+  $ ag -W 60 1 < ./blah.txt
+  blah.txt:1:12345678901234567890123456789012345678901234567890
+
+Truncate to width exactly input line length:
+
+  $ ag -W 50 1 < ./blah.txt
+  blah.txt:1:12345678901234567890123456789012345678901234567890
+


### PR DESCRIPTION
I'm doing a lot of agging over a codebase with single line packed JS files scattered through it. I do want to know if there were matches, and on which line, but some of those files with one massive line can play havoc with the output when I'm trying to navigate a couple of dozen matches. Things can get a bit tricky when most of the matches are nice 100 column lines, then one 15,000 column monster comes along! Lines that long don't exactly play nice with a terminal or a text editor (it crashes the current master of neovim using the Ag.vim plugin).

I've solved my problem by adding a `-W NUM` / `--width NUM` option which truncates matched lines to the length specified. -W was chosen as it didn't seem to clash with anything else, including in `grep` and `ack`. I thought I might clean it up, write some tests and see if you might find it a useful or worthy addition to ag. `make test` runs without errors, but I think my own test case might be missing a few scenarios, like the truncation when `print_path` is set to `PATH_PRINT_EACH_LINE`.

There are a couple of warts with my implementation - the newline handling on line 205 of print.c is problematic when you redirect the output to a file. It seems to clash with the "file without newline" detection. I didn't want to start digging too deeply into the newline handling logic without first starting a discussion. I figured it's also one of those things where someone who knew the codebase more intimately might be able to say "oh yeah, that's easy: you're doing that bit wrong, just move it over here and pow!", or even just "no, this whole thing isn't a good idea, you can already do that using *x*" ;)