### PR TITLE
options.c: ignored pipe no longer blocks context

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -810,6 +810,10 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
         }
     }
 
+    if (opts.passthrough) {
+        opts.print_line_numbers = 0;
+    }
+
 #ifdef _WIN32
     windows_use_ansi(opts.color_win_ansi);
 #endif

--- a/src/options.c
+++ b/src/options.c
@@ -739,14 +739,6 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
         }
     }
 
-    if (opts.search_stream) {
-        opts.print_break = 0;
-        opts.print_path = PATH_PRINT_NOTHING;
-        if (opts.print_line_numbers != 2) {
-            opts.print_line_numbers = 0;
-        }
-    }
-
     if (accepts_query && argc > 0) {
         // use the provided query
         opts.query = ag_strdup(argv[0]);
@@ -809,6 +801,14 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
     }
     (*paths)[i] = NULL;
     (*base_paths)[i] = NULL;
+
+    if (opts.search_stream) {
+        opts.print_break = 0;
+        opts.print_path = PATH_PRINT_NOTHING;
+        if (opts.print_line_numbers != 2) {
+            opts.print_line_numbers = 0;
+        }
+    }
 
 #ifdef _WIN32
     windows_use_ansi(opts.color_win_ansi);

--- a/tests/ignore_pipe.t
+++ b/tests/ignore_pipe.t
@@ -1,0 +1,9 @@
+Setup:
+
+  $ . $TESTDIR/setup.sh
+  $ printf 'blah\n' > ./blah.txt
+
+Pipe + file = ignore pipe:
+
+  $ printf 'bleh' | ag 'bl' ./blah.txt
+  1:blah


### PR DESCRIPTION
Before:

```
$ true | ag -nH hello file.txt
hello
```

After:

```
$ true | ag -nH hello file.txt
file.txt
1:hello
```

If `ag` gets a pipe and files, it will only search the files.
But before, the presence of an ignored pipe would inhibit line number
and filename printing.

Fixes #943.

This PR also includes a test for this behavior, `ignore_pipe.t`, and fixes a test that was relying on this bug.
