### PR TITLE
Fix default value typo

### DIFF
--- a/doc/ag.1
+++ b/doc/ag.1
@@ -24,11 +24,11 @@ Search all files\. This doesn\'t include hidden files, and doesn\'t respect any 
 .
 .TP
 \fB\-A \-\-after [LINES]\fR
-Print lines after match\. Defaults to 2\.
+Print lines after match\. Defaults to 0\.
 .
 .TP
 \fB\-B \-\-before [LINES]\fR
-Print lines before match\. Defaults to 2\.
+Print lines before match\. Defaults to 0\.
 .
 .TP
 \fB\-\-[no]break\fR


### PR DESCRIPTION
When testing `ag` without -A and -B, I get 0 lines shown above and below. I believe that this is a typo.