### PR TITLE
Fix instructions for installing on RHEL7

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ or
         dnf install the_silver_searcher
 * RHEL7+
 
-        yum install epel-release.noarch the_silver_searcher
+        yum install epel-release && yum install the_silver_searcher
 * Gentoo
 
         emerge the_silver_searcher


### PR DESCRIPTION
The existing instructions don't work, because yum resolves available
packages at the start of a run, and the Ag package isn't available
until _after_ epel-release is installed. To make it work you have to
install epel-release to make the epel repo available, and then do a
separate yum invocation to install Ag from that newly-available repo