### PR TITLE
Add .vtl and .vsl to Velocity file types

### DIFF
--- a/src/lang.c
+++ b/src/lang.c
@@ -86,7 +86,7 @@ lang_spec_t langs[] = {
     { "toml", { "toml" } },
     { "vala", { "vala", "vapi" } },
     { "vb", { "bas", "cls", "frm", "ctl", "vb", "resx" } },
-    { "velocity", { "vm" } },
+    { "velocity", { "vm", "vtl", "vsl" } },
     { "verilog", { "v", "vh", "sv" } },
     { "vhdl", { "vhd", "vhdl" } },
     { "vim", { "vim" } },

--- a/tests/list_file_types.t
+++ b/tests/list_file_types.t
@@ -250,7 +250,7 @@ Language types are output:
         .bas  .cls  .frm  .ctl  .vb  .resx
   
     --velocity
-        .vm
+        .vm  .vtl  .vsl
   
     --verilog
         .v  .vh  .sv


### PR DESCRIPTION
Apart from `.vm`, which already exists, [Velocity](https://velocity.apache.org/) uses `.vtl` and `.vsl` file types/extensions.

From velocity-user mailing list archives, [RE: What does vm stand for?](https://mail-archives.apache.org/mod_mbox/velocity-user/200904.mbox/<9127AA4A72BF0D40AFECC2BECB6FEB940184D36D@PSPCOREXCH02.SYNTELORG.COM>):

> Velocity used a file extension of "*.vm", standing for "Velocity Macro". Other extensions
are also being used for Velocity templates: ".vtl" and ".vsl" (Velocity Stylesheet).

These are now in ag.

> The declarative Velocity engine DVSL additionally uses either ".dvsl" or ".vslt" extensions
(analogous to ".xslt").

Haven't added these two at this time. Can be done later, if someone feels the need.