### PR TITLE
Use the print mutex when logging.

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -43,6 +43,7 @@ void vplog(const unsigned int level, const char *fmt, va_list args) {
         return;
     }
 
+    pthread_mutex_lock(&print_mtx);
     FILE *stream = out_fd;
 
     switch (level) {
@@ -63,6 +64,7 @@ void vplog(const unsigned int level, const char *fmt, va_list args) {
 
     vfprintf(stream, fmt, args);
     fprintf(stream, "\n");
+    pthread_mutex_unlock(&print_mtx);
 }
 
 void plog(const unsigned int level, const char *fmt, ...) {

--- a/src/log.h
+++ b/src/log.h
@@ -3,6 +3,14 @@
 
 #include <stdarg.h>
 
+#include "config.h"
+
+#ifdef HAVE_PTHREAD_H
+#include <pthread.h>
+#endif
+
+pthread_mutex_t print_mtx;
+
 enum log_level {
     LOG_LEVEL_DEBUG = 10,
     LOG_LEVEL_MSG = 20,

--- a/src/search.h
+++ b/src/search.h
@@ -44,7 +44,6 @@ work_queue_t *work_queue;
 work_queue_t *work_queue_tail;
 int done_adding_files;
 pthread_cond_t files_ready;
-pthread_mutex_t print_mtx;
 pthread_mutex_t stats_mtx;
 pthread_mutex_t work_queue_mtx;
 


### PR DESCRIPTION
 Fixes occasional glitches in log messages. Related to #959.