### PR TITLE
Add --stats-only option

### DIFF
--- a/doc/ag.1
+++ b/doc/ag.1
@@ -179,6 +179,10 @@ Suppress all log messages, including errors\.
 Print stats (files scanned, time taken, etc)\.
 .
 .TP
+\fB\-\-stats-only\fR
+Print stats (files scanned, time taken, etc) and nothing else\.
+.
+.TP
 \fB\-t \-\-all\-text\fR
 Search all text files\. This doesn\'t include hidden files\.
 .

--- a/doc/ag.1.md
+++ b/doc/ag.1.md
@@ -143,6 +143,9 @@ Recursively search for PATTERN in PATH. Like grep or ack, but faster.
   * `--stats`:
     Print stats (files scanned, time taken, etc).
 
+  * `--stats-only`:
+    Print stats (files scanned, time taken, etc) and nothing else.
+
   * `-t --all-text`:
     Search all text files. This doesn't include hidden files.
 

--- a/src/options.c
+++ b/src/options.c
@@ -70,6 +70,8 @@ Output Options:\n\
                           don't match\n\
      --silent             Suppress all log messages, including errors\n\
      --stats              Print stats (files scanned, time taken, etc.)\n\
+     --stats-only         Print stats and nothing else.\n\
+                          (Same as --count when searching a single file)\n\
      --vimgrep            Print results like vim's :vimgrep /pattern/g would\n\
                           (it reports every match on the line)\n\
   -0 --null --print0      Separate filenames with null (for 'xargs -0')\n\
@@ -283,6 +285,7 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
         { "skip-vcs-ignores", no_argument, NULL, 'U' },
         { "smart-case", no_argument, NULL, 'S' },
         { "stats", no_argument, &opts.stats, 1 },
+		{ "stats-only", no_argument, NULL, 0 },
         { "unrestricted", no_argument, NULL, 'u' },
         { "version", no_argument, &version, 1 },
         { "vimgrep", no_argument, &opts.vimgrep, 1 },
@@ -516,7 +519,12 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
                 } else if (strcmp(longopts[opt_index].name, "silent") == 0) {
                     set_log_level(LOG_LEVEL_NONE);
                     break;
-                }
+				} else if (strcmp(longopts[opt_index].name, "stats-only") == 0){
+					opts.print_filename_only = 1;
+					opts.print_path = PATH_PRINT_NOTHING;
+					opts.stats = 1;
+					break;
+				}
 
                 /* Continue to usage if we don't recognize the option */
                 if (longopts[opt_index].flag != 0) {

--- a/src/options.c
+++ b/src/options.c
@@ -285,7 +285,7 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
         { "skip-vcs-ignores", no_argument, NULL, 'U' },
         { "smart-case", no_argument, NULL, 'S' },
         { "stats", no_argument, &opts.stats, 1 },
-		{ "stats-only", no_argument, NULL, 0 },
+        { "stats-only", no_argument, NULL, 0 },
         { "unrestricted", no_argument, NULL, 'u' },
         { "version", no_argument, &version, 1 },
         { "vimgrep", no_argument, &opts.vimgrep, 1 },
@@ -519,12 +519,12 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
                 } else if (strcmp(longopts[opt_index].name, "silent") == 0) {
                     set_log_level(LOG_LEVEL_NONE);
                     break;
-				} else if (strcmp(longopts[opt_index].name, "stats-only") == 0){
-					opts.print_filename_only = 1;
-					opts.print_path = PATH_PRINT_NOTHING;
-					opts.stats = 1;
-					break;
-				}
+                } else if (strcmp(longopts[opt_index].name, "stats-only") == 0) {
+                    opts.print_filename_only = 1;
+                    opts.print_path = PATH_PRINT_NOTHING;
+                    opts.stats = 1;
+                    break;
+                }
 
                 /* Continue to usage if we don't recognize the option */
                 if (longopts[opt_index].flag != 0) {


### PR DESCRIPTION
Allows you to print just the stats and nothing else. Good way to check things like total matches from a script, or manually without flooding the screen.