### PR TITLE
Fix literal word-regexp.

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -66,8 +66,8 @@ void search_buf(const char *buf, const size_t buf_len,
                     /* It's a match */
                 } else {
                     /* It's not a match */
-                    match_ptr += opts.query_len;
-                    buf_offset = end - buf;
+                    match_ptr += find_skip_lookup[0] - opts.query_len + 1;
+                    buf_offset = match_ptr - buf;
                     continue;
                 }
             }

--- a/tests/literal_word_regexp.t
+++ b/tests/literal_word_regexp.t
@@ -1,0 +1,40 @@
+Setup:
+
+  $ . $TESTDIR/setup.sh
+  $ echo 'blah abc def' > blah1.txt
+  $ echo 'abc blah def' > blah2.txt
+  $ echo 'abc def blah' > blah3.txt
+  $ echo 'abcblah def' > blah4.txt
+  $ echo 'abc blahdef' >> blah4.txt
+  $ echo 'blahx blah' > blah5.txt
+  $ echo 'abcblah blah blah' > blah6.txt
+
+Match a word of the beginning:
+
+  $ ag -wF --column 'blah' blah1.txt
+  1:1:blah abc def
+
+Match a middle word:
+
+  $ ag -wF --column 'blah' blah2.txt
+  1:5:abc blah def
+
+Match a last word:
+
+  $ ag -wF --column 'blah' blah3.txt
+  1:9:abc def blah
+
+No match:
+
+  $ ag -wF --column 'blah' blah4.txt
+  [1]
+
+Match:
+
+  $ ag -wF --column 'blah' blah5.txt
+  1:7:blahx blah
+
+Case of a word repeating the same part:
+
+  $ ag -wF --column 'blah blah' blah6.txt
+  1:9:abcblah blah blah


### PR DESCRIPTION
```
$ cat blah.txt
abcblah blah blah

# Match. (GNU grep 2.6.3)
$ grep -wF 'blah blah' blah.txt
abcblah blah blah

# No match.
$ ag -wF 'blah blah' blah.txt

# expect?
$ ag -wF 'blah blah' blah.txt
1:abcblah blah blah
```
