### PR TITLE
File Types: Add eex under Elixir

### DIFF
--- a/src/lang.c
+++ b/src/lang.c
@@ -24,7 +24,7 @@ lang_spec_t langs[] = {
     { "delphi", { "pas", "int", "dfm", "nfm", "dof", "dpk", "dproj", "groupproj", "bdsgroup", "bdsproj" } },
     { "ebuild", { "ebuild", "eclass" } },
     { "elisp", { "el" } },
-    { "elixir", { "ex", "exs" } },
+    { "elixir", { "ex", "eex", "exs" } },
     { "erlang", { "erl", "hrl" } },
     { "factor", { "factor" } },
     { "fortran", { "f", "f77", "f90", "f95", "f03", "for", "ftn", "fpp" } },

--- a/tests/list_file_types.t
+++ b/tests/list_file_types.t
@@ -64,7 +64,7 @@ Language types are output:
         .el
   
     --elixir
-        .ex  .exs
+        .ex  .eex  .exs
   
     --erlang
         .erl  .hrl


### PR DESCRIPTION
`.eex` is the extension for Elixir templates

References:
- http://elixir-lang.org/docs/stable/eex/EEx.html