### PR TITLE
Fix a warning assignment discarding qualifiers

### DIFF
--- a/src/decompress.c
+++ b/src/decompress.c
@@ -48,8 +48,7 @@ static void *decompress_zlib(const void *buf, const int buf_len,
     }
 
     stream.avail_in = buf_len;
-    /* Explicitly cast away the const-ness of buf */
-    stream.next_in = (Bytef *)buf;
+    stream.next_in = (z_const Bytef *)buf;
 
     pagesize = getpagesize();
     result_size = ((buf_len + pagesize - 1) & ~(pagesize - 1));


### PR DESCRIPTION
Minor change to fix #662.

After merged #659, this issue #662 will be occurred as below warning message.
```
src/decompress.c: In function ‘decompress_zlib’:
src/decompress.c:52:22: warning: cast discards ‘__attribute__((const))’ qualifier from pointer target type [-Wcast-qual]
     stream.next_in = (Bytef *)buf;
```

I can reproduce on Ubuntu 14.04 x64.

And for more details about this PR.
According to http://www.zlib.net/manual.html, this should be cast as z_const Bytef * instead of const Bytef * or Bytef *

A separate note, we can close this #676 pull request.