### PR TITLE
remove shebang from bash completion script

### DIFF
--- a/ag.bashcomp.sh
+++ b/ag.bashcomp.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 _ag() {
   local lngopt shtopt split=false
   local cur prev


### PR DESCRIPTION
now, bash completion script have shabang, but there is not executable.
Therefore, warning occurs in package build of Debian.

see: https://lintian.debian.org/tags/script-not-executable.html

I think that shebang (and executable flag) is unnecessary for bash completion script.
