### PR TITLE
Add filetypes for the bro framework

### DIFF
--- a/src/lang.c
+++ b/src/lang.c
@@ -9,6 +9,7 @@ lang_spec_t langs[] = {
     { "ada", { "ada", "adb", "ads" } },
     { "asm", { "asm", "s" } },
     { "batch", { "bat", "cmd" } },
+    { "bro", { "bro", "bif" } },
     { "cc", { "c", "h", "xs" } },
     { "cfmx", { "cfc", "cfm", "cfml" } },
     { "clojure", { "clj", "cljs", "cljc", "cljx" } },

--- a/tests/list_file_types.t
+++ b/tests/list_file_types.t
@@ -18,6 +18,9 @@ Language types are output:
     --batch
         .bat  .cmd
   
+    --bro
+        .bro  .bif
+  
     --cc
         .c  .h  .xs
   


### PR DESCRIPTION
Bro (www.bro.org) is a network security monitor with its own scripting language (.bro) and the ability to provide functionalities from C/C++ (.bif) mixed with the own language.

I only added these two filetypes to the lang.c and adjusted the related test.