### PR TITLE
Print empty files with empty query and -ul

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -258,7 +258,11 @@ void search_file(const char *file_full_path) {
     f_len = statbuf.st_size;
 
     if (f_len == 0) {
-        log_debug("Skipping %s: file is empty.", file_full_path);
+        if (opts.query[0] == '.' && opts.query_len == 1 && !opts.literal && opts.search_all_files) {
+            search_buf(buf, f_len, file_full_path);
+        } else {
+            log_debug("Skipping %s: file is empty.", file_full_path);
+        }
         goto cleanup;
     }
 

--- a/tests/empty_match.t
+++ b/tests/empty_match.t
@@ -11,3 +11,12 @@ Zero-length match on an empty file should fail silently with return code 1
 A genuine zero-length match should succeed:
   $ ag "^" nonempty.txt
   1:foo
+
+Empty files should be listed with --unrestricted --files-with-matches (-ul)
+  $ ag -lu --stats | sed '$d' # Remove the last line about timing which will differ
+  empty.txt
+  nonempty.txt
+  2 matches
+  2 files contained matches
+  2 files searched
+  4 bytes searched


### PR DESCRIPTION
Fix issue #956:

`ag -ul` with an empty query should list all filenames, as the manual
says:

  -u --unrestricted
      Search _all_ files. ...

  -l --files-with-matches
      ...An empty query will print all files that would be searched.
