### PR TITLE
Accept empty query

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -729,11 +729,12 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
     }
 
     if (accepts_query && argc > 0) {
-        // use the provided query
         if (!needs_query && strlen(argv[0]) == 0) {
-          opts.query = ag_strdup(".");
+            // use default query
+            opts.query = ag_strdup(".");
         } else {
-          opts.query = ag_strdup(argv[0]);
+            // use the provided query
+            opts.query = ag_strdup(argv[0]);
         }
         argc--;
         argv++;

--- a/src/options.c
+++ b/src/options.c
@@ -730,7 +730,11 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
 
     if (accepts_query && argc > 0) {
         // use the provided query
-        opts.query = ag_strdup(argv[0]);
+        if (!needs_query && strlen(argv[0]) == 0) {
+          opts.query = ag_strdup(".");
+        } else {
+          opts.query = ag_strdup(argv[0]);
+        }
         argc--;
         argv++;
     } else if (!needs_query) {


### PR DESCRIPTION
As reported in https://github.com/ggreer/the_silver_searcher/issues/899, when using the -l flag, in the docs it says that we should be able to pass an empty query, but isn't currently allowed.
