### PR TITLE
Add support for RDoc files

### DIFF
--- a/src/lang.c
+++ b/src/lang.c
@@ -68,6 +68,7 @@ lang_spec_t langs[] = {
     { "restructuredtext", { "rst" } },
     { "rs", { "rs" } },
     { "r", { "R", "Rmd", "Rnw", "Rtex", "Rrst" } },
+    { "rdoc", { "rdoc" } },
     { "ruby", { "rb", "rhtml", "rjs", "rxml", "erb", "rake", "spec" } },
     { "rust", { "rs" } },
     { "salt", { "sls" } },

--- a/tests/list_file_types.t
+++ b/tests/list_file_types.t
@@ -195,6 +195,9 @@ Language types are output:
     --r
         .R  .Rmd  .Rnw  .Rtex  .Rrst
   
+    --rdoc
+        .rdoc
+  
     --ruby
         .rb  .rhtml  .rjs  .rxml  .erb  .rake  .spec
   


### PR DESCRIPTION
Same reasons as PR #518, adding support for [RDoc](http://rdoc.rubyforge.org) files.

Tests are passing:

```
tests/adjacent_matches.t: passed
tests/bad_path.t: passed
tests/case_sensitivity.t: passed
tests/color.t: passed
tests/column.t: passed
tests/count.t: passed
tests/ds_store_ignore.t: passed
tests/empty_match.t: passed
tests/exitcodes.t: passed
tests/hidden_option.t: passed
tests/ignore_abs_path.t: passed
tests/ignore_absolute_search_path_with_glob.t: passed
tests/ignore_backups.t: passed
tests/ignore_examine_parent_ignorefiles.t: passed
tests/ignore_extensions.t: passed
tests/ignore_gitignore.t: passed
tests/ignore_pattern_in_subdirectory.t: passed
tests/ignore_subdir.t: passed
tests/invert_match.t: passed
tests/is_binary_pdf.t: passed
tests/list_file_types.t: passed
tests/max_count.t: passed
tests/multiline.t: passed
tests/one_device.t: skipped
tests/only_matching.t: passed
tests/option_g.t: passed
tests/option_smartcase.t: passed
tests/passthrough.t: passed
tests/print_end.t: passed
tests/search_stdin.t: passed
tests/vimgrep.t: passed
# Ran 31 tests, 1 skipped, 0 failed.
```