### PR TITLE
Add support for non-extension filenames and use them for scons, cmake and make

### DIFF
--- a/src/lang.c
+++ b/src/lang.c
@@ -5,132 +5,145 @@
 #include "util.h"
 
 lang_spec_t langs[] = {
-    { "actionscript", { "as", "mxml" } },
-    { "ada", { "ada", "adb", "ads" } },
-    { "asm", { "asm", "s" } },
-    { "batch", { "bat", "cmd" } },
-    { "bitbake", { "bb", "bbappend", "bbclass", "inc" } },
-    { "bro", { "bro", "bif" } },
-    { "cc", { "c", "h", "xs" } },
-    { "cfmx", { "cfc", "cfm", "cfml" } },
-    { "clojure", { "clj", "cljs", "cljc", "cljx" } },
-    { "coffee", { "coffee", "cjsx" } },
-    { "cpp", { "cpp", "cc", "C", "cxx", "m", "hpp", "hh", "h", "H", "hxx" } },
-    { "crystal", { "cr", "ecr" } },
-    { "csharp", { "cs" } },
-    { "css", { "css" } },
-    { "delphi", { "pas", "int", "dfm", "nfm", "dof", "dpk", "dproj", "groupproj", "bdsgroup", "bdsproj" } },
-    { "ebuild", { "ebuild", "eclass" } },
-    { "elisp", { "el" } },
-    { "elixir", { "ex", "exs" } },
-    { "erlang", { "erl", "hrl" } },
-    { "fortran", { "f", "f77", "f90", "f95", "f03", "for", "ftn", "fpp" } },
-    { "fsharp", { "fs", "fsi", "fsx" } },
-    { "gettext", { "po", "pot", "mo" } },
-    { "go", { "go" } },
-    { "groovy", { "groovy", "gtmpl", "gpp", "grunit" } },
-    { "haml", { "haml" } },
-    { "haskell", { "hs", "lhs" } },
-    { "hh", { "h" } },
-    { "html", { "htm", "html", "shtml", "xhtml" } },
-    { "ini", { "ini" } },
-    { "jade", { "jade" } },
-    { "java", { "java", "properties" } },
-    { "js", { "js", "jsx" } },
-    { "json", { "json" } },
-    { "jsp", { "jsp", "jspx", "jhtm", "jhtml" } },
-    { "less", { "less" } },
-    { "liquid", { "liquid" } },
-    { "lisp", { "lisp", "lsp" } },
-    { "lua", { "lua" } },
-    { "m4", { "m4" } },
-    { "make", { "Makefiles", "mk", "mak" } },
-    { "mako", { "mako" } },
-    { "markdown", { "markdown", "mdown", "mdwn", "mkdn", "mkd", "md" } },
-    { "mason", { "mas", "mhtml", "mpl", "mtxt" } },
-    { "matlab", { "m" } },
-    { "mathematica", { "m", "wl" } },
-    { "mercury", { "m", "moo" } },
-    { "nim", { "nim" } },
-    { "objc", { "m", "h" } },
-    { "objcpp", { "mm", "h" } },
-    { "ocaml", { "ml", "mli", "mll", "mly" } },
-    { "octave", { "m" } },
-    { "parrot", { "pir", "pasm", "pmc", "ops", "pod", "pg", "tg" } },
-    { "perl", { "pl", "pm", "pm6", "pod", "t" } },
-    { "php", { "php", "phpt", "php3", "php4", "php5", "phtml" } },
-    { "pike", { "pike", "pmod" } },
-    { "plone", { "pt", "cpt", "metadata", "cpy", "py" } },
-    { "puppet", { "pp" } },
-    { "python", { "py" } },
-    { "racket", { "rkt", "ss", "scm" } },
-    { "rake", { "Rakefiles" } },
-    { "restructuredtext", { "rst" } },
-    { "rs", { "rs" } },
-    { "r", { "R", "Rmd", "Rnw", "Rtex", "Rrst" } },
-    { "rdoc", { "rdoc" } },
-    { "ruby", { "rb", "rhtml", "rjs", "rxml", "erb", "rake", "spec" } },
-    { "rust", { "rs" } },
-    { "salt", { "sls" } },
-    { "sass", { "sass", "scss" } },
-    { "scala", { "scala" } },
-    { "scheme", { "scm", "ss" } },
-    { "shell", { "sh", "bash", "csh", "tcsh", "ksh", "zsh" } },
-    { "smalltalk", { "st" } },
-    { "sml", { "sml", "fun", "mlb", "sig" } },
-    { "sql", { "sql", "ctl" } },
-    { "stylus", { "styl" } },
-    { "swift", { "swift" } },
-    { "tcl", { "tcl", "itcl", "itk" } },
-    { "tex", { "tex", "cls", "sty" } },
-    { "tt", { "tt", "tt2", "ttml" } },
-    { "toml", { "toml" } },
-    { "ts", { "ts", "tsx" } },
-    { "vala", { "vala", "vapi" } },
-    { "vb", { "bas", "cls", "frm", "ctl", "vb", "resx" } },
-    { "velocity", { "vm", "vtl", "vsl" } },
-    { "verilog", { "v", "vh", "sv" } },
-    { "vhdl", { "vhd", "vhdl" } },
-    { "vim", { "vim" } },
-    { "wsdl", { "wsdl" } },
-    { "wadl", { "wadl" } },
-    { "xml", { "xml", "dtd", "xsl", "xslt", "ent" } },
-    { "yaml", { "yaml", "yml" } }
+    { "actionscript", { "as", "mxml" }, {} },
+    { "ada", { "ada", "adb", "ads" }, {} },
+    { "asm", { "asm", "s" }, {} },
+    { "batch", { "bat", "cmd" }, {} },
+    { "bitbake", { "bb", "bbappend", "bbclass", "inc" }, {} },
+    { "bro", { "bro", "bif" }, {} },
+    { "cc", { "c", "h", "xs" }, {} },
+    { "cfmx", { "cfc", "cfm", "cfml" }, {} },
+    { "clojure", { "clj", "cljs", "cljc", "cljx" }, {} },
+    { "coffee", { "coffee", "cjsx" }, {} },
+    { "cpp", { "cpp", "cc", "C", "cxx", "m", "hpp", "hh", "h", "H", "hxx" }, {} },
+    { "crystal", { "cr", "ecr" }, {} },
+    { "csharp", { "cs" }, {} },
+    { "css", { "css" }, {} },
+    { "delphi", { "pas", "int", "dfm", "nfm", "dof", "dpk", "dproj", "groupproj", "bdsgroup", "bdsproj" }, {} },
+    { "ebuild", { "ebuild", "eclass" }, {} },
+    { "elisp", { "el" }, {} },
+    { "elixir", { "ex", "exs" }, {} },
+    { "erlang", { "erl", "hrl" }, {} },
+    { "fortran", { "f", "f77", "f90", "f95", "f03", "for", "ftn", "fpp" }, {} },
+    { "fsharp", { "fs", "fsi", "fsx" }, {} },
+    { "gettext", { "po", "pot", "mo" }, {} },
+    { "go", { "go" }, {} },
+    { "groovy", { "groovy", "gtmpl", "gpp", "grunit" }, {} },
+    { "haml", { "haml" }, {} },
+    { "haskell", { "hs", "lhs" }, {} },
+    { "hh", { "h" }, {} },
+    { "html", { "htm", "html", "shtml", "xhtml" }, {} },
+    { "ini", { "ini" }, {} },
+    { "jade", { "jade" }, {} },
+    { "java", { "java", "properties" }, {} },
+    { "js", { "js", "jsx" }, {} },
+    { "json", { "json" }, {} },
+    { "jsp", { "jsp", "jspx", "jhtm", "jhtml" }, {} },
+    { "less", { "less" }, {} },
+    { "liquid", { "liquid" }, {} },
+    { "lisp", { "lisp", "lsp" }, {} },
+    { "lua", { "lua" }, {} },
+    { "m4", { "m4" }, {} },
+    { "make", { "Makefiles", "mk", "mak" }, {}  },
+    { "mako", { "mako" }, {} },
+    { "markdown", { "markdown", "mdown", "mdwn", "mkdn", "mkd", "md" }, {} },
+    { "mason", { "mas", "mhtml", "mpl", "mtxt" }, {} },
+    { "matlab", { "m" }, {} },
+    { "mathematica", { "m", "wl" }, {} },
+    { "mercury", { "m", "moo" }, {} },
+    { "nim", { "nim" }, {} },
+    { "objc", { "m", "h" }, {} },
+    { "objcpp", { "mm", "h" }, {} },
+    { "ocaml", { "ml", "mli", "mll", "mly" }, {} },
+    { "octave", { "m" }, {} },
+    { "parrot", { "pir", "pasm", "pmc", "ops", "pod", "pg", "tg" }, {} },
+    { "perl", { "pl", "pm", "pm6", "pod", "t" }, {} },
+    { "php", { "php", "phpt", "php3", "php4", "php5", "phtml" }, {} },
+    { "pike", { "pike", "pmod" }, {} },
+    { "plone", { "pt", "cpt", "metadata", "cpy", "py" }, {} },
+    { "puppet", { "pp" }, {} },
+    { "python", { "py" }, {} },
+    { "racket", { "rkt", "ss", "scm" }, {} },
+    { "rake", { "Rakefiles" }, {} },
+    { "restructuredtext", { "rst" }, {} },
+    { "rs", { "rs" }, {} },
+    { "r", { "R", "Rmd", "Rnw", "Rtex", "Rrst" }, {} },
+    { "rdoc", { "rdoc" }, {} },
+    { "ruby", { "rb", "rhtml", "rjs", "rxml", "erb", "rake", "spec" }, {} },
+    { "rust", { "rs" }, {} },
+    { "salt", { "sls" }, {} },
+    { "sass", { "sass", "scss" }, {} },
+    { "scala", { "scala" }, {} },
+    { "scheme", { "scm", "ss" }, {} },
+    { "shell", { "sh", "bash", "csh", "tcsh", "ksh", "zsh" }, {} },
+    { "smalltalk", { "st" }, {} },
+    { "sml", { "sml", "fun", "mlb", "sig" }, {} },
+    { "sql", { "sql", "ctl" }, {} },
+    { "stylus", { "styl" }, {} },
+    { "swift", { "swift" }, {} },
+    { "tcl", { "tcl", "itcl", "itk" }, {} },
+    { "tex", { "tex", "cls", "sty" }, {} },
+    { "tt", { "tt", "tt2", "ttml" }, {} },
+    { "toml", { "toml" }, {} },
+    { "ts", { "ts", "tsx" }, {} },
+    { "vala", { "vala", "vapi" }, {} },
+    { "vb", { "bas", "cls", "frm", "ctl", "vb", "resx" }, {} },
+    { "velocity", { "vm", "vtl", "vsl" }, {} },
+    { "verilog", { "v", "vh", "sv" }, {} },
+    { "vhdl", { "vhd", "vhdl" }, {} },
+    { "vim", { "vim" }, {} },
+    { "wsdl", { "wsdl" }, {} },
+    { "wadl", { "wadl" }, {} },
+    { "xml", { "xml", "dtd", "xsl", "xslt", "ent" }, {} },
+    { "yaml", { "yaml", "yml" }, {} }
 };
 
 size_t get_lang_count() {
     return sizeof(langs) / sizeof(lang_spec_t);
 }
 
-char *make_lang_regex(char *ext_array, size_t num_exts) {
-    int regex_capacity = 100;
-    char *regex = ag_malloc(regex_capacity);
-    int regex_length = 3;
+char *make_lang_regex(char *ext_array, size_t num_exts,
+                      char *full_filenames, size_t num_filenames) {
+    // characters in the regex used for "management" not belonging to the names itself
+    const size_t mgmt_overhead = 20;
+    char *regex = ag_malloc(mgmt_overhead + 
+            num_exts * (SINGLE_EXT_LEN+1) +
+            num_filenames * (SINGLE_NAME_LEN+1) );
     int subsequent = 0;
-    char *extension;
     size_t i;
 
-    strcpy(regex, "\\.(");
+    // remember, the RE has the form
+    // '((^|[/\\])(full_name1|full_name2)|\.(extension1|extension2...))$'
 
-    for (i = 0; i < num_exts; ++i) {
-        extension = ext_array + i * SINGLE_EXT_LEN;
-        int extension_length = strlen(extension);
-        while (regex_length + extension_length + 3 + subsequent > regex_capacity) {
-            regex_capacity *= 2;
-            regex = ag_realloc(regex, regex_capacity);
-        }
+    regex[0] = '\0';
+
+    strcat(regex, "((^|[/\\\\])(");
+
+    for (i = 0; i < num_filenames; ++i) {
+        char *name = full_filenames + i * SINGLE_NAME_LEN;
         if (subsequent) {
-            regex[regex_length++] = '|';
+            strcat(regex, "|");
         } else {
             subsequent = 1;
         }
-        strcpy(regex + regex_length, extension);
-        regex_length += extension_length;
+        strcat(regex, name);
     }
 
-    regex[regex_length++] = ')';
-    regex[regex_length++] = '$';
-    regex[regex_length++] = 0;
+    strcat(regex, ")|\\.(");
+
+    subsequent = 0;
+    for (i = 0; i < num_exts; ++i) {
+        char *extension = ext_array + i * SINGLE_EXT_LEN;
+        if (subsequent) {
+            strcat(regex, "|");
+        } else {
+            subsequent = 1;
+        }
+        strcat(regex, extension);
+    }
+
+    strcat(regex, "))$");
+
     return regex;
 }
 
@@ -147,7 +160,7 @@ size_t combine_file_extensions(size_t *extension_index, size_t len, char **exts)
     for (i = 0; i < len; ++i) {
         size_t j = 0;
         const char *ext = langs[extension_index[i]].extensions[j];
-        do {
+        while (ext) {
             if (num_of_extensions == ext_capacity) {
                 break;
             }
@@ -155,8 +168,35 @@ size_t combine_file_extensions(size_t *extension_index, size_t len, char **exts)
             strncpy(pos, ext, strlen(ext));
             ++num_of_extensions;
             ext = langs[extension_index[i]].extensions[++j];
-        } while (ext);
+        }
     }
 
     return num_of_extensions;
+}
+
+size_t combine_full_filenames(size_t *extension_index, size_t len, char **names) {
+    /* Keep it fixed as 100 for the reason that if you have more than 100
+     * file types to search, you'd better search all the files.
+     * */
+    size_t names_capacity = 100;
+    (*names) = (char *)ag_malloc(names_capacity * SINGLE_NAME_LEN);
+    memset((*names), 0, names_capacity * SINGLE_NAME_LEN);
+    size_t num_of_names = 0;
+
+    size_t i;
+    for (i = 0; i < len; ++i) {
+        size_t j = 0;
+        const char *name = langs[extension_index[i]].full_filenames[j];
+        while (name) {
+            if (num_of_names == names_capacity) {
+                break;
+            }
+            char *pos = (*names) + num_of_names * SINGLE_NAME_LEN;
+            strncpy(pos, name, strlen(name));
+            ++num_of_names;
+            name = langs[extension_index[i]].full_filenames[++j];
+        }
+    }
+
+    return num_of_names;
 }

--- a/src/lang.c
+++ b/src/lang.c
@@ -14,6 +14,7 @@ lang_spec_t langs[] = {
     { "cc", { "c", "h", "xs" }, {} },
     { "cfmx", { "cfc", "cfm", "cfml" }, {} },
     { "clojure", { "clj", "cljs", "cljc", "cljx" }, {} },
+    { "cmake", { "cmake" }, { "CMakeLists.txt" } },
     { "coffee", { "coffee", "cjsx" }, {} },
     { "cpp", { "cpp", "cc", "C", "cxx", "m", "hpp", "hh", "h", "H", "hxx" }, {} },
     { "crystal", { "cr", "ecr" }, {} },

--- a/src/lang.c
+++ b/src/lang.c
@@ -73,6 +73,7 @@ lang_spec_t langs[] = {
     { "rust", { "rs" }, {} },
     { "salt", { "sls" }, {} },
     { "sass", { "sass", "scss" }, {} },
+    { "scons", { "py" }, {"SConstruct"} },
     { "scala", { "scala" }, {} },
     { "scheme", { "scm", "ss" }, {} },
     { "shell", { "sh", "bash", "csh", "tcsh", "ksh", "zsh" }, {} },

--- a/src/lang.c
+++ b/src/lang.c
@@ -44,7 +44,7 @@ lang_spec_t langs[] = {
     { "lisp", { "lisp", "lsp" }, {} },
     { "lua", { "lua" }, {} },
     { "m4", { "m4" }, {} },
-    { "make", { "Makefiles", "mk", "mak" }, {}  },
+    { "make", { "Makefiles", "mk", "mak" }, { "Makefile", "GNUmakefile" }  },
     { "mako", { "mako" }, {} },
     { "markdown", { "markdown", "mdown", "mdwn", "mkdn", "mkd", "md" }, {} },
     { "mason", { "mas", "mhtml", "mpl", "mtxt" }, {} },

--- a/src/lang.h
+++ b/src/lang.h
@@ -1,12 +1,16 @@
 #ifndef LANG_H
 #define LANG_H
 
-#define MAX_EXTENSIONS 12
-#define SINGLE_EXT_LEN 20
+#define MAX_EXTENSIONS  12
+#define SINGLE_EXT_LEN  20
+
+#define MAX_FILENAMES   12
+#define SINGLE_NAME_LEN 30
 
 typedef struct {
     const char *name;
     const char *extensions[MAX_EXTENSIONS];
+    const char *full_filenames[MAX_FILENAMES];
 } lang_spec_t;
 
 extern lang_spec_t langs[];
@@ -18,11 +22,13 @@ size_t get_lang_count(void);
 
 /**
 Convert a NULL-terminated array of language extensions
-into a regular expression of the form \.(extension1|extension2...)$
+into a regular expression of the form 
+'((^|[/\\])(full_name1|full_name2)|\.(extension1|extension2...))$'
 
 Caller is responsible for freeing the returned string.
 */
-char *make_lang_regex(char *ext_array, size_t num_exts);
+char *make_lang_regex(char *ext_array, size_t num_exts,
+                      char *full_filenames, size_t num_filenames);
 
 
 /**
@@ -33,4 +39,13 @@ The combined result is returned through *exts*;
 The number of extensions that *exts* actually contain is returned.
 */
 size_t combine_file_extensions(size_t *extension_index, size_t len, char **exts);
+
+/**
+Combine multiple file names into one array.
+
+The combined result is returned through *names*;
+*names* is one-dimension array, which can contain up to 100 extensions;
+The number of file names that *names* actually contain is returned.
+*/
+size_t combine_full_filenames(size_t *extension_index, size_t len, char **names);
 #endif

--- a/src/options.c
+++ b/src/options.c
@@ -211,8 +211,8 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
     option_t *longopts;
     char *lang_regex = NULL;
     size_t *ext_index = NULL;
-    char *extensions = NULL;
-    size_t num_exts = 0;
+    char *extensions = NULL, *full_filenames = NULL;
+    size_t num_exts = 0, num_names = 0;
 
     init_options();
 
@@ -574,12 +574,16 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
 
     if (ext_index[0]) {
         num_exts = combine_file_extensions(ext_index, lang_num, &extensions);
-        lang_regex = make_lang_regex(extensions, num_exts);
+        num_names = combine_full_filenames(ext_index, lang_num, &full_filenames);
+        lang_regex = make_lang_regex(extensions, num_exts, full_filenames, num_names);
         compile_study(&opts.file_search_regex, &opts.file_search_regex_extra, lang_regex, 0, 0);
     }
 
     if (extensions) {
         free(extensions);
+    }
+    if (full_filenames) {
+        free(full_filenames);
     }
     free(ext_index);
     if (lang_regex) {
@@ -616,6 +620,9 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
             int j;
             for (j = 0; j < MAX_EXTENSIONS && langs[lang_index].extensions[j]; j++) {
                 printf("  .%s", langs[lang_index].extensions[j]);
+            }
+            for (j = 0; j < MAX_FILENAMES && langs[lang_index].full_filenames[j]; j++) {
+                printf("  %s", langs[lang_index].full_filenames[j]);
             }
             printf("\n\n");
         }

--- a/tests/list_file_types.t
+++ b/tests/list_file_types.t
@@ -33,6 +33,9 @@ Language types are output:
     --clojure
         .clj  .cljs  .cljc  .cljx
   
+    --cmake
+        .cmake  CMakeLists.txt
+  
     --coffee
         .coffee  .cjsx
   

--- a/tests/list_file_types.t
+++ b/tests/list_file_types.t
@@ -210,6 +210,9 @@ Language types are output:
     --sass
         .sass  .scss
   
+    --scons
+        .py  SConstruct
+  
     --scala
         .scala
   

--- a/tests/list_file_types.t
+++ b/tests/list_file_types.t
@@ -124,7 +124,7 @@ Language types are output:
         .m4
   
     --make
-        .Makefiles  .mk  .mak
+        .Makefiles  .mk  .mak  Makefile  GNUmakefile
   
     --mako
         .mako


### PR DESCRIPTION
This patch adds support for languages that have files without an extension.

The next patches utilize that new support.
