### PR TITLE
Combining -c and --nofilename prints just the number of matches. Similar to ack's -clh

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -191,7 +191,9 @@ int main(int argc, char **argv) {
         printf("%ld matches\n%ld files contained matches\n%ld files searched\n%ld bytes searched\n%f seconds\n",
                stats.total_matches, stats.total_file_matches, stats.total_files, stats.total_bytes, time_diff);
         pthread_mutex_destroy(&stats_mtx);
-    }
+	} else if (opts.print_count && opts.print_filename_only && opts.print_path == PATH_PRINT_NOTHING) {
+		printf("%ld matches\n", stats.total_matches);
+	}
 
     if (opts.pager) {
         pclose(out_fd);

--- a/src/main.c
+++ b/src/main.c
@@ -191,7 +191,7 @@ int main(int argc, char **argv) {
         printf("%ld matches\n%ld files contained matches\n%ld files searched\n%ld bytes searched\n%f seconds\n",
                stats.total_matches, stats.total_file_matches, stats.total_files, stats.total_bytes, time_diff);
         pthread_mutex_destroy(&stats_mtx);
-    } else if (opts.print_count && opts.print_filename_only && opts.print_path == PATH_PRINT_NOTHING && !opts.search_stream && errno != ENOTDIR) {
+    } else if (opts.print_total_count_only) {
         printf("%ld matches\n", stats.total_matches);
     }
 

--- a/src/main.c
+++ b/src/main.c
@@ -191,7 +191,7 @@ int main(int argc, char **argv) {
         printf("%ld matches\n%ld files contained matches\n%ld files searched\n%ld bytes searched\n%f seconds\n",
                stats.total_matches, stats.total_file_matches, stats.total_files, stats.total_bytes, time_diff);
         pthread_mutex_destroy(&stats_mtx);
-	} else if (opts.print_count && opts.print_filename_only && opts.print_path == PATH_PRINT_NOTHING) {
+	} else if (opts.print_count && opts.print_filename_only && opts.print_path == PATH_PRINT_NOTHING && !opts.search_stream && errno != ENOTDIR) {
 		printf("%ld matches\n", stats.total_matches);
 	}
 

--- a/src/main.c
+++ b/src/main.c
@@ -191,9 +191,9 @@ int main(int argc, char **argv) {
         printf("%ld matches\n%ld files contained matches\n%ld files searched\n%ld bytes searched\n%f seconds\n",
                stats.total_matches, stats.total_file_matches, stats.total_files, stats.total_bytes, time_diff);
         pthread_mutex_destroy(&stats_mtx);
-	} else if (opts.print_count && opts.print_filename_only && opts.print_path == PATH_PRINT_NOTHING && !opts.search_stream && errno != ENOTDIR) {
-		printf("%ld matches\n", stats.total_matches);
-	}
+    } else if (opts.print_count && opts.print_filename_only && opts.print_path == PATH_PRINT_NOTHING && !opts.search_stream && errno != ENOTDIR) {
+        printf("%ld matches\n", stats.total_matches);
+    }
 
     if (opts.pager) {
         pclose(out_fd);

--- a/src/options.c
+++ b/src/options.c
@@ -635,7 +635,7 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
         opts.after = opts.context;
     }
 
-    if (opts.print_count && opts.print_path == PATH_PRINT_NOTHING) {
+    if (opts.print_count && opts.print_filename_only && opts.print_path == PATH_PRINT_NOTHING) {
         opts.print_total_count_only = 1;
     }
 

--- a/src/options.c
+++ b/src/options.c
@@ -635,6 +635,10 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
         opts.after = opts.context;
     }
 
+    if (opts.print_count && opts.print_path == PATH_PRINT_NOTHING) {
+        opts.print_total_count_only = 1;
+    }
+
     if (opts.ackmate) {
         opts.color = 0;
         opts.print_break = 1;

--- a/src/options.h
+++ b/src/options.h
@@ -61,6 +61,7 @@ typedef struct {
     int print_path;
     int print_line_numbers;
     int print_long_lines; /* TODO: support this in print.c */
+    int print_total_count_only;
     int passthrough;
     pcre *re;
     pcre_extra *re_extra;

--- a/src/search.c
+++ b/src/search.c
@@ -131,7 +131,7 @@ void search_buf(const char *buf, const size_t buf_len,
             stats.total_file_matches++;
         }
         pthread_mutex_unlock(&stats_mtx);
-    } else if (opts.print_count && opts.print_filename_only && opts.print_path == PATH_PRINT_NOTHING){
+    } else if (opts.print_count && opts.print_filename_only && opts.print_path == PATH_PRINT_NOTHING && !opts.search_stream && errno != ENOTDIR){
         pthread_mutex_lock(&stats_mtx);
 			stats.total_matches += matches_len;
         pthread_mutex_unlock(&stats_mtx);
@@ -152,7 +152,7 @@ void search_buf(const char *buf, const size_t buf_len,
              * checked. */
             if (!opts.invert_match || matches_len < 2) {
                 if (opts.print_count) {
-					if (opts.print_path != PATH_PRINT_NOTHING){
+					if (opts.print_path != PATH_PRINT_NOTHING || opts.search_stream || errno == ENOTDIR){
 						print_path_count(dir_full_path, opts.path_sep, (size_t)matches_len);
 					}
 				} else {

--- a/src/search.c
+++ b/src/search.c
@@ -142,7 +142,7 @@ void search_buf(const char *buf, const size_t buf_len,
             binary = is_binary((const void *)buf, buf_len);
         }
         pthread_mutex_lock(&print_mtx);
-        if (opts.print_filename_only && !opts.print_total_count_only) {
+        if (opts.print_filename_only) {
             /* If the --files-without-matches or -L option is passed we should
              * not print a matching line. This option currently sets
              * opts.print_filename_only and opts.invert_match. Unfortunately
@@ -152,7 +152,9 @@ void search_buf(const char *buf, const size_t buf_len,
 			 * checked. */
             if (!opts.invert_match || matches_len < 2) {
                 if (opts.print_count) {
-                    print_path_count(dir_full_path, opts.path_sep, (size_t)matches_len);
+                    if (!opts.print_total_count_only) {
+                        print_path_count(dir_full_path, opts.path_sep, (size_t)matches_len);
+                    }
                 } else {
                     print_path(dir_full_path, opts.path_sep);
                 }

--- a/src/search.c
+++ b/src/search.c
@@ -131,7 +131,7 @@ void search_buf(const char *buf, const size_t buf_len,
             stats.total_file_matches++;
         }
         pthread_mutex_unlock(&stats_mtx);
-    } else if (opts.print_count && opts.print_filename_only && opts.print_path == PATH_PRINT_NOTHING && !opts.search_stream && errno != ENOTDIR) {
+    } else if (opts.print_total_count_only) {
         pthread_mutex_lock(&stats_mtx);
         stats.total_matches += matches_len;
         pthread_mutex_unlock(&stats_mtx);
@@ -142,19 +142,17 @@ void search_buf(const char *buf, const size_t buf_len,
             binary = is_binary((const void *)buf, buf_len);
         }
         pthread_mutex_lock(&print_mtx);
-        if (opts.print_filename_only) {
+        if (opts.print_filename_only && !opts.print_total_count_only) {
             /* If the --files-without-matches or -L option is passed we should
              * not print a matching line. This option currently sets
              * opts.print_filename_only and opts.invert_match. Unfortunately
              * setting the latter has the side effect of making matches.len = 1
              * on a file-without-matches which is not desired behaviour. See
              * GitHub issue 206 for the consequences if this behaviour is not
-             * checked. */
+			 * checked. */
             if (!opts.invert_match || matches_len < 2) {
                 if (opts.print_count) {
-                    if (opts.print_path != PATH_PRINT_NOTHING || opts.search_stream || errno == ENOTDIR) {
-                        print_path_count(dir_full_path, opts.path_sep, (size_t)matches_len);
-                    }
+                    print_path_count(dir_full_path, opts.path_sep, (size_t)matches_len);
                 } else {
                     print_path(dir_full_path, opts.path_sep);
                 }

--- a/src/search.c
+++ b/src/search.c
@@ -131,7 +131,11 @@ void search_buf(const char *buf, const size_t buf_len,
             stats.total_file_matches++;
         }
         pthread_mutex_unlock(&stats_mtx);
-    }
+    } else if (opts.print_count && opts.print_filename_only && opts.print_path == PATH_PRINT_NOTHING){
+        pthread_mutex_lock(&stats_mtx);
+			stats.total_matches += matches_len;
+        pthread_mutex_unlock(&stats_mtx);
+	}
 
     if (matches_len > 0) {
         if (binary == -1 && !opts.print_filename_only) {
@@ -148,9 +152,11 @@ void search_buf(const char *buf, const size_t buf_len,
              * checked. */
             if (!opts.invert_match || matches_len < 2) {
                 if (opts.print_count) {
-                    print_path_count(dir_full_path, opts.path_sep, (size_t)matches_len);
-                } else {
-                    print_path(dir_full_path, opts.path_sep);
+					if (opts.print_path != PATH_PRINT_NOTHING){
+						print_path_count(dir_full_path, opts.path_sep, (size_t)matches_len);
+					}
+				} else {
+					print_path(dir_full_path, opts.path_sep);
                 }
             }
         } else if (binary) {

--- a/src/search.c
+++ b/src/search.c
@@ -131,11 +131,11 @@ void search_buf(const char *buf, const size_t buf_len,
             stats.total_file_matches++;
         }
         pthread_mutex_unlock(&stats_mtx);
-    } else if (opts.print_count && opts.print_filename_only && opts.print_path == PATH_PRINT_NOTHING && !opts.search_stream && errno != ENOTDIR){
+    } else if (opts.print_count && opts.print_filename_only && opts.print_path == PATH_PRINT_NOTHING && !opts.search_stream && errno != ENOTDIR) {
         pthread_mutex_lock(&stats_mtx);
-			stats.total_matches += matches_len;
+        stats.total_matches += matches_len;
         pthread_mutex_unlock(&stats_mtx);
-	}
+    }
 
     if (matches_len > 0) {
         if (binary == -1 && !opts.print_filename_only) {
@@ -152,11 +152,11 @@ void search_buf(const char *buf, const size_t buf_len,
              * checked. */
             if (!opts.invert_match || matches_len < 2) {
                 if (opts.print_count) {
-					if (opts.print_path != PATH_PRINT_NOTHING || opts.search_stream || errno == ENOTDIR){
-						print_path_count(dir_full_path, opts.path_sep, (size_t)matches_len);
-					}
-				} else {
-					print_path(dir_full_path, opts.path_sep);
+                    if (opts.print_path != PATH_PRINT_NOTHING || opts.search_stream || errno == ENOTDIR) {
+                        print_path_count(dir_full_path, opts.path_sep, (size_t)matches_len);
+                    }
+                } else {
+                    print_path(dir_full_path, opts.path_sep);
                 }
             }
         } else if (binary) {


### PR DESCRIPTION
Addresses issue #699. 

With this, combining `-c` and `--nofilename` prints just the total number of matches. 

Note: if `--nofilename` is followed at any point by a header option while doing this, then the file names will still be printed, which is about the same as what would happen when you combine those two in that order without `-c`, but it might *feel* like a bug if you're thinking you'll only get the total number of matches.