### PR TITLE
Improve multi-workers' performance by 15%

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -122,6 +122,9 @@ int main(int argc, char **argv) {
     if (pthread_mutex_init(&work_queue_mtx, NULL)) {
         die("pthread_mutex_init failed!");
     }
+    if (pthread_key_create(&worker_key, ag_specific_free)) {
+        die("pthread_mutex_init failed!");
+    }
 
     if (opts.casing == CASE_SMART) {
         opts.casing = is_lowercase(opts.query) ? CASE_INSENSITIVE : CASE_SENSITIVE;

--- a/src/main.c
+++ b/src/main.c
@@ -161,8 +161,10 @@ int main(int argc, char **argv) {
     }
 
     if (opts.search_stream) {
+        ag_setspecific();
         search_stream(stdin, "");
     } else {
+        ag_setspecific();
         set_affinity(pthread_self(), num_cores);
         for (i = 0; i < workers_len; i++) {
             workers[i].id = i;

--- a/src/main.c
+++ b/src/main.c
@@ -27,24 +27,24 @@ typedef struct {
 
 static void set_affinity(pthread_t tid, int num_cores) {
 #if defined(HAVE_PTHREAD_SETAFFINITY_NP) && defined(USE_CPU_SET)
-	if (opts.use_thread_affinity) {
-		static int cpu = 0;
-		cpu_set_t cpu_set;
-		CPU_ZERO(&cpu_set);
-		CPU_SET(cpu%num_cores, &cpu_set);
-		int rv = pthread_setaffinity_np(tid, sizeof(cpu_set), &cpu_set);
-		if (rv) {
-			log_err("Error in pthread_setaffinity_np(): %s", strerror(rv));
-			log_err("Performance may be affected. Use --noaffinity to suppress this message.");
-		} else {
-			log_debug("Thread %d set to CPU %d", tid, cpu);
-		}
-		cpu++;
-	} else {
-		log_debug("Thread affinity disabled.");
-	}
+    if (opts.use_thread_affinity) {
+        static int cpu = 0;
+        cpu_set_t cpu_set;
+        CPU_ZERO(&cpu_set);
+        CPU_SET(cpu%num_cores, &cpu_set);
+        int rv = pthread_setaffinity_np(tid, sizeof(cpu_set), &cpu_set);
+        if (rv) {
+            log_err("Error in pthread_setaffinity_np(): %s", strerror(rv));
+            log_err("Performance may be affected. Use --noaffinity to suppress this message.");
+        } else {
+            log_debug("Thread %d set to CPU %d", tid, cpu);
+        }
+        cpu++;
+    } else {
+        log_debug("Thread affinity disabled.");
+    }
 #else
-	log_debug("No CPU affinity support.");
+    log_debug("No CPU affinity support.");
 #endif
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -122,8 +122,8 @@ int main(int argc, char **argv) {
     if (pthread_mutex_init(&work_queue_mtx, NULL)) {
         die("pthread_mutex_init failed!");
     }
-    if (pthread_key_create(&worker_key, ag_specific_free)) {
-        die("pthread_mutex_init failed!");
+    if (pthread_key_create(&worker_key, ag_freespecific)) {
+        die("pthread_key_create failed!");
     }
 
     if (opts.casing == CASE_SMART) {
@@ -222,6 +222,7 @@ int main(int argc, char **argv) {
     pthread_cond_destroy(&files_ready);
     pthread_mutex_destroy(&work_queue_mtx);
     pthread_mutex_destroy(&print_mtx);
+    pthread_key_delete(worker_key);
     cleanup_ignore(root_ignores);
     free(workers);
     for (i = 0; paths[i] != NULL; i++) {

--- a/src/main.c
+++ b/src/main.c
@@ -25,6 +25,29 @@ typedef struct {
     int id;
 } worker_t;
 
+static void set_affinity(pthread_t tid, int num_cores) {
+#if defined(HAVE_PTHREAD_SETAFFINITY_NP) && defined(USE_CPU_SET)
+	if (opts.use_thread_affinity) {
+		static int cpu = 0;
+		cpu_set_t cpu_set;
+		CPU_ZERO(&cpu_set);
+		CPU_SET(cpu%num_cores, &cpu_set);
+		int rv = pthread_setaffinity_np(tid, sizeof(cpu_set), &cpu_set);
+		if (rv) {
+			log_err("Error in pthread_setaffinity_np(): %s", strerror(rv));
+			log_err("Performance may be affected. Use --noaffinity to suppress this message.");
+		} else {
+			log_debug("Thread %d set to CPU %d", tid, cpu);
+		}
+		cpu++;
+	} else {
+		log_debug("Thread affinity disabled.");
+	}
+#else
+	log_debug("No CPU affinity support.");
+#endif
+}
+
 int main(int argc, char **argv) {
     char **base_paths = NULL;
     char **paths = NULL;
@@ -137,30 +160,14 @@ int main(int argc, char **argv) {
     if (opts.search_stream) {
         search_stream(stdin, "");
     } else {
+        set_affinity(pthread_self(), num_cores);
         for (i = 0; i < workers_len; i++) {
             workers[i].id = i;
             int rv = pthread_create(&(workers[i].thread), NULL, &search_file_worker, &(workers[i].id));
             if (rv != 0) {
                 die("Error in pthread_create(): %s", strerror(rv));
             }
-#if defined(HAVE_PTHREAD_SETAFFINITY_NP) && defined(USE_CPU_SET)
-            if (opts.use_thread_affinity) {
-                cpu_set_t cpu_set;
-                CPU_ZERO(&cpu_set);
-                CPU_SET(i % num_cores, &cpu_set);
-                rv = pthread_setaffinity_np(workers[i].thread, sizeof(cpu_set), &cpu_set);
-                if (rv) {
-                    log_err("Error in pthread_setaffinity_np(): %s", strerror(rv));
-                    log_err("Performance may be affected. Use --noaffinity to suppress this message.");
-                } else {
-                    log_debug("Thread %i set to CPU %i", i, i);
-                }
-            } else {
-                log_debug("Thread affinity disabled.");
-            }
-#else
-            log_debug("No CPU affinity support.");
-#endif
+            set_affinity(workers[i].thread, num_cores);
         }
 
 #ifdef HAVE_PLEDGE

--- a/src/main.c
+++ b/src/main.c
@@ -31,7 +31,7 @@ static void set_affinity(pthread_t tid, int num_cores) {
         static int cpu = 0;
         cpu_set_t cpu_set;
         CPU_ZERO(&cpu_set);
-        CPU_SET(cpu%num_cores, &cpu_set);
+        CPU_SET(cpu % num_cores, &cpu_set);
         int rv = pthread_setaffinity_np(tid, sizeof(cpu_set), &cpu_set);
         if (rv) {
             log_err("Error in pthread_setaffinity_np(): %s", strerror(rv));

--- a/src/print.c
+++ b/src/print.c
@@ -25,7 +25,7 @@ static inline int ag_fprintf(FILE *stream, const char *format, ...) {
     ag_specific_t *as = (ag_specific_t *) ag_getspecific();
 
     va_start(args, format);
-    if (as->lock) {
+    if (as->print) {
         ret = fprintf(stream, format, args);
     } else {
         as->ds = ag_vsprintf(as->ds, format, args, &ret);
@@ -40,7 +40,7 @@ static inline size_t ag_fwrite(const void *ptr, size_t size, size_t nmemb,
     size_t ret;
     ag_specific_t *as = (ag_specific_t *) ag_getspecific();
 
-    if (as->lock) {
+    if (as->print) {
         ret = fwrite(ptr, size, nmemb, stream);
     } else {
         as->ds = ag_dsncat(as->ds, ptr, (size * nmemb));
@@ -54,7 +54,7 @@ static inline int ag_fputc(int c, FILE *stream) {
     int ret;
     ag_specific_t *as = (ag_specific_t *) ag_getspecific();
 
-    if (as->lock) {
+    if (as->print) {
         ret = fputc(c, stream);
     } else {
         as->ds = ag_dsncat(as->ds, (char *) &c, sizeof(char));
@@ -68,7 +68,7 @@ static inline int ag_fputs(const char *s, FILE *stream) {
     int ret;
     ag_specific_t *as = (ag_specific_t *) ag_getspecific();
 
-    if (as->lock) {
+    if (as->print) {
         ret = fputs(s, stream);
     } else {
         as->ds = ag_dsncat(as->ds, s, ret=strlen(s));
@@ -122,12 +122,12 @@ void print_binary_file_matches(const char *path) {
     ag_fprintf(out_fd, "Binary file %s matches.\n", path);
 }
 
-void print_file_matches(void) {
+void print_file_matches_in_ds(__attribute__((unused)) const char *path) {
     ag_specific_t *as = (ag_specific_t *) ag_getspecific();
     fprintf(out_fd, "%s", as->ds);
 }
 
-void convert_file_matches(const char *path, const char *buf, const size_t buf_len, const match_t matches[], const size_t matches_len) {
+void convert_file_matches_to_ds(const char *path, const char *buf, const size_t buf_len, const match_t matches[], const size_t matches_len) {
     size_t line = 1;
     char **context_prev_lines = NULL;
     size_t prev_line = 0;

--- a/src/print.c
+++ b/src/print.c
@@ -64,6 +64,19 @@ static inline int ag_fputc(int c, FILE *stream) {
     return ret;
 }
 
+static inline int ag_fputs(const char *s, FILE *stream) {
+    int ret;
+    ag_specific_t *as = (ag_specific_t *) ag_getspecific();
+
+    if (as->lock) {
+        ret = fputs(s, stream);
+    } else {
+        as->ds = ag_dsncat(as->ds, s, ret=strlen(s));
+    }
+
+    return ret;
+}
+
 void print_path(const char *path, const char sep) {
     if (opts.print_path == PATH_PRINT_NOTHING && !opts.vimgrep) {
         return;
@@ -256,7 +269,7 @@ void convert_file_matches(const char *path, const char *buf, const size_t buf_le
                          * before highlight opening */
                         if (j < buf_len && opts.width > 0 && j - prev_line_offset >= opts.width) {
                             if (j < i) {
-                                fputs(truncate_marker, out_fd);
+                                ag_fputs(truncate_marker, out_fd);
                             }
                             ag_fputc('\n', out_fd);
 

--- a/src/print.c
+++ b/src/print.c
@@ -26,7 +26,7 @@ static inline int ag_fprintf(FILE *stream, const char *format, ...) {
 
     va_start(args, format);
     if (as->print) {
-        ret = fprintf(stream, format, args);
+        ret = vfprintf(stream, format, args);
     } else {
         as->ds = ag_vsprintf(as->ds, format, args, &ret);
     }

--- a/src/print.c
+++ b/src/print.c
@@ -22,7 +22,7 @@ const char *truncate_marker = " [...]";
 static inline int ag_fprintf(FILE *stream, const char *format, ...) {
     int ret;
     va_list args;
-    ag_specific_t *as = (ag_specific_t *) ag_getspecific();
+    ag_specific_t *as = (ag_specific_t *)ag_getspecific();
 
     va_start(args, format);
     if (as->print) {
@@ -36,9 +36,9 @@ static inline int ag_fprintf(FILE *stream, const char *format, ...) {
 }
 
 static inline size_t ag_fwrite(const void *ptr, size_t size, size_t nmemb,
-			FILE *stream) {
+                               FILE *stream) {
     size_t ret;
-    ag_specific_t *as = (ag_specific_t *) ag_getspecific();
+    ag_specific_t *as = (ag_specific_t *)ag_getspecific();
 
     if (as->print) {
         ret = fwrite(ptr, size, nmemb, stream);
@@ -52,12 +52,12 @@ static inline size_t ag_fwrite(const void *ptr, size_t size, size_t nmemb,
 
 static inline int ag_fputc(int c, FILE *stream) {
     int ret;
-    ag_specific_t *as = (ag_specific_t *) ag_getspecific();
+    ag_specific_t *as = (ag_specific_t *)ag_getspecific();
 
     if (as->print) {
         ret = fputc(c, stream);
     } else {
-        as->ds = ag_dsncat(as->ds, (char *) &c, sizeof(char));
+        as->ds = ag_dsncat(as->ds, (char *)&c, sizeof(char));
         ret = sizeof(char);
     }
 
@@ -66,12 +66,12 @@ static inline int ag_fputc(int c, FILE *stream) {
 
 static inline int ag_fputs(const char *s, FILE *stream) {
     int ret;
-    ag_specific_t *as = (ag_specific_t *) ag_getspecific();
+    ag_specific_t *as = (ag_specific_t *)ag_getspecific();
 
     if (as->print) {
         ret = fputs(s, stream);
     } else {
-        as->ds = ag_dsncat(as->ds, s, ret=strlen(s));
+        as->ds = ag_dsncat(as->ds, s, ret = strlen(s));
     }
 
     return ret;
@@ -123,7 +123,7 @@ void print_binary_file_matches(const char *path) {
 }
 
 void print_file_matches_in_ds(__attribute__((unused)) const char *path) {
-    ag_specific_t *as = (ag_specific_t *) ag_getspecific();
+    ag_specific_t *as = (ag_specific_t *)ag_getspecific();
     fprintf(out_fd, "%s", as->ds);
 }
 
@@ -141,7 +141,7 @@ void convert_file_matches_to_ds(const char *path, const char *buf, const size_t 
     size_t i, j;
     int in_a_match = FALSE;
     int printing_a_match = FALSE;
-    ag_specific_t *as = (ag_specific_t *) ag_getspecific();
+    ag_specific_t *as = (ag_specific_t *)ag_getspecific();
 
     ag_dsreset(as->ds);
 
@@ -230,8 +230,8 @@ void convert_file_matches_to_ds(const char *path, const char *buf, const size_t 
                             start = 0;
                         }
                         ag_fprintf(out_fd, "%li %li",
-                                start,
-                                (long)(matches[last_printed_match].end - matches[last_printed_match].start));
+                                   start,
+                                   (long)(matches[last_printed_match].end - matches[last_printed_match].start));
                         last_printed_match == cur_match - 1 ? ag_fputc(':', out_fd) : ag_fputc(',', out_fd);
                     }
                     print_line(buf, i, prev_line_offset);

--- a/src/print.h
+++ b/src/print.h
@@ -7,8 +7,8 @@ void print_path(const char *path, const char sep);
 void print_path_count(const char *path, const char sep, const size_t count);
 void print_line(const char *buf, size_t buf_pos, size_t prev_line_offset);
 void print_binary_file_matches(const char *path);
-void convert_file_matches(const char *path, const char *buf, const size_t buf_len, const match_t matches[], const size_t matches_len);
-void print_file_matches(void);
+void convert_file_matches_to_ds(const char *path, const char *buf, const size_t buf_len, const match_t matches[], const size_t matches_len);
+void print_file_matches_in_ds(__attribute__((unused)) const char *path);
 void print_line_number(size_t line, const char sep);
 void print_column_number(const match_t matches[], size_t last_printed_match,
                          size_t prev_line_offset, const char sep);

--- a/src/print.h
+++ b/src/print.h
@@ -7,7 +7,8 @@ void print_path(const char *path, const char sep);
 void print_path_count(const char *path, const char sep, const size_t count);
 void print_line(const char *buf, size_t buf_pos, size_t prev_line_offset);
 void print_binary_file_matches(const char *path);
-void print_file_matches(const char *path, const char *buf, const size_t buf_len, const match_t matches[], const size_t matches_len);
+void convert_file_matches(const char *path, const char *buf, const size_t buf_len, const match_t matches[], const size_t matches_len);
+void print_file_matches(void);
 void print_line_number(size_t line, const char sep);
 void print_column_number(const match_t matches[], size_t last_printed_match,
                          size_t prev_line_offset, const char sep);

--- a/src/search.c
+++ b/src/search.c
@@ -525,7 +525,9 @@ void search_dir(ignores *ig, const char *base_path, const char *path, const int 
                 } else if (opts.match_files) {
                     log_debug("match_files: file_search_regex matched for %s.", dir_full_path);
                     pthread_mutex_lock(&print_mtx);
+                    ag_setprint();
                     print_path(dir_full_path, opts.path_sep);
+                    ag_unsetprint();
                     pthread_mutex_unlock(&print_mtx);
                     opts.match_found = 1;
                     goto cleanup;

--- a/src/search.c
+++ b/src/search.c
@@ -333,6 +333,8 @@ void *search_file_worker(void *i) {
     work_queue_t *queue_item;
     int worker_id = *(int *)i;
 
+    ag_setspecific();
+
     log_debug("Worker %i started", worker_id);
     while (TRUE) {
         pthread_mutex_lock(&work_queue_mtx);

--- a/src/search.c
+++ b/src/search.c
@@ -167,7 +167,11 @@ multiline_done:
         if (binary == -1 && !opts.print_filename_only) {
             binary = is_binary((const void *)buf, buf_len);
         }
+        if (!opts.print_filename_only && !binary) {
+            convert_file_matches(dir_full_path, buf, buf_len, matches, matches_len);
+        }
         pthread_mutex_lock(&print_mtx);
+        ag_lockspecific();
         if (opts.print_filename_only) {
             /* If the --files-without-matches or -L option is passed we should
              * not print a matching line. This option currently sets
@@ -186,8 +190,10 @@ multiline_done:
         } else if (binary) {
             print_binary_file_matches(dir_full_path);
         } else {
-            print_file_matches(dir_full_path, buf, buf_len, matches, matches_len);
+            /* Print file matches in dynamic string */
+            print_file_matches();
         }
+        ag_unlockspecific();
         pthread_mutex_unlock(&print_mtx);
         opts.match_found = 1;
     } else if (opts.search_stream && opts.passthrough) {

--- a/src/search.c
+++ b/src/search.c
@@ -168,10 +168,10 @@ multiline_done:
             binary = is_binary((const void *)buf, buf_len);
         }
         if (!opts.print_filename_only && !binary) {
-            convert_file_matches(dir_full_path, buf, buf_len, matches, matches_len);
+            convert_file_matches_to_ds(dir_full_path, buf, buf_len, matches, matches_len);
         }
         pthread_mutex_lock(&print_mtx);
-        ag_lockspecific();
+        ag_setprint();
         if (opts.print_filename_only) {
             /* If the --files-without-matches or -L option is passed we should
              * not print a matching line. This option currently sets
@@ -191,9 +191,9 @@ multiline_done:
             print_binary_file_matches(dir_full_path);
         } else {
             /* Print file matches in dynamic string */
-            print_file_matches();
+            print_file_matches_in_ds(dir_full_path);
         }
-        ag_unlockspecific();
+        ag_unsetprint();
         pthread_mutex_unlock(&print_mtx);
         opts.match_found = 1;
     } else if (opts.search_stream && opts.passthrough) {

--- a/src/util.c
+++ b/src/util.c
@@ -36,10 +36,10 @@ static ag_ds ag_dsmakeroom(ag_ds s, size_t addlen) {
     } else {
         newlen += MAX_AGDS_PREALLOC;
     }
-    sh = (void *) (s - sizeof(struct ag_dshdr));
+    sh = (void *)(s - sizeof(struct ag_dshdr));
     newsh = ag_realloc(sh, sizeof(struct ag_dshdr) + newlen + 1);
     newsh->free = newlen - len;
-    return (char *) newsh->buf;
+    return (char *)newsh->buf;
 }
 
 ag_ds ag_dsnew(size_t size) {
@@ -63,14 +63,14 @@ void ag_dsreset(ag_ds s) {
         return;
     }
     struct ag_dshdr *sh;
-    sh = (void *) (s - sizeof(struct ag_dshdr));
+    sh = (void *)(s - sizeof(struct ag_dshdr));
     sh->free += sh->len;
     sh->len = 0;
 }
 
 ag_ds ag_vsprintf(ag_ds s, const char *format, va_list ap, int *len) {
     unsigned int ret;
-    struct ag_dshdr *sh = (void *) (s - sizeof(struct ag_dshdr));
+    struct ag_dshdr *sh = (void *)(s - sizeof(struct ag_dshdr));
     size_t curlen = ag_dslen(s);
     va_list aq;
 
@@ -80,7 +80,7 @@ ag_ds ag_vsprintf(ag_ds s, const char *format, va_list ap, int *len) {
     ret = vsnprintf(s + sh->len, sh->free + 1, format, ap);
     if (ret >= sh->free + 1) {
         s = ag_dsmakeroom(s, ret);
-        sh = (void *) (s - sizeof(struct ag_dshdr));
+        sh = (void *)(s - sizeof(struct ag_dshdr));
         ret = vsnprintf(s + sh->len, sh->free + 1, format, aq);
         va_end(aq);
     } else {
@@ -98,7 +98,7 @@ ag_ds ag_dsncat(ag_ds s, const char *t, size_t len) {
     size_t curlen = ag_dslen(s);
 
     s = ag_dsmakeroom(s, len);
-    sh = (void *) (s - sizeof(struct ag_dshdr));
+    sh = (void *)(s - sizeof(struct ag_dshdr));
     memcpy(s + sh->len, t, len);
     sh->len = curlen + len;
     sh->free -= len;
@@ -118,12 +118,12 @@ void *ag_getspecific(void) {
 }
 
 void ag_setprint(void) {
-    ag_specific_t *as = (ag_specific_t *) ag_getspecific();
+    ag_specific_t *as = (ag_specific_t *)ag_getspecific();
     as->print = TRUE;
 }
 
 void ag_unsetprint(void) {
-    ag_specific_t *as = (ag_specific_t *) ag_getspecific();
+    ag_specific_t *as = (ag_specific_t *)ag_getspecific();
     as->print = FALSE;
 }
 

--- a/src/util.c
+++ b/src/util.c
@@ -83,6 +83,8 @@ ag_ds ag_vsprintf(ag_ds s, const char *format, va_list ap, int *len) {
         sh = (void *) (s - sizeof(struct ag_dshdr));
         ret = vsnprintf(s + sh->len, sh->free + 1, format, aq);
         va_end(aq);
+    } else {
+        va_end(aq);
     }
 
     sh->len = curlen + ret;

--- a/src/util.c
+++ b/src/util.c
@@ -74,17 +74,15 @@ int ag_vsprintf(ag_ds *s, const char *format, va_list ap) {
     size_t curlen = ag_dslen(*s);
 
     /* ret is the real length of the string */
-    ret = vsnprintf(*s + sh->len, sh->free, format, ap);
-    if (ret > sh->free) {
+    ret = vsnprintf(*s + sh->len, sh->free + 1, format, ap);
+    if (ret >= sh->free + 1) {
         *s = ag_dsmakeroom(*s, ret);
-		sh = (void *) (*s - sizeof(struct ag_dshdr));
-        ret = vsnprintf(*s + sh->len, sh->free, format, ap);
-    } else if (ret == sh->free) {
-		ret = vsnprintf(*s + sh->len, sh->free + 1, format, ap);
+        sh = (void *) (*s - sizeof(struct ag_dshdr));
+        ret = vsnprintf(*s + sh->len, sh->free + 1, format, ap);
     }
 
-	sh->len = curlen + ret;
-	sh->free -= ret;
+    sh->len = curlen + ret;
+    sh->free -= ret;
     return ret;
 }
 

--- a/src/util.c
+++ b/src/util.c
@@ -99,6 +99,22 @@ int ag_dsncat(ag_ds *s, const char *t, size_t len) {
     return len;
 }
 
+void ag_setspecific(void) {
+    ag_specific_t *as = ag_malloc(sizeof(as));
+    as->lock = FALSE;
+    as->ds = ag_dsnew(INIT_AGDSLEN);
+    pthread_setspecific(worker_key, as);
+}
+
+void *ag_getspecific(void) {
+    return pthread_getspecific(worker_key);
+}
+
+void ag_specific_free(void *data) {
+    ag_dsfree(((ag_specific_t *)data)->ds);
+    free(data);
+}
+
 void *ag_malloc(size_t size) {
     void *ptr = malloc(size);
     CHECK_AND_RETURN(ptr)

--- a/src/util.c
+++ b/src/util.c
@@ -107,8 +107,8 @@ ag_ds ag_dsncat(ag_ds s, const char *t, size_t len) {
 }
 
 void ag_setspecific(void) {
-    ag_specific_t *as = ag_malloc(sizeof(as));
-    as->lock = FALSE;
+    ag_specific_t *as = ag_malloc(sizeof(*as));
+    as->print = FALSE;
     as->ds = ag_dsnew(INIT_AGDSLEN);
     pthread_setspecific(worker_key, as);
 }
@@ -117,14 +117,14 @@ void *ag_getspecific(void) {
     return pthread_getspecific(worker_key);
 }
 
-void ag_lockspecific(void) {
+void ag_setprint(void) {
     ag_specific_t *as = (ag_specific_t *) ag_getspecific();
-    as->lock = TRUE;
+    as->print = TRUE;
 }
 
-void ag_unlockspecific(void) {
+void ag_unsetprint(void) {
     ag_specific_t *as = (ag_specific_t *) ag_getspecific();
-    as->lock = FALSE;
+    as->print = FALSE;
 }
 
 void ag_freespecific(void *data) {

--- a/src/util.h
+++ b/src/util.h
@@ -56,11 +56,14 @@ static inline size_t ag_dsavail(const ag_ds s) {
 ag_ds ag_dsnew(size_t size);
 void ag_dsfree(ag_ds s);
 void ag_dsreset(ag_ds s);
-int ag_vsprintf(ag_ds *s, const char *format, va_list ap);
-int ag_dsncat(ag_ds *s, const char *t, size_t len);
+ag_ds ag_vsprintf(ag_ds s, const char *format, va_list ap, int *len);
+ag_ds ag_dsncat(ag_ds s, const char *t, size_t len);
+
 void ag_setspecific(void);
 void *ag_getspecific(void);
-void ag_specific_free(void *data);
+void ag_lockspecific(void);
+void ag_unlockspecific(void);
+void ag_freespecific(void *data);
 
 void *ag_malloc(size_t size);
 void *ag_realloc(void *ptr, size_t size);

--- a/src/util.h
+++ b/src/util.h
@@ -22,6 +22,32 @@ FILE *out_fd;
 #define FALSE 0
 #endif
 
+#define MAX_AGDS_PREALLOC (1024*1024)
+
+typedef char *ag_ds;
+
+struct ag_dshdr {
+    unsigned int len;
+    unsigned int free;
+    char buf[];
+};
+
+static inline size_t ag_dslen(const ag_ds s) {
+    struct ag_dshdr *sh = (void *) (s - sizeof(struct ag_dshdr));
+    return sh->len;
+}
+
+static inline size_t ag_dsavail(const ag_ds s) {
+    struct ag_dshdr *sh = (void *) (s - sizeof(struct ag_dshdr));
+    return sh->free;
+}
+
+ag_ds ag_dsnew(size_t size);
+void ag_dsfree(ag_ds s);
+void ag_dsreset(ag_ds s);
+int ag_vsprintf(ag_ds *s, const char *format, va_list ap);
+int ag_dsncat(ag_ds *s, const char *t, size_t len);
+
 void *ag_malloc(size_t size);
 void *ag_realloc(void *ptr, size_t size);
 void *ag_calloc(size_t nelem, size_t elsize);

--- a/src/util.h
+++ b/src/util.h
@@ -28,7 +28,7 @@ pthread_key_t worker_key;
 #endif
 
 #define INIT_AGDSLEN 1024
-#define MAX_AGDS_PREALLOC (1024*1024)
+#define MAX_AGDS_PREALLOC (1024 * 1024)
 
 typedef char *ag_ds;
 
@@ -44,12 +44,12 @@ struct ag_dshdr {
 };
 
 static inline size_t ag_dslen(const ag_ds s) {
-    struct ag_dshdr *sh = (void *) (s - sizeof(struct ag_dshdr));
+    struct ag_dshdr *sh = (void *)(s - sizeof(struct ag_dshdr));
     return sh->len;
 }
 
 static inline size_t ag_dsavail(const ag_ds s) {
-    struct ag_dshdr *sh = (void *) (s - sizeof(struct ag_dshdr));
+    struct ag_dshdr *sh = (void *)(s - sizeof(struct ag_dshdr));
     return sh->free;
 }
 

--- a/src/util.h
+++ b/src/util.h
@@ -33,7 +33,7 @@ pthread_key_t worker_key;
 typedef char *ag_ds;
 
 typedef struct {
-    int lock;
+    volatile int print;
     ag_ds ds;
 } ag_specific_t;
 
@@ -61,8 +61,8 @@ ag_ds ag_dsncat(ag_ds s, const char *t, size_t len);
 
 void ag_setspecific(void);
 void *ag_getspecific(void);
-void ag_lockspecific(void);
-void ag_unlockspecific(void);
+void ag_setprint(void);
+void ag_unsetprint(void);
 void ag_freespecific(void *data);
 
 void *ag_malloc(size_t size);

--- a/src/util.h
+++ b/src/util.h
@@ -12,7 +12,12 @@
 #include "log.h"
 #include "options.h"
 
+#ifdef HAVE_PTHREAD_H
+#include <pthread.h>
+#endif
+
 FILE *out_fd;
+pthread_key_t worker_key;
 
 #ifndef TRUE
 #define TRUE 1
@@ -22,9 +27,15 @@ FILE *out_fd;
 #define FALSE 0
 #endif
 
+#define INIT_AGDSLEN 1024
 #define MAX_AGDS_PREALLOC (1024*1024)
 
 typedef char *ag_ds;
+
+typedef struct {
+    int lock;
+    ag_ds ds;
+} ag_specific_t;
 
 struct ag_dshdr {
     unsigned int len;
@@ -47,6 +58,9 @@ void ag_dsfree(ag_ds s);
 void ag_dsreset(ag_ds s);
 int ag_vsprintf(ag_ds *s, const char *format, va_list ap);
 int ag_dsncat(ag_ds *s, const char *t, size_t len);
+void ag_setspecific(void);
+void *ag_getspecific(void);
+void ag_specific_free(void *data);
 
 void *ag_malloc(size_t size);
 void *ag_realloc(void *ptr, size_t size);


### PR DESCRIPTION
Hi, Greer,
I have made some effort to improve the multiple workers' performance.
1. Set all the threads' affinities according to the CPU Threads in Round Robin manner.
2. Threads convert matches into thread specific dynamic string, so that workers can do more works in parallel.

Below are a few test charts I had made on my machines. The performance has been improved by 15%. The directory [linux-master](https://github.com/torvalds/linux) is about 720MB.
- ag --worker=$i -U -Q "#include" linux-master
  -  [Intel® Xeon® Processor E5-2648L](http://ark.intel.com/products/61426/Intel-Xeon-Processor-E5-2648L-20M-1_80-GHz-8_0-GTs-Intel-QPI) vs 16GB MEM
    ![image](https://cloud.githubusercontent.com/assets/4469678/15274414/34ad9a02-1ae3-11e6-91f9-2bb5f0febe0e.png)
  - [Intel® Xeon® Processor E5-2618L v3](http://ark.intel.com/products/83351/Intel-Xeon-Processor-E5-2618L-v3-20M-Cache-2_30-GHz?q=E5-2618L%20v3) \* 2 vs 128GB MEM
    ![image](https://cloud.githubusercontent.com/assets/4469678/15274426/9795fa38-1ae3-11e6-950b-094d4e997a5f.png)
- ag --worker=$i -U "#inc*" linux-master
  - [Intel® Xeon® Processor E5-2648L](http://ark.intel.com/products/61426/Intel-Xeon-Processor-E5-2648L-20M-1_80-GHz-8_0-GTs-Intel-QPI) vs 16GB MEM
    ![image](https://cloud.githubusercontent.com/assets/4469678/15274438/ffe2500a-1ae3-11e6-9ef9-18b98ffd0a24.png)
  - [Intel® Xeon® Processor E5-2618L v3](http://ark.intel.com/products/83351/Intel-Xeon-Processor-E5-2618L-v3-20M-Cache-2_30-GHz?q=E5-2618L%20v3) \* 2 vs 128GB MEM
    ![image](https://cloud.githubusercontent.com/assets/4469678/15274436/d35d1466-1ae3-11e6-96b7-291680e71bb8.png)
