### PR TITLE
Add filetypes for Chapel language

### DIFF
--- a/src/lang.c
+++ b/src/lang.c
@@ -13,6 +13,7 @@ lang_spec_t langs[] = {
     { "bro", { "bro", "bif" } },
     { "cc", { "c", "h", "xs" } },
     { "cfmx", { "cfc", "cfm", "cfml" } },
+    { "chpl", { "chpl" } },
     { "clojure", { "clj", "cljs", "cljc", "cljx" } },
     { "coffee", { "coffee", "cjsx" } },
     { "cpp", { "cpp", "cc", "C", "cxx", "m", "hpp", "hh", "h", "H", "hxx" } },

--- a/tests/list_file_types.t
+++ b/tests/list_file_types.t
@@ -30,6 +30,9 @@ Language types are output:
     --cfmx
         .cfc  .cfm  .cfml
   
+    --chpl
+        .chpl
+  
     --clojure
         .clj  .cljs  .cljc  .cljx
   

--- a/tests/list_file_types.t
+++ b/tests/list_file_types.t
@@ -30,7 +30,7 @@ Language types are output:
     --cfmx
         .cfc  .cfm  .cfml
   
-    --chpl 
+    --chpl
         .chpl
   
     --clojure

--- a/tests/list_file_types.t
+++ b/tests/list_file_types.t
@@ -30,7 +30,7 @@ Language types are output:
     --cfmx
         .cfc  .cfm  .cfml
   
-    --chpl
+    --chpl 
         .chpl
   
     --clojure


### PR DESCRIPTION
[Chapel](http://chapel.cray.com/) is an [open-source](https://github.com/chapel-lang/chapel) language built for productive parallel computing at scale.

I have added the Chapel source filetype: `.chpl`.

I have also formatted `CONTRIBUTING.md` for 80 character lines (a trivial edit for retriggering the previously broken Travis build)