### PR TITLE
On OpenBSD use pledge to drop privileges.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -57,7 +57,7 @@ AC_CHECK_DECL([CPU_ZERO, CPU_SET], [AC_DEFINE([USE_CPU_SET], [], [Use CPU_SET ma
 AC_CHECK_MEMBER([struct dirent.d_type], [AC_DEFINE([HAVE_DIRENT_DTYPE], [], [Have dirent struct member d_type])], [], [[#include <dirent.h>]])
 AC_CHECK_MEMBER([struct dirent.d_namlen], [AC_DEFINE([HAVE_DIRENT_DNAMLEN], [], [Have dirent struct member d_namlen])], [], [[#include <dirent.h>]])
 
-AC_CHECK_FUNCS(fgetln getline realpath strlcpy strndup vasprintf madvise posix_fadvise pthread_setaffinity_np)
+AC_CHECK_FUNCS(fgetln getline realpath strlcpy strndup vasprintf madvise posix_fadvise pthread_setaffinity_np pledge)
 
 AC_CONFIG_FILES([Makefile the_silver_searcher.spec])
 AC_CONFIG_HEADERS([src/config.h])

--- a/src/main.c
+++ b/src/main.c
@@ -35,6 +35,12 @@ int main(int argc, char **argv) {
     int workers_len;
     int num_cores;
 
+#ifdef HAVE_PLEDGE
+    if (pledge("stdio rpath proc exec", NULL) == -1) {
+        die("pledge: %s", strerror(errno));
+    }
+#endif
+
     set_log_level(LOG_LEVEL_WARN);
 
     work_queue = NULL;
@@ -156,6 +162,12 @@ int main(int argc, char **argv) {
             log_debug("No CPU affinity support.");
 #endif
         }
+
+#ifdef HAVE_PLEDGE
+        if (pledge("stdio rpath", NULL) == -1) {
+            die("pledge: %s", strerror(errno));
+        }
+#endif
         for (i = 0; paths[i] != NULL; i++) {
             log_debug("searching path %s for %s", paths[i], opts.query);
             symhash = NULL;

--- a/src/options.c
+++ b/src/options.c
@@ -600,6 +600,14 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
         }
     }
 
+#ifdef HAVE_PLEDGE
+    if (opts.skip_vcs_ignores) {
+        if (pledge("stdio rpath proc", NULL) == -1) {
+            die("pledge: %s", strerror(errno));
+        }
+    }
+#endif
+
     if (help) {
         usage();
         exit(0);
@@ -658,6 +666,12 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
             pclose(gitconfig_file);
         }
     }
+
+#ifdef HAVE_PLEDGE
+    if (pledge("stdio rpath proc", NULL) == -1) {
+        die("pledge: %s", strerror(errno));
+    }
+#endif
 
     if (opts.context > 0) {
         opts.before = opts.context;


### PR DESCRIPTION
With suggestions by Doug Hogan and the initial work by Michael McConville.

OpenBSD has added a new interface: [pledge](http://www.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/man2/pledge.2) which allows an application to drop privileges that are not needed. As `ag` is an application that searches a whole variety of files this should improve security, when unleashing `ag` on a set of unknown files.