### PR TITLE
Add faster substring search

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -109,6 +109,7 @@ int main(int argc, char **argv) {
         generate_alpha_skip(opts.query, opts.query_len, alpha_skip_lookup, opts.casing == CASE_SENSITIVE);
         find_skip_lookup = NULL;
         generate_find_skip(opts.query, opts.query_len, &find_skip_lookup, opts.casing == CASE_SENSITIVE);
+        generate_hash(opts.query, opts.query_len, h_table, opts.casing == CASE_SENSITIVE);
         if (opts.word_regexp) {
             init_wordchar_table();
             opts.literal_starts_wordchar = is_wordchar(opts.query[0]);

--- a/src/search.c
+++ b/src/search.c
@@ -47,7 +47,17 @@ void search_buf(const char *buf, const size_t buf_len,
         strncmp_fp ag_strnstr_fp = get_strstr(opts.casing);
 
         while (buf_offset < buf_len) {
+/* hash_strnstr only for little-endian platforms that allow unaligned access */
+#if defined(__i386__) || defined(__x86_64__)
+            /* Decide whether to fall back on boyer-moore */
+            if ((size_t)opts.query_len < 2 * sizeof(W_t) - 1 || opts.query_len >= UCHAR_MAX)
+                match_ptr = ag_strnstr_fp(match_ptr, opts.query, buf_len - buf_offset, opts.query_len, alpha_skip_lookup, find_skip_lookup);
+            else
+                match_ptr = hash_strnstr(match_ptr, opts.query, buf_len - buf_offset, opts.query_len, h_table, opts.casing == CASE_SENSITIVE);
+#else
             match_ptr = ag_strnstr_fp(match_ptr, opts.query, buf_len - buf_offset, opts.query_len, alpha_skip_lookup, find_skip_lookup);
+#endif
+
             if (match_ptr == NULL) {
                 break;
             }

--- a/src/search.h
+++ b/src/search.h
@@ -32,6 +32,7 @@
 
 size_t alpha_skip_lookup[256];
 size_t *find_skip_lookup;
+offset_t h_table[H_SIZE] __attribute__((aligned(64)));
 
 struct work_queue_t {
     char *path;

--- a/src/util.h
+++ b/src/util.h
@@ -4,6 +4,7 @@
 #include <dirent.h>
 #include <pcre.h>
 #include <stdio.h>
+#include <stdint.h>
 #include <string.h>
 #include <stdio.h>
 #include <sys/time.h>
@@ -21,6 +22,8 @@ FILE *out_fd;
 #ifndef FALSE
 #define FALSE 0
 #endif
+
+#define H_SIZE (64 * 1024)
 
 void *ag_malloc(size_t size);
 void *ag_realloc(void *ptr, size_t size);
@@ -52,6 +55,14 @@ typedef enum {
 ag_stats stats;
 
 typedef const char *(*strncmp_fp)(const char *, const char *, const size_t, const size_t, const size_t[], const size_t *);
+typedef uint16_t W_t;
+typedef uint8_t offset_t;
+
+/* Union to translate between chars and words without violating strict aliasing */
+typedef union {
+    char as_chars[sizeof(W_t)];
+    W_t as_word;
+} word_t;
 
 void free_strings(char **strs, const size_t strs_len);
 
@@ -59,6 +70,7 @@ void generate_alpha_skip(const char *find, size_t f_len, size_t skip_lookup[], c
 int is_prefix(const char *s, const size_t s_len, const size_t pos, const int case_sensitive);
 size_t suffix_len(const char *s, const size_t s_len, const size_t pos, const int case_sensitive);
 void generate_find_skip(const char *find, const size_t f_len, size_t **skip_lookup, const int case_sensitive);
+void generate_hash(const char *find, const size_t f_len, offset_t *H, const int case_sensitive);
 
 /* max is already defined on spec-violating compilers such as MinGW */
 size_t ag_max(size_t a, size_t b);
@@ -67,6 +79,7 @@ const char *boyer_moore_strnstr(const char *s, const char *find, const size_t s_
                                 const size_t alpha_skip_lookup[], const size_t *find_skip_lookup);
 const char *boyer_moore_strncasestr(const char *s, const char *find, const size_t s_len, const size_t f_len,
                                     const size_t alpha_skip_lookup[], const size_t *find_skip_lookup);
+const char *hash_strnstr(const char *s, const char *find, const size_t s_len, const size_t f_len, offset_t *h_table, const int case_sensitive);
 
 strncmp_fp get_strstr(enum case_behavior opts);
 


### PR DESCRIPTION
This commit implements the fast substring search algorithm described by
Leonid Volnitsky.

The full algorithm is described at:
http://volnitsky.com/project/str_search/

Briefly, we insert each consecutive pair of characters in the needle
into a hash table. We then step through pairs of characters in the
haystack. If the pair is in the hash table (and probably also the needle)
we do a character-by-character comparison.

Performance is 30-40% faster than Boyer-Moore on 2GB of text:

> ./ag_hash --stats blahblahbla ~/Downloads/wiki/
> 0 matches
> 0 files contained matches
> 4 files searched
> 1956034523 bytes searched
> 0.800452 seconds
> 
> ./ag_master --stats blahblahbla ~/Downloads/wiki/
> 0 matches
> 0 files contained matches
> 4 files searched
> 1956034523 bytes searched
> 1.310972 seconds
