### PR TITLE
Fix compilation error when using MinGW-w64

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -9,6 +9,7 @@
 #include "config.h"
 
 #ifdef _WIN32
+#include <windows.h>
 #define flockfile(x)
 #define funlockfile(x)
 #define getc_unlocked(x) getc(x)


### PR DESCRIPTION
After #788, compilation error occurs when using MinGW-w64.
This PR fixes the error.

```
  CC     src/util.o
src/util.c: In function 'is_directory':
src/util.c:439:18: warning: implicit declaration of function 'GetFileAttributesA' [-Wimplicit-function-declaration]
     int is_dir = GetFileAttributesA(full_path) & FILE_ATTRIBUTE_DIRECTORY;
                  ^
src/util.c:439:50: error: 'FILE_ATTRIBUTE_DIRECTORY' undeclared (first use in this function)
     int is_dir = GetFileAttributesA(full_path) & FILE_ATTRIBUTE_DIRECTORY;
                                                  ^
src/util.c:439:50: note: each undeclared identifier is reported only once for each function it appears in
src/util.c: In function 'is_symlink':
src/util.c:449:20: error: 'MAX_PATH' undeclared (first use in this function)
     char full_path[MAX_PATH + 1] = { 0 };
                    ^
src/util.c:451:45: error: 'FILE_ATTRIBUTE_REPARSE_POINT' undeclared (first use in this function)
     return (GetFileAttributesA(full_path) & FILE_ATTRIBUTE_REPARSE_POINT);
                                             ^
src/util.c:449:10: warning: unused variable 'full_path' [-Wunused-variable]
     char full_path[MAX_PATH + 1] = { 0 };
          ^
src/util.c:470:1: warning: control reaches end of non-void function [-Wreturn-type]
 }
 ^
```