### PR TITLE
Better ignore matching

### DIFF
--- a/src/ignore.c
+++ b/src/ignore.c
@@ -38,10 +38,10 @@ const char *ignore_pattern_files[] = {
 };
 
 int is_empty(ignores *ig) {
-    return (ig->extensions_len + ig->names_len + ig->slash_names_len + ig->globs_len + ig->slash_globs_len == 0);
+    return (ig->extensions_len + ig->names_len + ig->slash_names_len + ig->partial_names_len + ig->partial_slash_names_len + ig->globs_len + ig->slash_globs_len + ig->partial_globs_len + ig->partial_slash_globs_len == 0);
 };
 
-ignores *init_ignore(ignores *parent, const char *dirname, const size_t dirname_len) {
+ignores *init_ignore(ignores *parent, const char *dirname, const size_t dirname_len, struct ag_dirent *partials) {
     ignores *ig = ag_malloc(sizeof(ignores));
 
     ig->extensions = NULL;
@@ -64,6 +64,18 @@ ignores *init_ignore(ignores *parent, const char *dirname, const size_t dirname_
 
     ig->dirname = dirname;
     ig->dirname_len = dirname_len;
+
+    if (partials == NULL) {
+        ig->partial_names = NULL;
+        ig->partial_names_len = 0;
+        ig->partial_globs = NULL;
+        ig->partial_globs_len = 0;
+    } else {
+        ig->partial_names = partials->partial_name_matches;
+        ig->partial_names_len = partials->partial_name_matches_len;
+        ig->partial_globs = partials->partial_glob_matches;
+        ig->partial_globs_len = partials->partial_glob_matches_len;
+    }
 
     if (parent && is_empty(parent) && parent->parent) {
         ig->parent = parent->parent;
@@ -101,7 +113,6 @@ void cleanup_ignore(ignores *ig) {
 }
 
 void add_ignore_pattern(ignores *ig, const char *pattern) {
-    int i;
     int pattern_len;
 
     /* Strip off the leading dot so that matches are more likely. */
@@ -149,20 +160,7 @@ void add_ignore_pattern(ignores *ig, const char *pattern) {
         }
     }
 
-    ++*patterns_len;
-
-    char **patterns;
-
-    /* a balanced binary tree is best for performance, but I'm lazy */
-    *patterns_p = patterns = ag_realloc(*patterns_p, (*patterns_len) * sizeof(char *));
-    /* TODO: de-dupe these patterns */
-    for (i = *patterns_len - 1; i > 0; i--) {
-        if (strcmp(pattern, patterns[i - 1]) > 0) {
-            break;
-        }
-        patterns[i] = patterns[i - 1];
-    }
-    patterns[i] = ag_strndup(pattern, pattern_len);
+    ag_insert_str_sorted(patterns_p, patterns_len, pattern, pattern_len);
     log_debug("added ignore pattern %s to %s", pattern,
               ig == root_ignores ? "root ignores" : ig->abs_path);
 }
@@ -274,7 +272,7 @@ static int ackmate_dir_match(const char *dir_name) {
 }
 
 /* This is the hottest code in Ag. 10-15% of all execution time is spent here */
-static int path_ignore_search(const ignores *ig, struct ignore_iters *iters, int search_slashes, const char *path, const char *filename) {
+static int path_ignore_search(const ignores *ig, const char *path, const char *filename, struct ignore_iters *iters, int search_slashes, struct ag_dirent *ag_dir) {
     char *temp;
     size_t i;
     int match_pos;
@@ -285,7 +283,7 @@ static int path_ignore_search(const ignores *ig, struct ignore_iters *iters, int
         return 1;
     }
 
-    ag_asprintf(&temp, "%s/%s", path[0] == '.' ? path + 1 : path, filename);
+    ag_asprintf(&temp, "%s/%s", path[0] == '.' ? path + 2 : path, filename);
 
     if (strncmp(temp, ig->abs_path, ig->abs_path_len) == 0) {
         char *slash_filename = temp + ig->abs_path_len;
@@ -294,61 +292,97 @@ static int path_ignore_search(const ignores *ig, struct ignore_iters *iters, int
         }
 
         for (; iters->names_i < ig->names_len; iters->names_i++) {
-            int cmp = strcmp(slash_filename, ig->names[iters->names_i]);
+            int cmp = cmp_leading_dir(slash_filename, ig->names[iters->names_i]);
             if (cmp == 0) {
                 log_debug("file %s ignored because name matches static pattern %s", temp, ig->names[iters->names_i]);
                 free(temp);
                 return 1;
+            } else if (cmp == 2) {
+                const char *subdir = ig->names[iters->names_i];
+                size_t subdir_len = ag_subdir(&subdir);
+                log_debug("file %s's subdirectories may match static pattern %s; adding subdir %s to child's ignores", temp, ig->names[iters->names_i], subdir);
+                ag_insert_str_sorted(&ag_dir->partial_name_matches, &ag_dir->partial_name_matches_len, subdir, subdir_len);
+            } else {
+                log_debug("file %s doesn't match static pattern %s at index %d", temp, ig->names[iters->names_i], iters->names_i);
             }
-            log_debug("file %s doesn't match static pattern %s at index %d", temp, ig->names[iters->names_i], iters->names_i);
             if (cmp < 0) {
                 break;
             }
         }
 
-        for (; iters->slash_names_i < ig->slash_names_len; iters->slash_names_i++) {
-            int cmp = strcmp(slash_filename, ig->slash_names[iters->slash_names_i]);
-            if (cmp == 0) {
-                log_debug("file %s ignored because name matches slash static pattern %s", temp, ig->slash_names[iters->slash_names_i]);
-                free(temp);
-                return 1;
-            }
-            log_debug("file %s doesn't match slash static pattern %s at index %d", temp, ig->slash_names[iters->slash_names_i], iters->slash_names_i);
-            if (cmp < 0) {
-                break;
-            }
-        }
-
-        for (i = 0; i < ig->names_len; i++) {
-            char *pos = strstr(slash_filename, ig->names[i]);
-            if (pos == slash_filename || (pos && *(pos - 1) == '/')) {
-                pos += strlen(ig->names[i]);
-                if (*pos == '\0' || *pos == '/') {
-                    log_debug("file %s ignored because path somewhere matches name %s", slash_filename, ig->names[i]);
+        if (search_slashes) {
+            for (; iters->slash_names_i < ig->slash_names_len; iters->slash_names_i++) {
+                int cmp = cmp_leading_dir(slash_filename, ig->slash_names[iters->slash_names_i]);
+                if (cmp == 0) {
+                    log_debug("file %s ignored because name matches slash static pattern %s", temp, ig->slash_names[iters->slash_names_i]);
                     free(temp);
                     return 1;
+                } else if (cmp == 2) {
+                    const char *subdir = ig->slash_names[iters->slash_names_i];
+                    size_t subdir_len = ag_subdir(&subdir);
+                    log_debug("file %s's subdirectories may match slash static pattern %s; adding subdir %s to child's ignores", temp, ig->slash_names[iters->slash_names_i], subdir);
+                    ag_insert_str_sorted(&ag_dir->partial_name_matches, &ag_dir->partial_name_matches_len, subdir, subdir_len);
+                } else {
+                    log_debug("file %s doesn't match slash static pattern %s at index %d", temp, ig->slash_names[iters->slash_names_i], iters->slash_names_i);
+                }
+                if (cmp < 0) {
+                    break;
                 }
             }
-            log_debug("pattern %s doesn't match path %s", ig->names[i], slash_filename);
-        }
 
-        for (i = 0; i < ig->slash_globs_len; i++) {
-            if (fnmatch(ig->slash_globs[i], slash_filename, fnmatch_flags) == 0) {
-                log_debug("file %s ignored because name matches slash regex pattern %s", slash_filename, ig->slash_globs[i]);
-                free(temp);
-                return 1;
+            for (; iters->partial_names_i < ig->partial_names_len; iters->partial_names_i++) {
+                int cmp = cmp_leading_dir(slash_filename, ig->partial_names[iters->partial_names_i]);
+                if (cmp == 0) {
+                    log_debug("file %s ignored because name matches partial static pattern %s", temp, ig->partial_names[iters->partial_names_i]);
+                    free(temp);
+                    return 1;
+                } else if (cmp == 2) {
+                    const char *subdir = ig->partial_names[iters->partial_names_i];
+                    size_t subdir_len = ag_subdir(&subdir);
+                    log_debug("file %s's subdirectories may match partial static pattern %s; adding subdir %s to child's ignores", temp, ig->partial_names[iters->partial_names_i], subdir);
+                    ag_insert_str_sorted(&ag_dir->partial_name_matches, &ag_dir->partial_name_matches_len, subdir, subdir_len);
+                } else {
+                    log_debug("file %s doesn't match partial static pattern %s at index %d", temp, ig->partial_names[iters->partial_names_i], iters->partial_names_i);
+                }
+                if (cmp < 0) {
+                    break;
+                }
             }
-            log_debug("pattern %s doesn't match slash file %s", ig->slash_globs[i], slash_filename);
+
+            for (; iters->slash_globs_i < ig->slash_globs_len; iters->slash_globs_i++) {
+                /* cmp_leading_dir_glob modifies slash_filename, but restores it before it returns,
+                 * so this should be safe. */
+                int cmp = cmp_leading_dir_glob((char *)slash_filename, ig->slash_globs[iters->slash_globs_i]);
+                if (cmp == 0) {
+                    log_debug("file %s ignored because name matches slash glob pattern %s", slash_filename, ig->slash_globs[iters->slash_globs_i]);
+                    free(temp);
+                    return 1;
+                } else if (cmp == 2) {
+                    const char *subdir = ig->slash_globs[iters->slash_globs_i];
+                    size_t subdir_len = ag_subdir(&subdir);
+                    log_debug("file %s's subdirectories may match slash glob pattern %s; adding subdir %s to child's ignores", temp, ig->slash_globs[iters->slash_globs_i], subdir);
+                    ag_insert_str_sorted(&ag_dir->partial_glob_matches, &ag_dir->partial_glob_matches_len, subdir, subdir_len);
+                } else {
+                    log_debug("pattern %s doesn't match slash file %s", ig->slash_globs[iters->slash_globs_i], slash_filename);
+                }
+            }
         }
     }
 
     for (i = 0; i < ig->globs_len; i++) {
-        if (fnmatch(ig->globs[i], filename, fnmatch_flags) == 0) {
-            log_debug("file %s ignored because name matches regex pattern %s", filename, ig->globs[i]);
+        int cmp = cmp_leading_dir_glob((char *)filename, ig->globs[i]);
+        if (cmp == 0) {
+            log_debug("file %s ignored because name matches glob pattern %s", filename, ig->globs[i]);
             free(temp);
             return 1;
+        } else if (cmp == 2) {
+            const char *subdir = ig->globs[i];
+            size_t subdir_len = ag_subdir(&subdir);
+            log_debug("file %s's subdirectories may match glob pattern %s; adding subdir %s to child's ignores", temp, ig->globs[iters->globs_i], subdir);
+            ag_insert_str_sorted(&ag_dir->partial_glob_matches, &ag_dir->partial_glob_matches_len, subdir, subdir_len);
+        } else {
+            log_debug("pattern %s doesn't match file %s", ig->globs[i], filename);
         }
-        log_debug("pattern %s doesn't match file %s", ig->globs[i], filename);
     }
 
     int rv = ackmate_dir_match(temp);
@@ -357,7 +391,8 @@ static int path_ignore_search(const ignores *ig, struct ignore_iters *iters, int
 }
 
 /* This function is REALLY HOT. It gets called for every file */
-int filename_filter(const char *path, const struct dirent *dir, void *baton_) {
+int filename_filter(const char *path, struct ag_dirent *ag_dir, void *baton_) {
+    const struct dirent *dir = ag_dir->dirent;
     const char *filename = dir->d_name;
 /* TODO: don't call strlen on filename every time we call filename_filter() */
 #ifdef HAVE_DIRENT_DNAMLEN
@@ -372,7 +407,6 @@ int filename_filter(const char *path, const struct dirent *dir, void *baton_) {
     const char *base_path = baton->base_path;
     const size_t base_path_len = baton->base_path_len;
     const char *path_start = path;
-    char *temp;
     int search_slashes = 1;
 
     if (!opts.search_hidden_files && filename[0] == '.') {
@@ -430,17 +464,8 @@ int filename_filter(const char *path, const struct dirent *dir, void *baton_) {
             }
         }
 
-        if (path_ignore_search(ig, iters, search_slashes, path_start, filename)) {
+        if (path_ignore_search(ig, path_start, filename, iters, search_slashes, ag_dir)) {
             return 0;
-        }
-
-        if (is_directory(path, dir) && filename[filename_len - 1] != '/') {
-            ag_asprintf(&temp, "%s/", filename);
-            int rv = path_ignore_search(ig, iters, search_slashes, path_start, temp);
-            free(temp);
-            if (rv) {
-                return 0;
-            }
         }
 
         ig = ig->parent;
@@ -452,7 +477,7 @@ int filename_filter(const char *path, const struct dirent *dir, void *baton_) {
             if (iters->parent == NULL) {
                 return -1;
             }
-            *iters->parent = (struct ignore_iters){0, 0, 0, 0, NULL};
+            *iters->parent = (struct ignore_iters){0, 0, 0, 0, 0, 0, NULL};
         }
         iters = iters->parent;
         search_slashes = 0;

--- a/src/ignore.c
+++ b/src/ignore.c
@@ -379,10 +379,28 @@ static int path_ignore_search(const ignores *ig, const char *path, const char *f
         } else if (cmp == 2) {
             const char *subdir = ig->globs[i];
             size_t subdir_len = ag_subdir(&subdir);
-            log_debug("file %s's subdirectories may match glob pattern %s; adding subdir %s to child's ignores", temp, ig->globs[iters->globs_i], subdir);
+            log_debug("file %s's subdirectories may match glob pattern %s; adding subdir %s to child's ignores", temp, ig->globs[i], subdir);
             ag_insert_str_sorted(&ag_dir->partial_glob_matches, &ag_dir->partial_glob_matches_len, subdir, subdir_len);
         } else {
             log_debug("pattern %s doesn't match file %s", ig->globs[i], filename);
+        }
+    }
+
+    if (search_slashes) {
+        for (i = 0; i < ig->partial_globs_len; i++) {
+            int cmp = cmp_leading_dir_glob((char *)filename, ig->partial_globs[i]);
+            if (cmp == 0) {
+                log_debug("file %s ignored because name matches glob pattern %s", filename, ig->partial_globs[i]);
+                free(temp);
+                return 1;
+            } else if (cmp == 2) {
+                const char *subdir = ig->partial_globs[i];
+                size_t subdir_len = ag_subdir(&subdir);
+                log_debug("file %s's subdirectories may match glob pattern %s; adding subdir %s to child's ignores", temp, ig->partial_globs[i], subdir);
+                ag_insert_str_sorted(&ag_dir->partial_glob_matches, &ag_dir->partial_glob_matches_len, subdir, subdir_len);
+            } else {
+                log_debug("pattern %s doesn't match file %s", ig->partial_globs[i], filename);
+            }
         }
     }
 

--- a/src/ignore.c
+++ b/src/ignore.c
@@ -77,11 +77,12 @@ ignores *init_ignore(ignores *parent, const char *dirname, const size_t dirname_
         ig->partial_globs_len = partials->partial_glob_matches_len;
     }
 
-    if (parent && is_empty(parent) && parent->parent) {
-        ig->parent = parent->parent;
-    } else {
-        ig->parent = parent;
+    if (parent) {
+        while (is_empty(parent) && parent->parent) {
+            parent = parent->parent;
+        }
     }
+    ig->parent = parent;
 
     if (parent && parent->abs_path_len > 0) {
         ag_asprintf(&(ig->abs_path), "%s/%s", parent->abs_path, dirname);

--- a/src/ignore.c
+++ b/src/ignore.c
@@ -397,7 +397,11 @@ static int path_ignore_search(const ignores *ig, const char *path, const char *f
                 const char *subdir = ig->partial_globs[i];
                 size_t subdir_len = ag_subdir(&subdir);
                 log_debug("file %s's subdirectories may match glob pattern %s; adding subdir %s to child's ignores", temp, ig->partial_globs[i], subdir);
-                ag_insert_str_sorted(&ag_dir->partial_glob_matches, &ag_dir->partial_glob_matches_len, subdir, subdir_len);
+                if (is_fnmatch(subdir)) {
+                    ag_insert_str_sorted(&ag_dir->partial_glob_matches, &ag_dir->partial_glob_matches_len, subdir, subdir_len);
+                } else {
+                    ag_insert_str_sorted(&ag_dir->partial_name_matches, &ag_dir->partial_name_matches_len, subdir, subdir_len);
+                }
             } else {
                 log_debug("pattern %s doesn't match file %s", ig->partial_globs[i], filename);
             }

--- a/src/ignore.h
+++ b/src/ignore.h
@@ -17,7 +17,12 @@ struct ignores {
     char **slash_names; /* Same but starts with a slash */
     size_t slash_names_len;
 
-    char **regexes; /* For patterns that need fnmatch */
+    char **globs; /* For patterns that need fnmatch */
+    size_t globs_len;
+    char **slash_globs;
+    size_t slash_globs_len;
+
+    char **regexes; /* For patterns that need PCRE, e.g. in .hgignore with syntax: regexp */
     size_t regexes_len;
     char **slash_regexes;
     size_t slash_regexes_len;

--- a/src/ignore.h
+++ b/src/ignore.h
@@ -17,10 +17,20 @@ struct ignores {
     char **slash_names; /* Same but starts with a slash */
     size_t slash_names_len;
 
+    char **partial_names; /* Partial matches from the parent directory. */
+    size_t partial_names_len;
+    char **partial_slash_names;
+    size_t partial_slash_names_len;
+
     char **globs; /* For patterns that need fnmatch */
     size_t globs_len;
     char **slash_globs;
     size_t slash_globs_len;
+
+    char **partial_globs;
+    size_t partial_globs_len;
+    char **partial_slash_globs;
+    size_t partial_slash_globs_len;
 
     char **regexes; /* For patterns that need PCRE, e.g. in .hgignore with syntax: regexp */
     size_t regexes_len;
@@ -35,13 +45,14 @@ struct ignores {
     struct ignores *parent;
 };
 typedef struct ignores ignores;
+struct ag_dirent;
 
 ignores *root_ignores;
 
 extern const char *evil_hardcoded_ignore_files[];
 extern const char *ignore_pattern_files[];
 
-ignores *init_ignore(ignores *parent, const char *dirname, const size_t dirname_len);
+ignores *init_ignore(ignores *parent, const char *dirname, const size_t dirname_len, struct ag_dirent *partials);
 void cleanup_ignore(ignores *ig);
 
 void add_ignore_pattern(ignores *ig, const char *pattern);
@@ -49,7 +60,7 @@ void add_ignore_pattern(ignores *ig, const char *pattern);
 void load_ignore_patterns(ignores *ig, const char *path);
 void load_svn_ignore_patterns(ignores *ig, const char *path);
 
-int filename_filter(const char *path, const struct dirent *dir, void *baton);
+int filename_filter(const char *path, struct ag_dirent *ag_dir, void *baton);
 
 int is_empty(ignores *ig);
 

--- a/src/main.c
+++ b/src/main.c
@@ -39,7 +39,7 @@ int main(int argc, char **argv) {
 
     work_queue = NULL;
     work_queue_tail = NULL;
-    root_ignores = init_ignore(NULL, "", 0);
+    root_ignores = init_ignore(NULL, "", 0, NULL);
     out_fd = stdout;
 
     parse_options(argc, argv, &base_paths, &paths);
@@ -159,7 +159,7 @@ int main(int argc, char **argv) {
         for (i = 0; paths[i] != NULL; i++) {
             log_debug("searching path %s for %s", paths[i], opts.query);
             symhash = NULL;
-            ignores *ig = init_ignore(root_ignores, "", 0);
+            ignores *ig = init_ignore(root_ignores, "", 0, NULL);
             struct stat s = {.st_dev = 0 };
 #ifndef _WIN32
             /* The device is ignored if opts.one_dev is false, so it's fine

--- a/src/scandir.c
+++ b/src/scandir.c
@@ -23,7 +23,10 @@ int ag_scandir(const char *dirname,
     }
 
     for (i = 0; i < scanned_names_len; i++) {
-        if ((*filter)(dirname, scanned_names[i], baton) == FALSE) {
+        int result = (*filter)(dirname, scanned_names[i], baton);
+        if (result == -1) {
+            goto fail;
+        } else if (result == 0) {
             free(scanned_names[i]);
             scanned_names[i] = NULL;
             continue;

--- a/src/scandir.c
+++ b/src/scandir.c
@@ -43,6 +43,7 @@ int ag_scandir(const char *dirname,
         results_len++;
     }
 
+    free(scanned_names);
     *namelist = results;
     return results_len;
 
@@ -62,5 +63,6 @@ fail:
             free (scanned_names[i]);
         }
     }
+    free(scanned_names);
     return -1;
 }

--- a/src/scandir.c
+++ b/src/scandir.c
@@ -8,70 +8,44 @@ int ag_scandir(const char *dirname,
                struct dirent ***namelist,
                filter_fp filter,
                void *baton) {
-    DIR *dirp = NULL;
-    struct dirent **names = NULL;
-    struct dirent *entry, *d;
-    int names_len = 32;
-    int results_len = 0;
+    struct dirent **results = NULL;
+    struct dirent **scanned_names = NULL;
+    int i, scanned_names_len, results_len = 0;
 
-    dirp = opendir(dirname);
-    if (dirp == NULL) {
+    scanned_names_len = scandir(dirname, &scanned_names, 0, alphasort);
+    if (scanned_names_len == -1) {
         goto fail;
     }
 
-    names = malloc(sizeof(struct dirent *) * names_len);
-    if (names == NULL) {
+    results = malloc(sizeof(struct dirent *) * scanned_names_len);
+    if (results == NULL) {
         goto fail;
     }
 
-    while ((entry = readdir(dirp)) != NULL) {
-        if ((*filter)(dirname, entry, baton) == FALSE) {
+    for (i = 0; i < scanned_names_len; i++) {
+        if ((*filter)(dirname, scanned_names[i], baton) == FALSE) {
+            free(scanned_names[i]);
+            scanned_names[i] = NULL;
             continue;
         }
-        if (results_len >= names_len) {
-            struct dirent **tmp_names = names;
-            names_len *= 2;
-            names = realloc(names, sizeof(struct dirent *) * names_len);
-            if (names == NULL) {
-                free(tmp_names);
-                goto fail;
-            }
-        }
-
-#if defined(__MINGW32__) || defined(__CYGWIN__)
-        d = malloc(sizeof(struct dirent));
-#else
-        d = malloc(entry->d_reclen);
-#endif
-
-        if (d == NULL) {
-            goto fail;
-        }
-#if defined(__MINGW32__) || defined(__CYGWIN__)
-        memcpy(d, entry, sizeof(struct dirent));
-#else
-        memcpy(d, entry, entry->d_reclen);
-#endif
-
-        names[results_len] = d;
+        results[results_len] = scanned_names[i];
         results_len++;
     }
 
-    closedir(dirp);
-    *namelist = names;
+    *namelist = results;
     return results_len;
 
 fail:
-    if (dirp) {
-        closedir(dirp);
-    }
-
-    if (names != NULL) {
-        int i;
+    if (results != NULL) {
         for (i = 0; i < results_len; i++) {
-            free(names[i]);
+            free(results[i]);
         }
-        free(names);
+        free(results);
+    }
+    if (scanned_names != NULL) {
+        for (i = 0; i < scanned_names_len; i++) {
+            free (scanned_names[i]);
+        }
     }
     return -1;
 }

--- a/src/scandir.h
+++ b/src/scandir.h
@@ -3,12 +3,17 @@
 
 #include "ignore.h"
 
-typedef struct {
-    const ignores *ig;
+struct ignore_iters {
     size_t names_i;
     size_t slash_names_i;
     size_t globs_i;
     size_t slash_globs_i;
+    struct ignore_iters *parent;
+};
+
+typedef struct {
+    const ignores *ig;
+    struct ignore_iters iters;
     const char *base_path;
     size_t base_path_len;
 } scandir_baton_t;

--- a/src/scandir.h
+++ b/src/scandir.h
@@ -6,9 +6,19 @@
 struct ignore_iters {
     size_t names_i;
     size_t slash_names_i;
+    size_t partial_names_i;
     size_t globs_i;
     size_t slash_globs_i;
+    size_t partial_globs_i;
     struct ignore_iters *parent;
+};
+
+struct ag_dirent {
+    struct dirent *dirent;
+    char **partial_name_matches;
+    size_t partial_name_matches_len;
+    char **partial_glob_matches;
+    size_t partial_glob_matches_len;
 };
 
 typedef struct {
@@ -18,10 +28,10 @@ typedef struct {
     size_t base_path_len;
 } scandir_baton_t;
 
-typedef int (*filter_fp)(const char *path, const struct dirent *, void *);
+typedef int (*filter_fp)(const char *path, struct ag_dirent *, void *);
 
 int ag_scandir(const char *dirname,
-               struct dirent ***namelist,
+               struct ag_dirent ***namelist,
                filter_fp filter,
                void *baton);
 

--- a/src/scandir.h
+++ b/src/scandir.h
@@ -7,9 +7,6 @@ struct ignore_iters {
     size_t names_i;
     size_t slash_names_i;
     size_t partial_names_i;
-    size_t globs_i;
-    size_t slash_globs_i;
-    size_t partial_globs_i;
     struct ignore_iters *parent;
 };
 

--- a/src/scandir.h
+++ b/src/scandir.h
@@ -5,6 +5,10 @@
 
 typedef struct {
     const ignores *ig;
+    size_t names_i;
+    size_t slash_names_i;
+    size_t globs_i;
+    size_t slash_globs_i;
     const char *base_path;
     size_t base_path_len;
 } scandir_baton_t;

--- a/src/search.c
+++ b/src/search.c
@@ -453,9 +453,15 @@ void search_dir(ignores *ig, const char *base_path, const char *path, const int 
     }
 
     scandir_baton.ig = ig;
+    scandir_baton.iters = (struct ignore_iters){0, 0, 0, 0, NULL};
     scandir_baton.base_path = base_path;
     scandir_baton.base_path_len = base_path ? strlen(base_path) : 0;
     results = ag_scandir(path, &dir_list, &filename_filter, &scandir_baton);
+    struct ignore_iters *it = scandir_baton.iters.parent, *next;
+    for (; it != NULL; it = next) {
+        next = it->parent;
+        free(it);
+    }
     if (results == 0) {
         log_debug("No results found in directory %s", path);
         goto search_dir_cleanup;

--- a/src/search.c
+++ b/src/search.c
@@ -454,7 +454,7 @@ void search_dir(ignores *ig, const char *base_path, const char *path, const int 
     }
 
     scandir_baton.ig = ig;
-    scandir_baton.iters = (struct ignore_iters){0, 0, 0, 0, NULL};
+    scandir_baton.iters = (struct ignore_iters){0, 0, 0, NULL};
     scandir_baton.base_path = base_path;
     scandir_baton.base_path_len = base_path ? strlen(base_path) : 0;
     results = ag_scandir(path, &dir_list, &filename_filter, &scandir_baton);

--- a/src/search.c
+++ b/src/search.c
@@ -417,7 +417,8 @@ static int check_symloop_leave(dirkey_t *dirkey) {
  */
 void search_dir(ignores *ig, const char *base_path, const char *path, const int depth,
                 dev_t original_dev) {
-    struct dirent **dir_list = NULL;
+    struct ag_dirent **dir_list = NULL;
+    struct ag_dirent *ag_dir = NULL;
     struct dirent *dir = NULL;
     scandir_baton_t scandir_baton;
     int results = 0;
@@ -491,7 +492,8 @@ void search_dir(ignores *ig, const char *base_path, const char *path, const int 
 
     for (i = 0; i < results; i++) {
         queue_item = NULL;
-        dir = dir_list[i];
+        ag_dir = dir_list[i];
+        dir = ag_dir->dirent;
         ag_asprintf(&dir_full_path, "%s/%s", path, dir->d_name);
 #ifndef _WIN32
         if (opts.one_dev) {
@@ -548,9 +550,9 @@ void search_dir(ignores *ig, const char *base_path, const char *path, const int 
                 log_debug("Searching dir %s", dir_full_path);
                 ignores *child_ig;
 #ifdef HAVE_DIRENT_DNAMLEN
-                child_ig = init_ignore(ig, dir->d_name, dir->d_namlen);
+                child_ig = init_ignore(ig, dir->d_name, dir->d_namlen, ag_dir);
 #else
-                child_ig = init_ignore(ig, dir->d_name, strlen(dir->d_name));
+                child_ig = init_ignore(ig, dir->d_name, strlen(dir->d_name), ag_dir);
 #endif
                 search_dir(child_ig, base_path, dir_full_path, depth + 1,
                            original_dev);

--- a/src/util.h
+++ b/src/util.h
@@ -28,6 +28,8 @@ void *ag_calloc(size_t nelem, size_t elsize);
 char *ag_strdup(const char *s);
 char *ag_strndup(const char *s, size_t size);
 
+void ag_insert_str_sorted(char ***arr, size_t *len, const char *el, size_t el_len);
+
 typedef struct {
     size_t start; /* Byte at which the match starts */
     size_t end;   /* and where it ends */
@@ -92,6 +94,10 @@ int is_symlink(const char *path, const struct dirent *d);
 int is_named_pipe(const char *path, const struct dirent *d);
 
 void die(const char *fmt, ...);
+
+int cmp_leading_dir(const char *a, const char *b);
+int cmp_leading_dir_glob(char *a, char *b);
+size_t ag_subdir(const char **str);
 
 void ag_asprintf(char **ret, const char *fmt, ...);
 

--- a/src/util.h
+++ b/src/util.h
@@ -28,7 +28,7 @@ void *ag_calloc(size_t nelem, size_t elsize);
 char *ag_strdup(const char *s);
 char *ag_strndup(const char *s, size_t size);
 
-void ag_insert_str_sorted(char ***arr, size_t *len, const char *el, size_t el_len);
+void ag_insert_str_sorted(char ***arr, size_t *len, char *el, size_t el_len, int copy);
 
 typedef struct {
     size_t start; /* Byte at which the match starts */
@@ -97,7 +97,7 @@ void die(const char *fmt, ...);
 
 int cmp_leading_dir(const char *a, const char *b);
 int cmp_leading_dir_glob(char *a, char *b);
-size_t ag_subdir(const char **str);
+size_t ag_subdir(char **str);
 
 void ag_asprintf(char **ret, const char *fmt, ...);
 

--- a/tests/ignore_absolute_search_path_with_glob.t
+++ b/tests/ignore_absolute_search_path_with_glob.t
@@ -5,12 +5,12 @@ Setup:
   $ echo 'match1' > parent/multi-part/file1.txt
   $ echo 'parent/multi-*' > .gitignore
 
-# Ignore directory specified by glob:
+Ignore directory specified by glob:
 
-#   $ ag match .
-#   [1]
+  $ ag match .
+  [1]
 
-# Ignore directory specified by glob with absolute search path (#448):
+Ignore directory specified by glob with absolute search path (#448):
 
-#   $ ag match $(pwd)
-#   [1]
+  $ ag match $(pwd)
+  [1]

--- a/tests/ignore_glob.t
+++ b/tests/ignore_glob.t
@@ -8,6 +8,7 @@ Setup:
 Ignore foo.yml but not blah.yml:
 
   $ ag whatever .
+  [1]
 
 Dont ignore anything (unrestricted search):
 

--- a/tests/ignore_glob_absolute_multipart.t
+++ b/tests/ignore_glob_absolute_multipart.t
@@ -2,8 +2,10 @@ Setup:
 
   $ . $TESTDIR/setup.sh
   $ mkdir -p parent/multi-part
+  $ mkdir -p parent2/more-multi/part
   $ echo 'match1' > parent/multi-part/file1.txt
-  $ echo 'parent/multi-*' > .gitignore
+  $ echo 'match2' > parent2/more-multi/part/file2.txt
+  $ echo 'parent/multi-*\nparent*/more-multi/part' > .gitignore
 
 Ignore directory specified by glob:
 

--- a/tests/ignore_multiple.t
+++ b/tests/ignore_multiple.t
@@ -1,0 +1,36 @@
+Setup:
+
+  $ . $TESTDIR/setup.sh
+  $ echo 'whatever1' > ./a.txt
+  $ echo 'whatever2' > ./B.txt
+  $ echo 'whatever3' > ./c.txt
+  $ echo 'whatever4' > ./D.txt
+  $ echo 'whatever5' > ./e.txt
+  $ echo 'whatever6' > ./F.txt
+  $ echo 'whatever7' > ./g.txt
+  $ echo 'whatever8' > ./H.txt
+  $ echo 'whatever9' > ./i.txt
+  $ echo "B.txt\ne.txt\nH.txt" > ./.gitignore
+
+Ignore B.txt, e.txt, and H.txt:
+
+  $ ag whatever . | sort
+  D.txt:1:whatever4
+  F.txt:1:whatever6
+  a.txt:1:whatever1
+  c.txt:1:whatever3
+  g.txt:1:whatever7
+  i.txt:1:whatever9
+
+Dont ignore anything (unrestricted search):
+
+  $ ag -u whatever . | sort
+  B.txt:1:whatever2
+  D.txt:1:whatever4
+  F.txt:1:whatever6
+  H.txt:1:whatever8
+  a.txt:1:whatever1
+  c.txt:1:whatever3
+  e.txt:1:whatever5
+  g.txt:1:whatever7
+  i.txt:1:whatever9


### PR DESCRIPTION
The optimisations in this PR are mainly built around matching ignore patterns one leading directory at a time, so that we don't have to match all patterns in `slash_names` and `slash_globs` of all `ignores` in the tree for each child directory.

This change also makes it easy to properly support globs like `parent/multi-*`, which I have also done. Previously disabled tests `ignore_absolute_search_path_with_glob.t` and `stupid_fnmatch.t.disabled` now pass.

(Unfortunately, the speed boost that I ended up being able to achieve was very modest: around 1–2%.)