### PR TITLE
Add fflush call to print_file_matches

### DIFF
--- a/src/print.c
+++ b/src/print.c
@@ -272,6 +272,7 @@ void print_file_matches(const char *path, const char *buf, const size_t buf_len,
         }
     }
     free(context_prev_lines);
+    fflush(out_fd);
 }
 
 void print_line_number(size_t line, const char sep) {


### PR DESCRIPTION
When piping the output of `ag` into another program results are not seen by the other program until the output buffer is full.

This PR adds a `fflush` call to `print_file_matches` so that results are seen as they are generated.
