### PR TITLE
Add '-j/--max-matches NUM' option

### DIFF
--- a/doc/ag.1
+++ b/doc/ag.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "AG" "1" "February 2015" "" ""
+.TH "AG" "1" "August 2015" "" ""
 .
 .SH "NAME"
 \fBag\fR \- The Silver Searcher\. Like ack, but faster\.
@@ -113,6 +113,10 @@ Alias for \-\-ignore for compatibility with ack\.
 .TP
 \fB\-i \-\-ignore\-case\fR
 Match case\-insensitively\.
+.
+.TP
+\fB\-j \-\-max\-matches NUM\fR
+Stop after finding NUM matches\. Default is 0, which does not limit the number of matches\.
 .
 .TP
 \fB\-l \-\-files\-with\-matches\fR

--- a/doc/ag.1.md
+++ b/doc/ag.1.md
@@ -92,6 +92,10 @@ Recursively search for PATTERN in PATH. Like grep or ack, but faster.
   * `-i --ignore-case`:
     Match case-insensitively.
 
+  * `-j --max-matches NUM`:
+    Stop after finding NUM matches. Default is 0, which does not limit the
+    number of matches.
+
   * `-l --files-with-matches`:
     Only print the names of files containing matches, not the matching
     lines. An empty query will print all files that would be searched.

--- a/src/main.c
+++ b/src/main.c
@@ -49,7 +49,7 @@ int main(int argc, char **argv) {
         gettimeofday(&(stats.time_start), NULL);
     }
 
-    if(opts.max_matches){
+    if (opts.max_matches) {
         total_matches = 0;
     }
 
@@ -176,9 +176,9 @@ int main(int argc, char **argv) {
             search_dir(ig, base_paths[i], paths[i], 0, s.st_dev);
             cleanup_ignore(ig);
 
-            if (opts.max_matches){
+            if (opts.max_matches) {
                 pthread_mutex_lock(&match_limit_mtx);
-                if (total_matches >= opts.max_matches){
+                if (total_matches >= opts.max_matches) {
                     pthread_mutex_unlock(&match_limit_mtx);
                     break;
                 }

--- a/src/options.c
+++ b/src/options.c
@@ -416,10 +416,10 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
             case 'j':
                 temp_input = strtol(optarg, NULL, 10);
                 if (temp_input < 0) {
-                  log_debug("Invalid number of max matches %ld, defaulting to 0", temp_input);
-                  temp_input = 0;
+                    log_debug("Invalid number of max matches %ld, defaulting to 0", temp_input);
+                    temp_input = 0;
                 }
-                opts.max_matches = (unsigned long) temp_input;
+                opts.max_matches = (unsigned long)temp_input;
                 break;
             case 'L':
                 opts.invert_match = 1;

--- a/src/options.h
+++ b/src/options.h
@@ -83,6 +83,7 @@ typedef struct {
     int use_thread_affinity;
     int vimgrep;
     int word_regexp;
+    unsigned long max_matches;
     int workers;
 } cli_options;
 

--- a/src/search.c
+++ b/src/search.c
@@ -122,9 +122,9 @@ void search_buf(const char *buf, const size_t buf_len,
         matches_len = invert_matches(buf, buf_len, matches, matches_len);
     }
 
-    if (opts.max_matches){
+    if (opts.max_matches) {
         pthread_mutex_lock(&match_limit_mtx);
-        if (total_matches + matches_len > opts.max_matches){
+        if (total_matches + matches_len > opts.max_matches) {
             matches_len = opts.max_matches - total_matches;
         }
         total_matches += matches_len;
@@ -334,9 +334,9 @@ void *search_file_worker(void *i) {
         free(queue_item->path);
         free(queue_item);
 
-        if (opts.max_matches){
+        if (opts.max_matches) {
             pthread_mutex_lock(&match_limit_mtx);
-            if (total_matches >= opts.max_matches){
+            if (total_matches >= opts.max_matches) {
                 pthread_mutex_unlock(&match_limit_mtx);
                 pthread_exit(NULL);
             }
@@ -405,10 +405,9 @@ static int check_symloop_leave(dirkey_t *dirkey) {
  */
 void search_dir(ignores *ig, const char *base_path, const char *path, const int depth,
                 dev_t original_dev) {
-
-    if (opts.max_matches){
+    if (opts.max_matches) {
         pthread_mutex_lock(&match_limit_mtx);
-        if (total_matches >= opts.max_matches){
+        if (total_matches >= opts.max_matches) {
             pthread_mutex_unlock(&match_limit_mtx);
             return;
         }

--- a/src/search.c
+++ b/src/search.c
@@ -122,6 +122,15 @@ void search_buf(const char *buf, const size_t buf_len,
         matches_len = invert_matches(buf, buf_len, matches, matches_len);
     }
 
+    if (opts.max_matches){
+        pthread_mutex_lock(&match_limit_mtx);
+        if (total_matches + matches_len > opts.max_matches){
+            matches_len = opts.max_matches - total_matches;
+        }
+        total_matches += matches_len;
+        pthread_mutex_unlock(&match_limit_mtx);
+    }
+
     if (opts.stats) {
         pthread_mutex_lock(&stats_mtx);
         stats.total_bytes += buf_len;
@@ -324,6 +333,15 @@ void *search_file_worker(void *i) {
         search_file(queue_item->path);
         free(queue_item->path);
         free(queue_item);
+
+        if (opts.max_matches){
+            pthread_mutex_lock(&match_limit_mtx);
+            if (total_matches >= opts.max_matches){
+                pthread_mutex_unlock(&match_limit_mtx);
+                pthread_exit(NULL);
+            }
+            pthread_mutex_unlock(&match_limit_mtx);
+        }
     }
 }
 
@@ -387,6 +405,16 @@ static int check_symloop_leave(dirkey_t *dirkey) {
  */
 void search_dir(ignores *ig, const char *base_path, const char *path, const int depth,
                 dev_t original_dev) {
+
+    if (opts.max_matches){
+        pthread_mutex_lock(&match_limit_mtx);
+        if (total_matches >= opts.max_matches){
+            pthread_mutex_unlock(&match_limit_mtx);
+            return;
+        }
+        pthread_mutex_unlock(&match_limit_mtx);
+    }
+
     struct dirent **dir_list = NULL;
     struct dirent *dir = NULL;
     scandir_baton_t scandir_baton;

--- a/src/search.h
+++ b/src/search.h
@@ -46,6 +46,7 @@ pthread_cond_t files_ready;
 pthread_mutex_t print_mtx;
 pthread_mutex_t stats_mtx;
 pthread_mutex_t work_queue_mtx;
+pthread_mutex_t match_limit_mtx;
 
 
 /* For symlink loop detection */

--- a/src/util.h
+++ b/src/util.h
@@ -51,6 +51,8 @@ typedef enum {
 
 ag_stats stats;
 
+unsigned long total_matches;
+
 typedef const char *(*strncmp_fp)(const char *, const char *, const size_t, const size_t, const size_t[], const size_t *);
 
 void free_strings(char **strs, const size_t strs_len);

--- a/tests/max_matches.t
+++ b/tests/max_matches.t
@@ -1,0 +1,29 @@
+Setup:
+
+  $ . $TESTDIR/setup.sh
+  $ echo 'test' > ./blah.txt
+  $ echo 'test' >> ./blah.txt
+  $ echo 'lala' > ./blah2.txt
+  $ echo 'test' >> ./blah2.txt
+  $ echo 'lala' >> ./blah2.txt
+
+Limit to 1 match, one file:
+
+  $ ag -j 1 test blah.txt
+  1:test
+
+Limit to 1 match, multiple files:
+
+  $ ag -j 1 test blah.txt blah2.txt
+  blah.txt:1:test
+
+Limit matches to a number greater than total possible matches:
+
+  $ ag -j 100 test blah.txt
+  1:test
+  2:test
+
+Limit matches using long option:
+
+  $ ag --max-matches 1 test blah.txt
+  1:test


### PR DESCRIPTION
Allow the search to stop after NUM matches have been found.
Useful for large code bases where finding all matches of a pattern
may take too long or be unimportant.

Introduce counter for the number of matches. After NUM matches are
found stop adding files to work queue and stop worker threads.

When used with --stat the number of matches is reported to be
consistent with NUM despite there possibly being more matches
that were found.

Resolves issue #734.
