### PR TITLE
Just a friendly reminder to use binary searching

### DIFF
--- a/src/ignore.c
+++ b/src/ignore.c
@@ -355,6 +355,7 @@ int filename_filter(const char *path, const struct dirent *dir, void *baton) {
         return 0;
     }
 
+    /* TODO: Use binary search once this list becomes "huge-ass" */
     for (i = 0; evil_hardcoded_ignore_files[i] != NULL; i++) {
         if (strcmp(filename, evil_hardcoded_ignore_files[i]) == 0) {
             return 0;


### PR DESCRIPTION
`filename_filter` [searches a hardcoded list](https://github.com/ggreer/the_silver_searcher/blob/master/src/ignore.c#L358) of files to ignore.  At present a linear search is used, which is OK because the list is very short.  However, should the list grow in the future a binary search will be better suited.