### PR TITLE
modify README with up-to-date installation instructions for redhat systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,7 @@ or
         dnf install the_silver_searcher
 * RHEL7+
 
-        rpm -Uvh http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
-        yum install the_silver_searcher
+        yum install epel-release.noarch the_silver_searcher
 * Gentoo
 
         emerge the_silver_searcher


### PR DESCRIPTION
this is in regard to #928 

The instructions in the README don't seem to work anymore but @jschpp recommended installing the `epel-release.noarch` package before trying `the_silver_searcher`, which works (tested on Centos 7.2). 