### PR TITLE
Fix --word-regexp not applying to alternates

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -120,7 +120,7 @@ int main(int argc, char **argv) {
         }
         if (opts.word_regexp) {
             char *word_regexp_query;
-            ag_asprintf(&word_regexp_query, "\\b%s\\b", opts.query);
+            ag_asprintf(&word_regexp_query, "\\b(?:%s)\\b", opts.query);
             free(opts.query);
             opts.query = word_regexp_query;
             opts.query_len = strlen(opts.query);

--- a/tests/word_regexp.t
+++ b/tests/word_regexp.t
@@ -1,0 +1,12 @@
+Setup:
+
+  $ . $TESTDIR/setup.sh
+  $ echo 'foo' > blah.txt
+  $ echo 'bar' >> blah.txt
+  $ echo 'foobar' >> blah.txt
+
+Word regexp:
+
+  $ ag -w 'foo|bar' ./
+  blah.txt:1:foo
+  blah.txt:2:bar


### PR DESCRIPTION
`ag -w 'foo|bar'` would match `foobar`.  Test included.