### PR TITLE
Fix #845

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -28,6 +28,7 @@
 #include "options.h"
 #include "print.h"
 #include "util.h"
+#include "decompress.h"
 #include "uthash.h"
 
 size_t alpha_skip_lookup[256];

--- a/src/util.h
+++ b/src/util.h
@@ -42,12 +42,6 @@ typedef struct {
     struct timeval time_end;
 } ag_stats;
 
-typedef enum {
-    AG_NO_COMPRESSION,
-    AG_GZIP,
-    AG_COMPRESS,
-    AG_ZIP
-} ag_compression_type;
 
 ag_stats stats;
 
@@ -74,8 +68,6 @@ size_t invert_matches(const char *buf, const size_t buf_len, match_t matches[], 
 void realloc_matches(match_t **matches, size_t *matches_size, size_t matches_len);
 void compile_study(pcre **re, pcre_extra **re_extra, char *q, const int pcre_opts, const int study_opts);
 
-void *decompress(const ag_compression_type zip_type, const void *buf, const int buf_len, const char *dir_full_path, int *new_buf_len);
-ag_compression_type is_zipped(const void *buf, const int buf_len);
 
 int is_binary(const void *buf, const size_t buf_len);
 int is_regex(const char *query);


### PR DESCRIPTION
Fix for #845
I don't get why `decompress` and `ag_compression_type` were declared in util.h
If there was a logic behind it simply ignore this^^