### PR TITLE
Adds restructuredText (.rst) language type

### DIFF
--- a/src/lang.c
+++ b/src/lang.c
@@ -65,6 +65,7 @@ lang_spec_t langs[] = {
     { "python", { "py" } },
     { "racket", { "rkt", "ss", "scm" } },
     { "rake", { "Rakefiles" } },
+    { "restructuredtext", { "rst" } },
     { "rs", { "rs" } },
     { "r", { "R", "Rmd", "Rnw", "Rtex", "Rrst" } },
     { "ruby", { "rb", "rhtml", "rjs", "rxml", "erb", "rake", "spec" } },

--- a/tests/list_file_types.t
+++ b/tests/list_file_types.t
@@ -186,6 +186,9 @@ Language types are output:
     --rake
         .Rakefiles
   
+    --restructuredtext
+        .rst
+  
     --rs
         .rs
   


### PR DESCRIPTION
[restructuredText](https://en.wikipedia.org/wiki/ReStructuredText) is a lightweight markup format used widely for e.g.

 - Python documentation
 - Static site generators
 - Academic papers