### PR TITLE
Use printf in place of echo in tests

### DIFF
--- a/tests/adjacent_matches.t
+++ b/tests/adjacent_matches.t
@@ -2,7 +2,7 @@ Setup:
 
   $ . $TESTDIR/setup.sh
   $ alias ag="$TESTDIR/../ag --workers=1 --parallel --color"
-  $ echo blahfoofooblah > ./fooblah.txt
+  $ printf 'blahfoofooblah\n' > ./fooblah.txt
 
 Highlights are adjacent:
 

--- a/tests/case_sensitivity.t
+++ b/tests/case_sensitivity.t
@@ -1,8 +1,8 @@
 Setup:
 
   $ . $TESTDIR/setup.sh
-  $ echo Foo >> ./sample
-  $ echo bar >> ./sample
+  $ printf 'Foo\n' >> ./sample
+  $ printf 'bar\n' >> ./sample
 
 Smart case by default:
 

--- a/tests/color.t
+++ b/tests/color.t
@@ -3,8 +3,8 @@ stdout isn't a tty when running in cram.
 
   $ . $TESTDIR/setup.sh
   $ alias ag="$TESTDIR/../ag --workers=1 --parallel --color"
-  $ echo foo > ./blah.txt
-  $ echo bar >> ./blah.txt
+  $ printf 'foo\n' > ./blah.txt
+  $ printf 'bar\n' >> ./blah.txt
 
 Matches should contain colors:
 

--- a/tests/column.t
+++ b/tests/column.t
@@ -1,7 +1,7 @@
 Setup:
 
   $ . $TESTDIR/setup.sh
-  $ echo "blah\nblah2" > blah.txt
+  $ printf "blah\nblah2\n" > blah.txt
 
 Ensure column is correct:
 

--- a/tests/count.t
+++ b/tests/count.t
@@ -3,10 +3,10 @@ Setup:
   $ . $TESTDIR/setup.sh
   $ unalias ag
   $ alias ag="$TESTDIR/../ag --nocolor --workers=1"
-  $ echo "blah" > blah.txt
-  $ echo "blah2" >> blah.txt
-  $ echo "blah_OTHER" > other_file.txt
-  $ echo "blah_OTHER" >> other_file.txt
+  $ printf "blah\n" > blah.txt
+  $ printf "blah2\n" >> blah.txt
+  $ printf "blah_OTHER\n" > other_file.txt
+  $ printf "blah_OTHER\n" >> other_file.txt
 
 Count matches:
 
@@ -16,7 +16,7 @@ Count matches:
 
 Count stream matches:
 
-  $ echo 'blah blah blah' | ag --count blah
+  $ printf 'blah blah blah\n' | ag --count blah
   3
 
 Count stream matches per line (not very useful since it does not print zero):

--- a/tests/ds_store_ignore.t
+++ b/tests/ds_store_ignore.t
@@ -1,8 +1,8 @@
 Setup.
   $ . $TESTDIR/setup.sh
   $ mkdir -p dir0/dir1/dir2
-  $ echo '*.DS_Store' > dir0/.gitignore
-  $ echo blah > dir0/dir1/dir2/blah.txt
+  $ printf '*.DS_Store\n' > dir0/.gitignore
+  $ printf 'blah\n' > dir0/dir1/dir2/blah.txt
   $ touch dir0/dir1/.DS_Store
 
 Find blah in blah.txt

--- a/tests/empty_match.t
+++ b/tests/empty_match.t
@@ -1,7 +1,7 @@
 Setup.
   $ . $TESTDIR/setup.sh
   $ touch empty.txt
-  $ echo foo > nonempty.txt
+  $ printf 'foo\n' > nonempty.txt
 
 Zero-length match on an empty file should fail silently with return code 1
 

--- a/tests/exitcodes.t
+++ b/tests/exitcodes.t
@@ -1,8 +1,8 @@
 Setup:
 
   $ . $TESTDIR/setup.sh
-  $ echo foo > ./exitcodes_test.txt
-  $ echo bar >> ./exitcodes_test.txt
+  $ printf 'foo\n' > ./exitcodes_test.txt
+  $ printf 'bar\n' >> ./exitcodes_test.txt
 
 Normal matching:
 

--- a/tests/fail/unicode_case_insensitive.t
+++ b/tests/fail/unicode_case_insensitive.t
@@ -1,8 +1,8 @@
 Setup:
 
   $ . $TESTDIR/../setup.sh
-  $ echo "hello=你好" > test.txt
-  $ echo "hello=你好" >> test.txt
+  $ printf "hello=你好\n" > test.txt
+  $ printf "hello=你好\n" >> test.txt
 
 Normal search:
 

--- a/tests/fail/unicode_case_insensitive.t.err
+++ b/tests/fail/unicode_case_insensitive.t.err
@@ -1,8 +1,8 @@
 Setup:
 
   $ . $TESTDIR/../setup.sh
-  $ echo "hello=你好" > test.txt
-  $ echo "hello=你好" >> test.txt
+  $ printf "hello=你好\n" > test.txt
+  $ printf "hello=你好\n" >> test.txt
 
 Normal search:
 

--- a/tests/filetype.t
+++ b/tests/filetype.t
@@ -5,8 +5,8 @@ Setup:
   $ TEST_FILETYPE_EXT2=`ag --list-file-types | grep -E '^\s+\..+' | tail -n 1 | awk '{ print $1 }'`
   $ TEST_FILETYPE_DIR=filetype_test
   $ mkdir $TEST_FILETYPE_DIR
-  $ echo "This is filetype test1." >  $TEST_FILETYPE_DIR/test.$TEST_FILETYPE_EXT1
-  $ echo "This is filetype test2." >  $TEST_FILETYPE_DIR/test.$TEST_FILETYPE_EXT2
+  $ printf "This is filetype test1.\n" >  $TEST_FILETYPE_DIR/test.$TEST_FILETYPE_EXT1
+  $ printf "This is filetype test2.\n" >  $TEST_FILETYPE_DIR/test.$TEST_FILETYPE_EXT2
 
 Match only top file type:
 

--- a/tests/hidden_option.t
+++ b/tests/hidden_option.t
@@ -3,10 +3,10 @@ Setup:
   $ . $TESTDIR/setup.sh
   $ mkdir hidden_bug
   $ cd hidden_bug
-  $ echo "test" > a.txt
+  $ printf "test\n" > a.txt
   $ git init --quiet
   $ if [ ! -d .git/info ] ; then mkdir .git/info ; fi
-  $ echo "a.txt" > .git/info/exclude
+  $ printf "a.txt\n" > .git/info/exclude
 
   $ ag --ignore-dir .git test
   [1]
@@ -21,7 +21,7 @@ Setup:
   a.txt:1:test
 
   $ mkdir -p ./.hidden
-  $ echo 'whatever' > ./.hidden/a.txt
+  $ printf 'whatever\n' > ./.hidden/a.txt
 
   $ ag whatever
   [1]
@@ -29,7 +29,7 @@ Setup:
   $ ag --hidden whatever
   [1]
 
-  $ echo "" > .git/info/exclude
+  $ printf "\n" > .git/info/exclude
 
   $ ag whatever
   [1]

--- a/tests/ignore_abs_path.t
+++ b/tests/ignore_abs_path.t
@@ -2,9 +2,9 @@ Setup:
 
   $ . $TESTDIR/setup.sh
   $ mkdir -p ./a/b/c
-  $ echo 'whatever1' > ./a/b/c/blah.yml
-  $ echo 'whatever2' > ./a/b/foo.yml
-  $ echo '/a/b/foo.yml' > ./.gitignore
+  $ printf 'whatever1\n' > ./a/b/c/blah.yml
+  $ printf 'whatever2\n' > ./a/b/foo.yml
+  $ printf '/a/b/foo.yml\n' > ./.gitignore
 
 Ignore foo.yml but not blah.yml:
 

--- a/tests/ignore_absolute_search_path_with_glob.t
+++ b/tests/ignore_absolute_search_path_with_glob.t
@@ -2,8 +2,8 @@ Setup:
 
   $ . $TESTDIR/setup.sh
   $ mkdir -p parent/multi-part
-  $ echo 'match1' > parent/multi-part/file1.txt
-  $ echo 'parent/multi-*' > .gitignore
+  $ printf 'match1\n' > parent/multi-part/file1.txt
+  $ printf 'parent/multi-*\n' > .gitignore
 
 # Ignore directory specified by glob:
 

--- a/tests/ignore_backups.t
+++ b/tests/ignore_backups.t
@@ -2,24 +2,24 @@ Setup:
 
   $ . $TESTDIR/setup.sh
   $ mkdir -p ./a/b/c
-  $ echo 'whatever1'  > ./a/b/c/foo.yml
-  $ echo 'whatever2'  > ./a/b/c/foo.yml~
-  $ echo 'whatever3'  > ./a/b/c/.foo.yml.swp
-  $ echo 'whatever4'  > ./a/b/c/.foo.yml.swo
-  $ echo 'whatever5'  > ./a/b/foo.yml
-  $ echo 'whatever6'  > ./a/b/foo.yml~
-  $ echo 'whatever7'  > ./a/b/.foo.yml.swp
-  $ echo 'whatever8'  > ./a/b/.foo.yml.swo
-  $ echo 'whatever9'  > ./a/foo.yml
-  $ echo 'whatever10' > ./a/foo.yml~
-  $ echo 'whatever11' > ./a/.foo.yml.swp
-  $ echo 'whatever12' > ./a/.foo.yml.swo
-  $ echo 'whatever13' > ./foo.yml
-  $ echo 'whatever14' > ./foo.yml~
-  $ echo 'whatever15' > ./.foo.yml.swp
-  $ echo 'whatever16' > ./.foo.yml.swo
-  $ echo '*~'         > ./.gitignore
-  $ echo '*.sw[po]'   >> ./.gitignore
+  $ printf 'whatever1\n'  > ./a/b/c/foo.yml
+  $ printf 'whatever2\n'  > ./a/b/c/foo.yml~
+  $ printf 'whatever3\n'  > ./a/b/c/.foo.yml.swp
+  $ printf 'whatever4\n'  > ./a/b/c/.foo.yml.swo
+  $ printf 'whatever5\n'  > ./a/b/foo.yml
+  $ printf 'whatever6\n'  > ./a/b/foo.yml~
+  $ printf 'whatever7\n'  > ./a/b/.foo.yml.swp
+  $ printf 'whatever8\n'  > ./a/b/.foo.yml.swo
+  $ printf 'whatever9\n'  > ./a/foo.yml
+  $ printf 'whatever10\n' > ./a/foo.yml~
+  $ printf 'whatever11\n' > ./a/.foo.yml.swp
+  $ printf 'whatever12\n' > ./a/.foo.yml.swo
+  $ printf 'whatever13\n' > ./foo.yml
+  $ printf 'whatever14\n' > ./foo.yml~
+  $ printf 'whatever15\n' > ./.foo.yml.swp
+  $ printf 'whatever16\n' > ./.foo.yml.swo
+  $ printf '*~\n'         > ./.gitignore
+  $ printf '*.sw[po]\n'   >> ./.gitignore
 
 Ignore all files except foo.yml
 

--- a/tests/ignore_examine_parent_ignorefiles.t
+++ b/tests/ignore_examine_parent_ignorefiles.t
@@ -2,8 +2,8 @@ Setup:
 
   $ . $TESTDIR/setup.sh
   $ mkdir -p subdir
-  $ echo 'match1' > subdir/file1.txt
-  $ echo 'file1.txt' > .gitignore
+  $ printf 'match1\n' > subdir/file1.txt
+  $ printf 'file1.txt\n' > .gitignore
 
 Ignore directory specified by name:
 

--- a/tests/ignore_extensions.t
+++ b/tests/ignore_extensions.t
@@ -1,15 +1,15 @@
 Setup:
 
   $ . $TESTDIR/setup.sh
-  $ echo '*.js' > .gitignore
-  $ echo '\n*.test.txt' >> .gitignore
-  $ echo 'targetA' > something.js
-  $ echo 'targetB' > aFile.test.txt
-  $ echo 'targetC' > aFile.txt
+  $ printf '*.js\n' > .gitignore
+  $ printf '\n*.test.txt\n' >> .gitignore
+  $ printf 'targetA\n' > something.js
+  $ printf 'targetB\n' > aFile.test.txt
+  $ printf 'targetC\n' > aFile.txt
   $ mkdir -p subdir
-  $ echo 'targetD' > subdir/somethingElse.js
-  $ echo 'targetE' > subdir/anotherFile.test.txt
-  $ echo 'targetF' > subdir/anotherFile.txt
+  $ printf 'targetD\n' > subdir/somethingElse.js
+  $ printf 'targetE\n' > subdir/anotherFile.test.txt
+  $ printf 'targetF\n' > subdir/anotherFile.txt
 
 Ignore patterns with single extension in root directory:
 

--- a/tests/ignore_gitignore.t
+++ b/tests/ignore_gitignore.t
@@ -3,7 +3,7 @@ Setup:
   $ . $TESTDIR/setup.sh
   $ export HOME=$PWD
   $ printf '[core]\nexcludesfile = ~/.gitignore.global' >> $HOME/.gitconfig
-  $ echo 'PATTERN_MARKER' > .gitignore.global
+  $ printf 'PATTERN_MARKER\n' > .gitignore.global
 
 Test that the ignore pattern got picked up:
 

--- a/tests/ignore_pattern_in_subdirectory.t
+++ b/tests/ignore_pattern_in_subdirectory.t
@@ -2,9 +2,9 @@ Setup:
 
   $ . $TESTDIR/setup.sh
   $ mkdir subdir
-  $ echo 'first' > file1.txt
-  $ echo 'second' > subdir/file2.txt
-  $ echo '*.txt' > .gitignore
+  $ printf 'first\n' > file1.txt
+  $ printf 'second\n' > subdir/file2.txt
+  $ printf '*.txt\n' > .gitignore
 
 Ignore file based on extension match:
 

--- a/tests/ignore_subdir.t
+++ b/tests/ignore_subdir.t
@@ -2,11 +2,11 @@ Setup:
 
   $ . $TESTDIR/setup.sh
   $ mkdir -p ./a/b/c
-  $ echo 'whatever1' > ./a/b/c/blah.yml
-  $ echo 'whatever2' > ./a/b/foo.yml
-  $ echo 'a/b/foo.yml' > ./.gitignore
+  $ printf 'whatever1\n' > ./a/b/c/blah.yml
+  $ printf 'whatever2\n' > ./a/b/foo.yml
+  $ printf 'a/b/foo.yml\n' > ./.gitignore
 # TODO: have this work instead of the above
-# $ echo 'a/b/*.yml' > ./.gitignore
+# $ printf 'a/b/*.yml\n' > ./.gitignore
 
 Ignore foo.yml but not blah.yml:
 

--- a/tests/invert_match.t
+++ b/tests/invert_match.t
@@ -1,13 +1,13 @@
 Setup:
 
   $ . $TESTDIR/setup.sh
-  $ echo 'valid: 1' > ./blah.txt
-  $ echo 'some_string' >> ./blah.txt
-  $ echo 'valid: 654' >> ./blah.txt
-  $ echo 'some_other_string' >> ./blah.txt
-  $ echo 'valid: 0' >> ./blah.txt
-  $ echo 'valid: 23' >> ./blah.txt
-  $ echo 'valid: 0' >> ./blah.txt
+  $ printf 'valid: 1\n' > ./blah.txt
+  $ printf 'some_string\n' >> ./blah.txt
+  $ printf 'valid: 654\n' >> ./blah.txt
+  $ printf 'some_other_string\n' >> ./blah.txt
+  $ printf 'valid: 0\n' >> ./blah.txt
+  $ printf 'valid: 23\n' >> ./blah.txt
+  $ printf 'valid: 0\n' >> ./blah.txt
 
 Search for lines not matching "valid: 0" in blah.txt:
 

--- a/tests/line_width.t
+++ b/tests/line_width.t
@@ -1,7 +1,7 @@
 Setup:
 
   $ . $TESTDIR/setup.sh
-  $ echo "12345678901234567890123456789012345678901234567890" >> ./blah.txt
+  $ printf "12345678901234567890123456789012345678901234567890\n" >> ./blah.txt
 
 Truncate to width inside input line length:
 

--- a/tests/max_count.t
+++ b/tests/max_count.t
@@ -1,18 +1,18 @@
 Setup:
 
   $ . $TESTDIR/setup.sh
-  $ echo "blah" > blah.txt
-  $ echo "blah2" >> blah.txt
-  $ echo "blah2" > blah2.txt
-  $ echo "blah2" >> blah2.txt
-  $ echo "blah2" >> blah2.txt
-  $ echo "blah2" >> blah2.txt
-  $ echo "blah2" >> blah2.txt
-  $ echo "blah2" >> blah2.txt
-  $ echo "blah2" >> blah2.txt
-  $ echo "blah2" >> blah2.txt
-  $ echo "blah2" >> blah2.txt
-  $ echo "blah2" >> blah2.txt # 10 lines
+  $ printf "blah\n" > blah.txt
+  $ printf "blah2\n" >> blah.txt
+  $ printf "blah2\n" > blah2.txt
+  $ printf "blah2\n" >> blah2.txt
+  $ printf "blah2\n" >> blah2.txt
+  $ printf "blah2\n" >> blah2.txt
+  $ printf "blah2\n" >> blah2.txt
+  $ printf "blah2\n" >> blah2.txt
+  $ printf "blah2\n" >> blah2.txt
+  $ printf "blah2\n" >> blah2.txt
+  $ printf "blah2\n" >> blah2.txt
+  $ printf "blah2\n" >> blah2.txt # 10 lines
 
 Max match of 1:
 

--- a/tests/multiline.t
+++ b/tests/multiline.t
@@ -1,9 +1,9 @@
 Setup:
 
   $ . $TESTDIR/setup.sh
-  $ echo 'what' > blah.txt
-  $ echo 'ever' >> blah.txt
-  $ echo 'whatever' >> blah.txt
+  $ printf 'what\n' > blah.txt
+  $ printf 'ever\n' >> blah.txt
+  $ printf 'whatever\n' >> blah.txt
 
 Multiline:
 

--- a/tests/one_device.t
+++ b/tests/one_device.t
@@ -6,7 +6,7 @@ Setup:
   > exit 80
   > fi
   $ TEST_TMPDIR=`mktemp -d --tmpdir=/dev/shm ag_test.XXX`
-  $ echo "blah" > $TEST_TMPDIR/blah.txt
+  $ printf "blah\n" > $TEST_TMPDIR/blah.txt
   $ ln -s $TEST_TMPDIR other_device
 
 Should not descend into /dev/shm symlink when --one-device specified:

--- a/tests/only_matching.t
+++ b/tests/only_matching.t
@@ -1,11 +1,11 @@
 Setup:
 
   $ . $TESTDIR/setup.sh
-  $ echo "the quick brown foxy" > blah.txt
-  $ echo "blah blah blah" >> blah.txt
-  $ echo "another foxlike word" >> blah.txt
-  $ echo "no matches here" >> blah.txt
-  $ echo "blah blah blah" >> blah.txt
+  $ printf "the quick brown foxy\n" > blah.txt
+  $ printf "blah blah blah\n" >> blah.txt
+  $ printf "another foxlike word\n" >> blah.txt
+  $ printf "no matches here\n" >> blah.txt
+  $ printf "blah blah blah\n" >> blah.txt
 
 Only print matches:
 

--- a/tests/option_smartcase.t
+++ b/tests/option_smartcase.t
@@ -1,8 +1,8 @@
 Setup:
 
   $ . $TESTDIR/setup.sh
-  $ echo 'asdf' > test.txt
-  $ echo 'AsDf' >> test.txt
+  $ printf 'asdf\n' > test.txt
+  $ printf 'AsDf\n' >> test.txt
 
 Smart case search:
 

--- a/tests/passthrough.t
+++ b/tests/passthrough.t
@@ -3,9 +3,9 @@ Setup:
   $ . $TESTDIR/setup.sh
   $ unalias ag
   $ alias ag="$TESTDIR/../ag --nocolor --workers=1"
-  $ echo "foo bar" > passthrough_test.txt
-  $ echo "zoo zar" >> passthrough_test.txt
-  $ echo "foo test" >> passthrough_test.txt
+  $ printf "foo bar\n" > passthrough_test.txt
+  $ printf "zoo zar\n" >> passthrough_test.txt
+  $ printf "foo test\n" >> passthrough_test.txt
 
 No impact on non-stream:
 

--- a/tests/search_stdin.t
+++ b/tests/search_stdin.t
@@ -1,7 +1,7 @@
 Setup:
 
   $ . $TESTDIR/setup.sh
-  $ echo 'blah' > ./blah.txt
+  $ printf 'blah\n' > ./blah.txt
 
 Feed blah.txt from stdin:
 

--- a/tests/stupid_fnmatch.t.disabled
+++ b/tests/stupid_fnmatch.t.disabled
@@ -2,8 +2,8 @@ Setup:
 
   $ . $TESTDIR/setup.sh
   $ mkdir -p ./a/bomb
-  $ echo 'whatever' > ./a/bomb/foo.yml
-  $ echo '*b/foo.yml' > ./.gitignore
+  $ printf 'whatever\n' > ./a/bomb/foo.yml
+  $ printf '*b/foo.yml\n' > ./.gitignore
 
 Ignore foo.yml but not blah.yml:
 

--- a/tests/vimgrep.t
+++ b/tests/vimgrep.t
@@ -1,10 +1,10 @@
 Setup:
 
   $ . $TESTDIR/setup.sh
-  $ echo 'Hello, "Hello, world" programs output "Hello, world".' > ./test_vimgrep.txt
-  $ echo '"Hello, world" programs are simple programs.' >> ./test_vimgrep.txt
-  $ echo 'They illustrate the most basic syntax of a programming language' >> ./test_vimgrep.txt
-  $ echo 'In javascript: alert("Hello, world!");' >> ./test_vimgrep.txt
+  $ printf 'Hello, "Hello, world" programs output "Hello, world".\n' > ./test_vimgrep.txt
+  $ printf '"Hello, world" programs are simple programs.\n' >> ./test_vimgrep.txt
+  $ printf 'They illustrate the most basic syntax of a programming language\n' >> ./test_vimgrep.txt
+  $ printf 'In javascript: alert("Hello, world!");\n' >> ./test_vimgrep.txt
 
 Search for lines matching "hello" in test_vimgrep.txt:
 


### PR DESCRIPTION
The behaviour of echo is inconsistent between implementations, in
particular regarding whether it expands escapes like `\n`.  Use printf
consistently in test scripts to avoid test failures from inconsistent
echo behaviour.

Fixes #866.