### PR TITLE
Support WiX files with --wix

### DIFF
--- a/src/lang.c
+++ b/src/lang.c
@@ -93,6 +93,7 @@ lang_spec_t langs[] = {
     { "verilog", { "v", "vh", "sv" } },
     { "vhdl", { "vhd", "vhdl" } },
     { "vim", { "vim" } },
+    { "wix", { "wxi", "wxs" } },
     { "wsdl", { "wsdl" } },
     { "wadl", { "wadl" } },
     { "xml", { "xml", "dtd", "xsl", "xslt", "ent" } },

--- a/tests/list_file_types.t
+++ b/tests/list_file_types.t
@@ -270,6 +270,9 @@ Language types are output:
     --vim
         .vim
   
+    --wix
+        .wxi  .wxs
+  
     --wsdl
         .wsdl
   


### PR DESCRIPTION
Add the XML source [file extensions](http://wixtoolset.org/documentation/manual/v3/overview/files.html)
that are commonly used by WiX installer projects.