### PR TITLE
Skip one_device.t if /dev/shm isn't a mountpoint

### DIFF
--- a/tests/one_device.t
+++ b/tests/one_device.t
@@ -4,6 +4,9 @@ Setup:
   > if [ ! -e "/dev/shm" ]; then
   > echo "No /dev/shm. Skipping test."
   > exit 80
+  > elif [ "$(stat -c%d /dev/)" == "$(stat -c%d /dev/shm/)" ]; then
+  > echo "/dev/shm not a different device.  Skipping test."
+  > exit 80
   > fi
   $ TEST_TMPDIR=`mktemp -d --tmpdir=/dev/shm ag_test.XXX`
   $ echo "blah" > $TEST_TMPDIR/blah.txt

--- a/tests/one_device.t
+++ b/tests/one_device.t
@@ -4,7 +4,7 @@ Setup:
   > if [ ! -e "/dev/shm" ]; then
   > echo "No /dev/shm. Skipping test."
   > exit 80
-  > elif [ "$(stat -c%d /dev/)" == "$(stat -c%d /dev/shm/)" ]; then
+  > elif [ "$(stat -c%d /dev/)" = "$(stat -c%d /dev/shm/)" ]; then
   > echo "/dev/shm not a different device.  Skipping test."
   > exit 80
   > fi


### PR DESCRIPTION
If /dev/shm isn't a separate device to its parent directory, skip using
it to test limiting a search to a single device.  If /dev/shm isn't a
mountpoint there's no obvious alternative for checking Ag doesn't
descend into one, so just skip the test entirely.

Fixes #864.