### PR TITLE
Fix some printf formatting specifiers.

### DIFF
--- a/src/decompress.c
+++ b/src/decompress.c
@@ -61,7 +61,7 @@ static void *decompress_zlib(const void *buf, const int buf_len,
             result = (unsigned char *)realloc(result, result_size * sizeof(unsigned char));
             if (result == NULL) {
                 free(tmp_result);
-                log_err("Unable to allocate %d bytes to decompress file %s", result_size * sizeof(unsigned char), dir_full_path);
+                log_err("Unable to allocate %zd bytes to decompress file %s", result_size * sizeof(unsigned char), dir_full_path);
                 inflateEnd(&stream);
                 goto error_out;
             }
@@ -150,7 +150,7 @@ static void *decompress_lzma(const void *buf, const int buf_len,
             result = (unsigned char *)realloc(result, result_size * sizeof(unsigned char));
             if (result == NULL) {
                 free(tmp_result);
-                log_err("Unable to allocate %d bytes to decompress file %s", result_size * sizeof(unsigned char), dir_full_path);
+                log_err("Unable to allocate %zd bytes to decompress file %s", result_size * sizeof(unsigned char), dir_full_path);
                 goto error_out;
             }
 

--- a/src/ignore.c
+++ b/src/ignore.c
@@ -223,7 +223,7 @@ void load_svn_ignore_patterns(ignores *ig, const char *path) {
         }
 
         if (strncmp(SVN_PROP_IGNORE, key, bytes_read) != 0) {
-            log_debug("key is %s, not %s. skipping %u bytes", key, SVN_PROP_IGNORE, entry_len);
+            log_debug("key is %s, not %s. skipping %zu bytes", key, SVN_PROP_IGNORE, entry_len);
             /* Not the key we care about. fseek and repeat */
             int rv = fseek(fp, entry_len + 1, SEEK_CUR); /* +1 to account for newline. yes I know this is hacky */
             if (rv == -1) {

--- a/src/util.c
+++ b/src/util.c
@@ -203,7 +203,7 @@ size_t invert_matches(const char *buf, const size_t buf_len, match_t matches[], 
     int in_inverted_match = TRUE;
     match_t next_match;
 
-    log_debug("Inverting %u matches.", matches_len);
+    log_debug("Inverting %zu matches.", matches_len);
 
     if (matches_len > 0) {
         next_match = matches[0];
@@ -253,7 +253,7 @@ size_t invert_matches(const char *buf, const size_t buf_len, match_t matches[], 
     }
 
     for (i = 0; i < matches_len; i++) {
-        log_debug("Inverted match %i start %i end %i.", i, matches[i].start, matches[i].end);
+        log_debug("Inverted match %zi start %zi end %zi.", i, matches[i].start, matches[i].end);
     }
 
     return inverted_match_count;


### PR DESCRIPTION
Thanks for your work with this tool. I find it invaluable.

I accidentally stumbled across an issue with these format specifiers when applying [GCC's format attribute](https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-g_t_0040code_007bformat_007d-function-attribute-3232) to the log functions. I can add another commit that makes this change as well if you like, but I wasn't sure if this might cause portability problems for some targets.
