### PR TITLE
Add TOML filetype support

### DIFF
--- a/src/lang.c
+++ b/src/lang.c
@@ -82,6 +82,7 @@ lang_spec_t langs[] = {
     { "tcl", { "tcl", "itcl", "itk" } },
     { "tex", { "tex", "cls", "sty" } },
     { "tt", { "tt", "tt2", "ttml" } },
+    { "toml", { "toml" } },
     { "vala", { "vala", "vapi" } },
     { "vb", { "bas", "cls", "frm", "ctl", "vb", "resx" } },
     { "velocity", { "vm" } },

--- a/tests/list_file_types.t
+++ b/tests/list_file_types.t
@@ -236,7 +236,7 @@ Language types are output:
   
     --tt
         .tt  .tt2  .ttml
-
+  
     --toml
         .toml
   


### PR DESCRIPTION
TOML is a markup language used for the configuration of Rust's main build tool, [Cargo](https://crates.io). The spec is online [here](https://github.com/toml-lang/toml). This would allow Ag to search through TOML files via its regex file rules.