### PR TITLE
Add failing test for ignoring files with multiple extensions

### DIFF
--- a/tests/ignore_extensions.t
+++ b/tests/ignore_extensions.t
@@ -4,10 +4,12 @@ Setup:
   $ echo '*.js' > .gitignore
   $ echo '\n*.test.txt' >> .gitignore
   $ echo 'targetA' > something.js
+  $ echo 'targetG' > something.min.js
   $ echo 'targetB' > aFile.test.txt
   $ echo 'targetC' > aFile.txt
   $ mkdir -p subdir
   $ echo 'targetD' > subdir/somethingElse.js
+  $ echo 'targetH' > subdir/somethingElse.min.js
   $ echo 'targetE' > subdir/anotherFile.test.txt
   $ echo 'targetF' > subdir/anotherFile.txt
 
@@ -19,6 +21,11 @@ Ignore patterns with single extension in root directory:
 Ignore patterns with multiple extensions in root directory:
 
   $ ag "targetB"
+  [1]
+
+Ignore files with multiple extensions in root directory:
+
+  $ ag "targetG"
   [1]
 
 Do not ignore patterns with partial extensions in root directory:
@@ -34,6 +41,11 @@ Ignore patterns with single extension in subdirectory:
 Ignore patterns with multiple extensions in subdirectory:
 
   $ ag "targetE"
+  [1]
+
+Ignore files with multiple extensions in subdirectory:
+
+  $ ag "targetH"
   [1]
 
 Do not ignore patterns with partial extensions in subdirectory:


### PR DESCRIPTION
Covers the issue reported in #755
The `.min.js` files should be ignored due to the general `*.js` rule.
