### PR TITLE
Fix --files-with(out)-matches with single filename

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -424,6 +424,7 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
             case 'l':
                 needs_query = 0;
                 opts.print_filename_only = 1;
+                opts.print_path = PATH_PRINT_TOP;
                 break;
             case 'm':
                 opts.max_matches_per_file = atoi(optarg);

--- a/tests/files_with_matches.t
+++ b/tests/files_with_matches.t
@@ -1,0 +1,23 @@
+Setup:
+
+  $ . $TESTDIR/setup.sh
+  $ printf 'foo\n' > ./foo.txt
+  $ printf 'bar\n' > ./bar.txt
+
+Files with matches:
+
+  $ ag --files-with-matches foo foo.txt
+  foo.txt
+  $ ag --files-with-matches foo foo.txt bar.txt
+  foo.txt
+  $ ag --files-with-matches foo bar.txt
+  [1]
+
+Files without matches:
+
+  $ ag --files-without-matches bar foo.txt
+  foo.txt
+  $ ag --files-without-matches bar foo.txt bar.txt
+  foo.txt
+  $ ag --files-without-matches bar bar.txt
+  [1]


### PR DESCRIPTION
print_path() by default doesn't print file names if there was only one
specified on the command line, but when listing files with or without
matches we always want to print it.

Also add a test for --files-with(out)-matches, of which there were none.

Fixes #769
