### PR TITLE
Fix #347 - Keep enough context around to print in stream mode

### DIFF
--- a/src/print.c
+++ b/src/print.c
@@ -8,6 +8,7 @@
 #include "log.h"
 #include "options.h"
 #include "print.h"
+#include "search.h"
 #include "util.h"
 #ifdef _WIN32
 #define fprintf(...) fprintf_w32(__VA_ARGS__)
@@ -18,6 +19,47 @@ int first_file_match = 1;
 const char *color_reset = "\033[0m\033[K";
 
 const char *truncate_marker = " [...]";
+
+__thread struct print_context {
+    size_t line;
+    char **context_prev_lines;
+    size_t prev_line;
+    size_t last_prev_line;
+    size_t prev_line_offset;
+    size_t lines_since_last_match;
+    size_t last_printed_match;
+    int in_a_match;
+    int printing_a_match;
+} print_context;
+
+void print_init_context(void) {
+    if (print_context.context_prev_lines != NULL)
+        return;
+    print_context.context_prev_lines = ag_calloc(sizeof(char *), (opts.before + 1));
+    print_context.line = 1;
+    print_context.prev_line = 0;
+    print_context.last_prev_line = 0;
+    print_context.prev_line_offset = 0;
+    print_context.lines_since_last_match = INT_MAX;
+    print_context.last_printed_match = 0;
+    print_context.in_a_match = FALSE;
+    print_context.printing_a_match = FALSE;
+}
+
+void print_cleanup_context(void) {
+    size_t i;
+
+    if (print_context.context_prev_lines == NULL)
+        return;
+
+    for (i = 0; i < opts.before; i++) {
+        if (print_context.context_prev_lines[i] != NULL) {
+            free(print_context.context_prev_lines[i]);
+        }
+    }
+    free(print_context.context_prev_lines);
+    print_context.context_prev_lines = NULL;
+}
 
 void print_path(const char *path, const char sep) {
     if (opts.print_path == PATH_PRINT_NOTHING && !opts.vimgrep) {
@@ -65,19 +107,10 @@ void print_binary_file_matches(const char *path) {
 }
 
 void print_file_matches(const char *path, const char *buf, const size_t buf_len, const match_t matches[], const size_t matches_len) {
-    size_t line = 1;
-    char **context_prev_lines = NULL;
-    size_t prev_line = 0;
-    size_t last_prev_line = 0;
-    size_t prev_line_offset = 0;
     size_t cur_match = 0;
-    size_t lines_since_last_match = INT_MAX;
     ssize_t lines_to_print = 0;
-    size_t last_printed_match = 0;
     char sep = '-';
     size_t i, j;
-    int in_a_match = FALSE;
-    int printing_a_match = FALSE;
 
     if (opts.ackmate || opts.vimgrep) {
         sep = ':';
@@ -99,20 +132,18 @@ void print_file_matches(const char *path, const char *buf, const size_t buf_len,
         }
     }
 
-    context_prev_lines = ag_calloc(sizeof(char *), (opts.before + 1));
-
-    for (i = 0; i <= buf_len && (cur_match < matches_len || lines_since_last_match <= opts.after); i++) {
+    for (i = 0; i <= buf_len && (cur_match < matches_len || print_context.lines_since_last_match <= opts.after); i++) {
         if (cur_match < matches_len && i == matches[cur_match].start) {
-            in_a_match = TRUE;
+            print_context.in_a_match = TRUE;
             /* We found the start of a match */
-            if (cur_match > 0 && opts.context && lines_since_last_match > (opts.before + opts.after + 1)) {
+            if (cur_match > 0 && opts.context && print_context.lines_since_last_match > (opts.before + opts.after + 1)) {
                 fprintf(out_fd, "--\n");
             }
 
-            if (lines_since_last_match > 0 && opts.before > 0) {
+            if (print_context.lines_since_last_match > 0 && opts.before > 0) {
                 /* TODO: better, but still needs work */
                 /* print the previous line(s) */
-                lines_to_print = lines_since_last_match - (opts.after + 1);
+                lines_to_print = print_context.lines_since_last_match - (opts.after + 1);
                 if (lines_to_print < 0) {
                     lines_to_print = 0;
                 } else if ((size_t)lines_to_print > opts.before) {
@@ -120,80 +151,80 @@ void print_file_matches(const char *path, const char *buf, const size_t buf_len,
                 }
 
                 for (j = (opts.before - lines_to_print); j < opts.before; j++) {
-                    prev_line = (last_prev_line + j) % opts.before;
-                    if (context_prev_lines[prev_line] != NULL) {
+                    print_context.prev_line = (print_context.last_prev_line + j) % opts.before;
+                    if (print_context.context_prev_lines[print_context.prev_line] != NULL) {
                         if (opts.print_path == PATH_PRINT_EACH_LINE) {
                             print_path(path, ':');
                         }
-                        print_line_number(line - (opts.before - j), sep);
-                        fprintf(out_fd, "%s\n", context_prev_lines[prev_line]);
+                        print_line_number(print_context.line - (opts.before - j), sep);
+                        fprintf(out_fd, "%s\n", print_context.context_prev_lines[print_context.prev_line]);
                     }
                 }
             }
-            lines_since_last_match = 0;
+            print_context.lines_since_last_match = 0;
         }
 
         if (cur_match < matches_len && i == matches[cur_match].end) {
             /* We found the end of a match. */
             cur_match++;
-            in_a_match = FALSE;
+            print_context.in_a_match = FALSE;
         }
 
         /* We found the end of a line. */
         if ((i == buf_len || buf[i] == '\n') && opts.before > 0) {
-            if (context_prev_lines[last_prev_line] != NULL) {
-                free(context_prev_lines[last_prev_line]);
+            if (print_context.context_prev_lines[print_context.last_prev_line] != NULL) {
+                free(print_context.context_prev_lines[print_context.last_prev_line]);
             }
             /* We don't want to strcpy the \n */
-            context_prev_lines[last_prev_line] = ag_strndup(&buf[prev_line_offset], i - prev_line_offset);
-            last_prev_line = (last_prev_line + 1) % opts.before;
+            print_context.context_prev_lines[print_context.last_prev_line] = ag_strndup(&buf[print_context.prev_line_offset], i - print_context.prev_line_offset);
+            print_context.last_prev_line = (print_context.last_prev_line + 1) % opts.before;
         }
 
         if (i == buf_len || buf[i] == '\n') {
-            if (lines_since_last_match == 0) {
+            if (print_context.lines_since_last_match == 0) {
                 if (opts.print_path == PATH_PRINT_EACH_LINE && !opts.search_stream) {
                     print_path(path, ':');
                 }
                 if (opts.ackmate) {
                     /* print headers for ackmate to parse */
-                    print_line_number(line, ';');
-                    for (; last_printed_match < cur_match; last_printed_match++) {
+                    print_line_number(print_context.line, ';');
+                    for (; print_context.last_printed_match < cur_match; print_context.last_printed_match++) {
                         /* Don't print negative offsets. This isn't quite right, but not many people use --ackmate */
-                        long start = (long)(matches[last_printed_match].start - prev_line_offset);
+                        long start = (long)(matches[print_context.last_printed_match].start - print_context.prev_line_offset);
                         if (start < 0) {
                             start = 0;
                         }
                         fprintf(out_fd, "%li %li",
                                 start,
-                                (long)(matches[last_printed_match].end - matches[last_printed_match].start));
-                        last_printed_match == cur_match - 1 ? fputc(':', out_fd) : fputc(',', out_fd);
+                                (long)(matches[print_context.last_printed_match].end - matches[print_context.last_printed_match].start));
+                        print_context.last_printed_match == cur_match - 1 ? fputc(':', out_fd) : fputc(',', out_fd);
                     }
-                    print_line(buf, i, prev_line_offset);
+                    print_line(buf, i, print_context.prev_line_offset);
                 } else if (opts.vimgrep) {
-                    for (; last_printed_match < cur_match; last_printed_match++) {
+                    for (; print_context.last_printed_match < cur_match; print_context.last_printed_match++) {
                         print_path(path, sep);
-                        print_line_number(line, sep);
-                        print_column_number(matches, last_printed_match, prev_line_offset, sep);
-                        print_line(buf, i, prev_line_offset);
+                        print_line_number(print_context.line, sep);
+                        print_column_number(matches, print_context.last_printed_match, print_context.prev_line_offset, sep);
+                        print_line(buf, i, print_context.prev_line_offset);
                     }
                 } else {
-                    print_line_number(line, ':');
+                    print_line_number(print_context.line, ':');
                     int printed_match = FALSE;
                     if (opts.column) {
-                        print_column_number(matches, last_printed_match, prev_line_offset, ':');
+                        print_column_number(matches, print_context.last_printed_match, print_context.prev_line_offset, ':');
                     }
 
-                    if (printing_a_match && opts.color) {
+                    if (print_context.printing_a_match && opts.color) {
                         fprintf(out_fd, "%s", opts.color_match);
                     }
-                    for (j = prev_line_offset; j <= i; j++) {
+                    for (j = print_context.prev_line_offset; j <= i; j++) {
                         /* close highlight of match term */
-                        if (last_printed_match < matches_len && j == matches[last_printed_match].end) {
+                        if (print_context.last_printed_match < matches_len && j == matches[print_context.last_printed_match].end) {
                             if (opts.color) {
                                 fprintf(out_fd, "%s", color_reset);
                             }
-                            printing_a_match = FALSE;
-                            last_printed_match++;
+                            print_context.printing_a_match = FALSE;
+                            print_context.last_printed_match++;
                             printed_match = TRUE;
                             if (opts.only_matching) {
                                 fputc('\n', out_fd);
@@ -201,7 +232,7 @@ void print_file_matches(const char *path, const char *buf, const size_t buf_len,
                         }
                         /* skip remaining characters if truncation width exceeded, needs to be done
                          * before highlight opening */
-                        if (j < buf_len && opts.width > 0 && j - prev_line_offset >= opts.width) {
+                        if (j < buf_len && opts.width > 0 && j - print_context.prev_line_offset >= opts.width) {
                             if (j < i) {
                                 fputs(truncate_marker, out_fd);
                             }
@@ -209,55 +240,55 @@ void print_file_matches(const char *path, const char *buf, const size_t buf_len,
 
                             /* prevent any more characters or highlights */
                             j = i;
-                            last_printed_match = matches_len;
+                            print_context.last_printed_match = matches_len;
                         }
                         /* open highlight of match term */
-                        if (last_printed_match < matches_len && j == matches[last_printed_match].start) {
+                        if (print_context.last_printed_match < matches_len && j == matches[print_context.last_printed_match].start) {
                             if (opts.only_matching && printed_match) {
                                 if (opts.print_path == PATH_PRINT_EACH_LINE) {
                                     print_path(path, ':');
                                 }
-                                print_line_number(line, ':');
+                                print_line_number(print_context.line, ':');
                                 if (opts.column) {
-                                    print_column_number(matches, last_printed_match, prev_line_offset, ':');
+                                    print_column_number(matches, print_context.last_printed_match, print_context.prev_line_offset, ':');
                                 }
                             }
                             if (opts.color) {
                                 fprintf(out_fd, "%s", opts.color_match);
                             }
-                            printing_a_match = TRUE;
+                            print_context.printing_a_match = TRUE;
                         }
                         /* Don't print the null terminator */
                         if (j < buf_len) {
                             /* if only_matching is set, print only matches and newlines */
-                            if (!opts.only_matching || printing_a_match) {
-                                if (opts.width == 0 || j - prev_line_offset < opts.width) {
+                            if (!opts.only_matching || print_context.printing_a_match) {
+                                if (opts.width == 0 || j - print_context.prev_line_offset < opts.width) {
                                     fputc(buf[j], out_fd);
                                 }
                             }
                         }
                     }
-                    if (printing_a_match && opts.color) {
+                    if (print_context.printing_a_match && opts.color) {
                         fprintf(out_fd, "%s", color_reset);
                     }
                 }
-            } else if (lines_since_last_match <= opts.after) {
+            } else if (print_context.lines_since_last_match <= opts.after) {
                 /* print context after matching line */
                 if (opts.print_path == PATH_PRINT_EACH_LINE) {
                     print_path(path, ':');
                 }
-                print_line_number(line, sep);
+                print_line_number(print_context.line, sep);
 
-                for (j = prev_line_offset; j < i; j++) {
+                for (j = print_context.prev_line_offset; j < i; j++) {
                     fputc(buf[j], out_fd);
                 }
                 fputc('\n', out_fd);
             }
 
-            prev_line_offset = i + 1; /* skip the newline */
-            line++;
-            if (!in_a_match && lines_since_last_match < INT_MAX) {
-                lines_since_last_match++;
+            print_context.prev_line_offset = i + 1; /* skip the newline */
+            print_context.line++;
+            if (!print_context.in_a_match && print_context.lines_since_last_match < INT_MAX) {
+                print_context.lines_since_last_match++;
             }
             /* File doesn't end with a newline. Print one so the output is pretty. */
             if (i == buf_len && buf[i - 1] != '\n' && !opts.search_stream) {
@@ -265,13 +296,6 @@ void print_file_matches(const char *path, const char *buf, const size_t buf_len,
             }
         }
     }
-
-    for (i = 0; i < opts.before; i++) {
-        if (context_prev_lines[i] != NULL) {
-            free(context_prev_lines[i]);
-        }
-    }
-    free(context_prev_lines);
 }
 
 void print_line_number(size_t line, const char sep) {

--- a/src/print.h
+++ b/src/print.h
@@ -5,6 +5,8 @@
 
 void print_init_context(void);
 void print_cleanup_context(void);
+void print_context_append(const char *line, size_t len);
+void print_trailing_context(const char *path, const char *buf, size_t n);
 void print_path(const char *path, const char sep);
 void print_path_count(const char *path, const char sep, const size_t count);
 void print_line(const char *buf, size_t buf_pos, size_t prev_line_offset);

--- a/src/print.h
+++ b/src/print.h
@@ -3,6 +3,8 @@
 
 #include "util.h"
 
+void print_init_context(void);
+void print_cleanup_context(void);
 void print_path(const char *path, const char sep);
 void print_path_count(const char *path, const char sep, const size_t count);
 void print_line(const char *buf, size_t buf_pos, size_t prev_line_offset);

--- a/src/search.c
+++ b/src/search.c
@@ -1,3 +1,4 @@
+#include "print.h"
 #include "search.h"
 #include "scandir.h"
 
@@ -208,12 +209,15 @@ void search_stream(FILE *stream, const char *path) {
     size_t line_cap = 0;
     size_t i;
 
+    print_init_context();
+
     for (i = 1; (line_len = getline(&line, &line_cap, stream)) > 0; i++) {
         opts.stream_line_num = i;
         search_buf(line, line_len, path);
     }
 
     free(line);
+    print_cleanup_context();
 }
 
 void search_file(const char *file_full_path) {
@@ -246,6 +250,8 @@ void search_file(const char *file_full_path) {
         log_err("Skipping %s: Mode %u is not a file.", file_full_path, statbuf.st_mode);
         goto cleanup;
     }
+
+    print_init_context();
 
     if (statbuf.st_mode & S_IFIFO) {
         log_debug("%s is a named pipe. stream searching", file_full_path);
@@ -317,6 +323,7 @@ void search_file(const char *file_full_path) {
 
 cleanup:
 
+    print_cleanup_context();
     if (buf != NULL) {
 #ifdef _WIN32
         UnmapViewOfFile(buf);

--- a/src/search.c
+++ b/src/search.c
@@ -197,6 +197,10 @@ multiline_done:
         log_debug("No match in %s", dir_full_path);
     }
 
+    if (matches_len == 0 && opts.search_stream) {
+        print_context_append(buf, buf_len - 1);
+    }
+
     if (matches_size > 0) {
         free(matches);
     }
@@ -214,6 +218,10 @@ void search_stream(FILE *stream, const char *path) {
     for (i = 1; (line_len = getline(&line, &line_cap, stream)) > 0; i++) {
         opts.stream_line_num = i;
         search_buf(line, line_len, path);
+        if (line[line_len - 1] == '\n') {
+            line_len--;
+        }
+        print_trailing_context(path, line, line_len);
     }
 
     free(line);

--- a/tests/pipecontext.t
+++ b/tests/pipecontext.t
@@ -1,0 +1,29 @@
+Setup:
+
+  $ . $TESTDIR/setup.sh
+  $ mkdir pipecontext_dir
+  $ printf "a\nb\nc\n" > pipecontext_test.txt
+  $ cd pipecontext_dir
+
+Do not use parallel flag, which disables stream input:
+
+  $ unalias ag
+  $ alias ag="$TESTDIR/../ag --nocolor --workers=1"
+
+B flag on pipe:
+
+  $ cat ../pipecontext_test.txt | ag --numbers -B1 b
+  1-a
+  2:b
+
+C flag on pipe:
+
+  $ cat ../pipecontext_test.txt | ag --numbers -C1 b
+  1-a
+  2:b
+  3-c
+
+Just match last line:
+
+  $ cat ../pipecontext_test.txt | ag --numbers c
+  3:c


### PR DESCRIPTION
Includes a new set of tests from #347, `pipecontext.t`.
