### PR TITLE
Added support for user-defined languages 

### DIFF
--- a/src/lang.c
+++ b/src/lang.c
@@ -4,7 +4,9 @@
 #include "lang.h"
 #include "util.h"
 
-lang_spec_t langs[] = {
+#define MAX_LANGS 1000
+
+lang_spec_t langs[MAX_LANGS] = {
     { "actionscript", { "as", "mxml" } },
     { "ada", { "ada", "adb", "ads" } },
     { "asm", { "asm", "s" } },
@@ -96,8 +98,124 @@ lang_spec_t langs[] = {
     { "yaml", { "yaml", "yml" } }
 };
 
+lang_spec_t* get_lang_slot()
+    {
+    lang_spec_t * first_free = langs;
+    for (;first_free < langs + MAX_LANGS && first_free->name; ++first_free);
+
+    return first_free;
+    }
+
+bool lang_add_ext (lang_spec_t *l, char const * ext)
+    {
+    const char ** pExt = l->extensions;
+    for (size_t i = 0; i < MAX_EXTENSIONS && *pExt; ++pExt, ++i);
+
+    if (!*pExt)
+        {
+        *pExt = strdup (ext);
+        return true;
+        }
+    else
+        {
+        return  false;
+        }
+    }
+
+lang_spec_t * lang_new (char const* name)
+    {
+    lang_spec_t * result = get_lang_slot ();
+    if (result < langs + MAX_LANGS)
+        {
+        result->name = strdup (name);
+        return result;
+        }
+
+    return 0;
+    }
+
+lang_spec_t * lang_find (char const* name)
+    {
+    for (lang_spec_t * result = langs; result < langs + MAX_LANGS; ++result)
+        if (!_stricmp (name, result->name))
+            return result;
+
+    return 0;
+    }
+
+lang_spec_t * lang_parse_spec (char const * spec)
+    {
+    lang_spec_t * result = 0;
+    if (char * _spec = strdup (spec))
+        {
+        if (const char * name = strtok (_spec, " "))
+            {
+            if (const char * op = strtok(NULL, " "))
+                {
+                switch (op[0])
+                    {
+                    case ':':
+                        result = lang_new (name);
+                        break;
+                    case '+':
+                        result = lang_find (name);
+                        break;
+                    }
+                }
+            }
+
+        if (result)
+            {
+            while (const char * ext = strtok (NULL, " ,"))
+                lang_add_ext (result, ext);
+            }
+
+        free (_spec);
+        }
+
+    return result;
+    }
+
+void lang_parse_file (const char * path)
+    {
+    if (FILE* f = fopen(path, "rt"))
+        {
+        char * line = 0;
+        size_t len = 0, read = 0;
+
+        while ((read = getline (&line, &len, f)) != -1)
+            {
+            if (char * line_contents = strtok (line, "\n"))
+                {
+                if (line_contents[0] != '#' && line_contents[0] != 0)
+                    lang_parse_spec (line_contents);
+                }
+            }
+
+        if (line) free (line);
+        fclose (f);
+        }
+    }
+
+void lang_parse_user_spec ()
+    {
+    char dot_ag_path[1024] = { 0 };
+#ifdef _WIN32
+    strncat (dot_ag_path, getenv ("USERPROFILE"), sizeof (dot_ag_path));
+#else
+    strncat (dot_ag_path, getenv ("HOME"), sizeof (dot_ag_path));
+#endif
+    strncat (dot_ag_path, "\\.aglang", sizeof (dot_ag_path));
+    if ( _access(dot_ag_path, 0) != -1)
+        lang_parse_file (dot_ag_path);
+    }
+
 size_t get_lang_count() {
-    return sizeof(langs) / sizeof(lang_spec_t);
+    return (get_lang_slot() - langs);
+}
+
+lang_spec_t const* get_langs(void) {
+    return langs;
 }
 
 char *make_lang_regex(char *ext_array, size_t num_exts) {

--- a/src/lang.h
+++ b/src/lang.h
@@ -9,7 +9,15 @@ typedef struct {
     const char *extensions[MAX_EXTENSIONS];
 } lang_spec_t;
 
-extern lang_spec_t langs[];
+/**
+ Parses additional lang_spec_t from a file
+ */
+void lang_parse_user_spec ();
+
+/**
+ Returns languages directory
+ */
+lang_spec_t const* get_langs(void);
 
 /**
  Return the language count.

--- a/src/main.c
+++ b/src/main.c
@@ -19,6 +19,7 @@
 #include "options.h"
 #include "search.h"
 #include "util.h"
+#include "lang.h"
 
 typedef struct {
     pthread_t thread;
@@ -42,6 +43,7 @@ int main(int argc, char **argv) {
     root_ignores = init_ignore(NULL, "", 0);
     out_fd = stdout;
 
+    lang_parse_user_spec ();
     parse_options(argc, argv, &base_paths, &paths);
     log_debug("PCRE Version: %s", pcre_version());
     if (opts.stats) {

--- a/src/options.c
+++ b/src/options.c
@@ -304,6 +304,7 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
     ext_index = (size_t *)ag_malloc(sizeof(size_t) * lang_count);
     memset(ext_index, 0, sizeof(size_t) * lang_count);
 
+    lang_spec_t const * langs = get_langs();
     for (i = 0; i < lang_count; i++) {
         option_t opt = { langs[i].name, no_argument, NULL, 0 };
         longopts[i + longopts_len] = opt;


### PR DESCRIPTION
Language definitions are read from ~/.aglang file on startup.
The format follows:
# Lines starting with a # symbol on position 0 are skiped (comments)
# next line will define a new language lan with etensions .lll and .lan
lan : .lll, .lan

# next line will add a custom extension .ccc to cpp language defintion
.cpp + .ccc