### PR TITLE
Add dpr to delphi source files

### DIFF
--- a/src/lang.c
+++ b/src/lang.c
@@ -21,7 +21,7 @@ lang_spec_t langs[] = {
     { "csharp", { "cs" } },
     { "css", { "css" } },
     { "cython", { "pyx", "pxd", "pxi" } },
-    { "delphi", { "pas", "int", "dfm", "nfm", "dof", "dpk", "dproj", "groupproj", "bdsgroup", "bdsproj" } },
+    { "delphi", { "pas", "int", "dfm", "nfm", "dof", "dpk", "dpr", "dproj", "groupproj", "bdsgroup", "bdsproj" } },
     { "ebuild", { "ebuild", "eclass" } },
     { "elisp", { "el" } },
     { "elixir", { "ex", "eex", "exs" } },

--- a/tests/list_file_types.t
+++ b/tests/list_file_types.t
@@ -55,7 +55,7 @@ Language types are output:
         .pyx  .pxd  .pxi
   
     --delphi
-        .pas  .int  .dfm  .nfm  .dof  .dpk  .dproj  .groupproj  .bdsgroup  .bdsproj
+        .pas  .int  .dfm  .nfm  .dof  .dpk  .dpr  .dproj  .groupproj  .bdsgroup  .bdsproj
   
     --ebuild
         .ebuild  .eclass


### PR DESCRIPTION
dpr files are the main source files for delphi projects (like dpk are the main files for delphi package projects.) Add them to the list of the delphi language extensions.
