### PR TITLE
make test instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,13 @@ Run the relevant [`setup-*.exe`](https://cygwin.com/install.html), and select "t
 
         sudo make install
 
+4. Make test (Optional):
+
+    * OS X:
+              brew install clang-format
+              pip install cram
+              make test
+
 
 ### Building a release tarball
 


### PR DESCRIPTION
I was trying to run `make test` locally on OS X and didn't see any information about the dependencies on `clang-format` or `cram` until I read the `CONTRIBUTING.md` file, which wasn't a place I thought to look originally. I've seen documentation for these sorts of dependencies in `README` or `INSTALL` before.