### PR TITLE
Fix list_file_types test

### DIFF
--- a/tests/list_file_types.t
+++ b/tests/list_file_types.t
@@ -236,6 +236,9 @@ Language types are output:
   
     --tt
         .tt  .tt2  .ttml
+
+    --toml
+        .toml
   
     --vala
         .vala  .vapi


### PR DESCRIPTION
My addition of the TOML regex in #760 broke the test that listed all of the supported languages. This should fix that.