### PR TITLE
Support TypeScript with --ts (.ts, .tsx)

### DIFF
--- a/src/lang.c
+++ b/src/lang.c
@@ -85,6 +85,7 @@ lang_spec_t langs[] = {
     { "tex", { "tex", "cls", "sty" } },
     { "tt", { "tt", "tt2", "ttml" } },
     { "toml", { "toml" } },
+    { "ts", { "ts", "tsx" } },
     { "vala", { "vala", "vapi" } },
     { "vb", { "bas", "cls", "frm", "ctl", "vb", "resx" } },
     { "velocity", { "vm", "vtl", "vsl" } },

--- a/tests/list_file_types.t
+++ b/tests/list_file_types.t
@@ -246,6 +246,9 @@ Language types are output:
     --toml
         .toml
   
+    --ts
+        .ts  .tsx
+  
     --vala
         .vala  .vapi
   


### PR DESCRIPTION
Could also be --typescript but given JavaScript is in as --ts I thought I'd go with that.