### PR TITLE
Fix filetype option

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -206,6 +206,7 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
     int rv;
     size_t lang_count;
     size_t lang_num = 0;
+    int has_filetype = 0;
 
     size_t longopts_len, full_len;
     option_t *longopts;
@@ -544,6 +545,7 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
 
                 for (i = 0; i < lang_count; i++) {
                     if (strcmp(longopts[opt_index].name, langs[i].name) == 0) {
+                        has_filetype = 1;
                         ext_index[lang_num++] = i;
                         break;
                     }
@@ -572,7 +574,7 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
         free(file_search_regex);
     }
 
-    if (ext_index[0]) {
+    if (has_filetype) {
         num_exts = combine_file_extensions(ext_index, lang_num, &extensions);
         lang_regex = make_lang_regex(extensions, num_exts);
         compile_study(&opts.file_search_regex, &opts.file_search_regex_extra, lang_regex, 0, 0);

--- a/tests/filetype.t
+++ b/tests/filetype.t
@@ -1,0 +1,15 @@
+Setup:
+
+  $ . $TESTDIR/setup.sh
+  $ TEST_FILETYPE_EXT1=`ag --list-file-types | grep -E '^\s+\..+' | head -n 1 | awk '{ print $1 }'`
+  $ TEST_FILETYPE_EXT2=`ag --list-file-types | grep -E '^\s+\..+' | tail -n 1 | awk '{ print $1 }'`
+  $ TEST_FILETYPE_DIR=filetype_test
+  $ mkdir $TEST_FILETYPE_DIR
+  $ echo "This is filetype test1." >  $TEST_FILETYPE_DIR/test.$TEST_FILETYPE_EXT1
+  $ echo "This is filetype test2." >  $TEST_FILETYPE_DIR/test.$TEST_FILETYPE_EXT2
+
+Match only top file type:
+
+  $ TEST_FILETYPE_OPTION=`ag --list-file-types | grep -E '^\s+--.+' | head -n 1 | awk '{ print $1 }'`
+  $ ag 'This is filetype test' --nofilename $TEST_FILETYPE_OPTION $TEST_FILETYPE_DIR
+  This is filetype test1.


### PR DESCRIPTION
In the case of next, all files are searched.
```
$ ls ag_test
hoge    hoge.as hoge.c
$ ag hoge --actionscript ag_test
ag_test/hoge.as
1:hoge

ag_test/hoge.c
1:hoge

ag_test/hoge
1:hoge
```

expect:
```
$ ag hoge --actionscript ag_test
ag_test/hoge.as
1:hoge
```