### PR TITLE
Fixing bug #915

### DIFF
--- a/src/ignore.c
+++ b/src/ignore.c
@@ -1,6 +1,7 @@
 #include <ctype.h>
 #include <dirent.h>
 #include <limits.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -278,6 +279,7 @@ static int path_ignore_search(const ignores *ig, const char *path, const char *f
     char *temp;
     size_t i;
     int match_pos;
+    bool unignore = false;
 
     match_pos = binary_search(filename, ig->names, 0, ig->names_len);
     if (match_pos >= 0) {
@@ -330,12 +332,27 @@ static int path_ignore_search(const ignores *ig, const char *path, const char *f
     }
 
     for (i = 0; i < ig->regexes_len; i++) {
-        if (fnmatch(ig->regexes[i], filename, fnmatch_flags) == 0) {
+        if (strcmp(ig->regexes[i], "*") == 0) {
+            log_debug("Ignoring %s to prevent ignoring everything", ig->regexes[i]);
+            size_t j;
+            for (j = 0; j < ig->regexes_len; j++) {
+                if (ig->regexes[j][0] == '!') {
+                    if (fnmatch(ig->regexes[j]+1, filename, fnmatch_flags) == 0) {
+                        log_debug("File un-ignored due to matching un-ignore pattern %s", ig->regexes[j]);
+                        unignore = true;
+                        // Since this is hot code, fast break out of this loop
+                        goto skip;
+                    }
+                }
+            }
+            return 1;
+        } else if (fnmatch(ig->regexes[i], filename, fnmatch_flags) == 0) {
             log_debug("file %s ignored because name matches regex pattern %s", filename, ig->regexes[i]);
             free(temp);
             return 1;
         }
-        log_debug("pattern %s doesn't match file %s", ig->regexes[i], filename);
+        skip:
+        log_debug("pattern %s doesn't match file %s.  Unignore match?: %s", ig->regexes[i], filename, unignore ? "true" : "false");
     }
 
     int rv = ackmate_dir_match(temp);

--- a/tests/ignore_gitignore_wildcard.t
+++ b/tests/ignore_gitignore_wildcard.t
@@ -1,0 +1,12 @@
+Setup:
+
+  $ . $TESTDIR/setup.sh
+  $ export HOME=$PWD
+  $ printf '[core]\nexcludesfile = ~/.gitignore.global' >> $HOME/.gitconfig
+  $ printf '*\n!PATTERN_MARKER\n' > .gitignore.global
+  $ printf 'testing1234' > PATTERN_MARKER
+
+Test that the unignore works correctly:
+
+  $ ag -l . --debug | grep "PATTERN_MARKER.*Unignore match?: true"
+  DEBUG: pattern * doesn't match file PATTERN_MARKER.  Unignore match?: true


### PR DESCRIPTION
Wildcard ignores cause ag to discard all result files.  This commit
addresses this issue by first checking if a wildcard '*' gitignore is
present then performs a negative check against all files that would be
disqualified by the wildcard ignore with any negative-ignores
(represented by entries starting with '!' in a .gitignore file).  If a
negative match is found, the previous match against '*' is skipped.