### PR TITLE
ignore local-domain sockets just like named pipes

### DIFF
--- a/src/ignore.c
+++ b/src/ignore.c
@@ -354,7 +354,7 @@ int filename_filter(const char *path, const struct dirent *dir, void *baton) {
     }
 
     if (is_named_pipe(path, dir)) {
-        log_debug("%s ignored because it's a named pipe", path);
+        log_debug("%s ignored because it's a named pipe or socket", path);
         return 0;
     }
 

--- a/src/util.c
+++ b/src/util.c
@@ -473,7 +473,7 @@ int is_symlink(const char *path, const struct dirent *d) {
 int is_named_pipe(const char *path, const struct dirent *d) {
 #ifdef HAVE_DIRENT_DTYPE
     if (d->d_type != DT_UNKNOWN) {
-        return d->d_type == DT_FIFO;
+        return d->d_type == DT_FIFO || d->d_type == DT_SOCK;
     }
 #endif
     char *full_path;
@@ -484,7 +484,7 @@ int is_named_pipe(const char *path, const struct dirent *d) {
         return FALSE;
     }
     free(full_path);
-    return S_ISFIFO(s.st_mode);
+    return S_ISFIFO(s.st_mode) || S_ISSOCK(s.st_mode);
 }
 
 void ag_asprintf(char **ret, const char *fmt, ...) {


### PR DESCRIPTION
Trivial fix for issue #884 that I reported few weeks ago.
