### PR TITLE
Output logging messages all in one shot

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -45,24 +45,29 @@ void vplog(const unsigned int level, const char *fmt, va_list args) {
 
     FILE *stream = out_fd;
 
+    char *level_fmt = malloc(strlen(fmt) + 9);
+    level_fmt[0] = 0;
     switch (level) {
         case LOG_LEVEL_DEBUG:
-            fprintf(stream, "DEBUG: ");
+            strcat(level_fmt, "DEBUG: ");
             break;
         case LOG_LEVEL_MSG:
-            fprintf(stream, "MSG: ");
+            strcat(level_fmt, "MSG: ");
             break;
         case LOG_LEVEL_WARN:
-            fprintf(stream, "WARN: ");
+            strcat(level_fmt, "WARN: ");
             break;
         case LOG_LEVEL_ERR:
             stream = stderr;
-            fprintf(stream, "ERR: ");
+            strcat(level_fmt, "ERR: ");
             break;
     }
+    strcat(level_fmt, fmt);
+    strcat(level_fmt, "\n");
 
-    vfprintf(stream, fmt, args);
-    fprintf(stream, "\n");
+    vfprintf(stream, level_fmt, args);
+
+    free(level_fmt);
 }
 
 void plog(const unsigned int level, const char *fmt, ...) {


### PR DESCRIPTION
ag uses multiple processes, so outputting messages piecemeal caused different messages to get interleaved.  That made them hard to use and interfered with downstream tools.

This commit reduces the likelihood of the problem (I used to see the interleaving many times per day), but I have never seen it in weeks of use with this patch), by constructing an entire line of output before passing the whole thing to vprintf.  The performance impact is negligible.