### PR TITLE
Search files named Rakefile with --rake flag

### DIFF
--- a/src/lang.c
+++ b/src/lang.c
@@ -70,7 +70,7 @@ lang_spec_t langs[] = {
     { "python", { "py" } },
     { "qml", { "qml" } },
     { "racket", { "rkt", "ss", "scm" } },
-    { "rake", { "Rakefiles" } },
+    { "rake", { "Rakefile" } },
     { "restructuredtext", { "rst" } },
     { "rs", { "rs" } },
     { "r", { "R", "Rmd", "Rnw", "Rtex", "Rrst" } },

--- a/tests/list_file_types.t
+++ b/tests/list_file_types.t
@@ -202,7 +202,7 @@ Language types are output:
         .rkt  .ss  .scm
   
     --rake
-        .Rakefiles
+        .Rakefile
   
     --restructuredtext
         .rst


### PR DESCRIPTION
Ruby rake commands are typically kept in a file named "Rakefile", not "Rakefiles" (see examples at https://github.com/ruby/rake). This small change changes `--rake` to search the correct file name.