### PR TITLE
Prefer .ignore to .agignore.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Do you know C? I invite you to pair with me to [help me get to Ag 1.0](http://ge
 
 * It is an order of magnitude faster than `ack`.
 * It ignores file patterns from your `.gitignore` and `.hgignore`.
-* If there are files in your source repo you don't want to search, just add their patterns to a `.agignore` file. (\*cough\* extern \*cough\*)
+* If there are files in your source repo you don't want to search, just add their patterns to a `.ignore` file. (\*cough\* `*.min.js` \*cough\*)
 * The command name is 33% shorter than `ack`, and all keys are on the home row!
 
 Ag is quite stable now. Most changes are new features, minor bug fixes, or performance improvements. It's much faster than Ack in my benchmarks:

--- a/doc/ag.1.md
+++ b/doc/ag.1.md
@@ -153,12 +153,12 @@ Recursively search for PATTERN in PATH. Like grep or ack, but faster.
     Search all text files. This doesn't include hidden files.
 
   * `-u --unrestricted`:
-    Search *all* files. This ignores .agignore, .gitignore, etc. It searches
+    Search *all* files. This ignores .ignore, .gitignore, etc. It searches
     binary and hidden files as well.
 
   * `-U --skip-vcs-ignores`:
     Ignore VCS ignore files (.gitignore, .hgignore, svn:ignore), but still
-    use .agignore.
+    use .ignore.
 
   * `-v --invert-match`:
     Match every line *not* containing the specified pattern.
@@ -195,13 +195,13 @@ run `ag --list-file-types`.
 ## IGNORING FILES
 
 By default, ag will ignore files whose names match patterns in .gitignore,
-.hgignore, or .agignore. These files can be anywhere in the directories being
+.hgignore, or .ignore. These files can be anywhere in the directories being
 searched. Ag also ignores files matched by the svn:ignore property if `svn
 --version` is 1.6 or older.  Finally, ag looks in $HOME/.agignore for ignore
 patterns. Binary files are ignored by default as well.
 
 If you want to ignore .gitignore, .hgignore, and svn:ignore, but still take
-.agignore into account, use `-U`.
+.ignore into account, use `-U`.
 
 Use the `-t` option to search all text files; `-a` to search all files; and `-u`
 to search all, including hidden files.

--- a/src/ignore.c
+++ b/src/ignore.c
@@ -28,9 +28,11 @@ const char *evil_hardcoded_ignore_files[] = {
     NULL
 };
 
-/* Warning: changing the first string will break skip_vcs_ignores. */
+/* Warning: changing the first two strings will break skip_vcs_ignores. */
 const char *ignore_pattern_files[] = {
+    /* Warning: .agignore will one day be removed in favor of .ignore */
     ".agignore",
+    ".ignore",
     ".gitignore",
     ".git/info/exclude",
     ".hgignore",

--- a/src/options.c
+++ b/src/options.c
@@ -99,10 +99,10 @@ Search Options:\n\
                           uppercase characters (Enabled by default)\n\
      --search-binary      Search binary files for matches\n\
   -t --all-text           Search all text files (doesn't include hidden files)\n\
-  -u --unrestricted       Search all files (ignore .agignore, .gitignore, etc.;\n\
+  -u --unrestricted       Search all files (ignore .ignore, .gitignore, etc.;\n\
                           searches binary and hidden files as well)\n\
   -U --skip-vcs-ignores   Ignore VCS ignore files\n\
-                          (.gitignore, .hgignore, .svnignore; still obey .agignore)\n\
+                          (.gitignore, .hgignore, .svnignore; still obey .ignore)\n\
   -v --invert-match\n\
   -w --word-regexp        Only match whole words\n\
   -W --width NUM          Truncate match lines after NUM characters\n\

--- a/src/search.c
+++ b/src/search.c
@@ -448,8 +448,8 @@ void search_dir(ignores *ig, const char *base_path, const char *path, const int 
         return;
     }
 
-    /* find agignore/gitignore/hgignore/etc files to load ignore patterns from */
-    for (i = 0; opts.skip_vcs_ignores ? (i == 0) : (ignore_pattern_files[i] != NULL); i++) {
+    /* find .*ignore files to load ignore patterns from */
+    for (i = 0; opts.skip_vcs_ignores ? (i <= 1) : (ignore_pattern_files[i] != NULL); i++) {
         ignore_file = ignore_pattern_files[i];
         ag_asprintf(&dir_full_path, "%s/%s", path, ignore_file);
         if (strcmp(SVN_DIR, ignore_file) == 0) {

--- a/src/util.c
+++ b/src/util.c
@@ -292,6 +292,7 @@ int is_binary(const void *buf, const size_t buf_len) {
     size_t i;
 
     if (buf_len == 0) {
+        /* Is an empty file binary? Is it text? */
         return 0;
     }
 

--- a/tests/ds_store_ignore.t
+++ b/tests/ds_store_ignore.t
@@ -1,7 +1,7 @@
 Setup.
   $ . $TESTDIR/setup.sh
   $ mkdir -p dir0/dir1/dir2
-  $ printf '*.DS_Store\n' > dir0/.gitignore
+  $ printf '*.DS_Store\n' > dir0/.ignore
   $ printf 'blah\n' > dir0/dir1/dir2/blah.txt
   $ touch dir0/dir1/.DS_Store
 

--- a/tests/ignore_abs_path.t
+++ b/tests/ignore_abs_path.t
@@ -4,7 +4,7 @@ Setup:
   $ mkdir -p ./a/b/c
   $ printf 'whatever1\n' > ./a/b/c/blah.yml
   $ printf 'whatever2\n' > ./a/b/foo.yml
-  $ printf '/a/b/foo.yml\n' > ./.gitignore
+  $ printf '/a/b/foo.yml\n' > ./.ignore
 
 Ignore foo.yml but not blah.yml:
 

--- a/tests/ignore_absolute_search_path_with_glob.t
+++ b/tests/ignore_absolute_search_path_with_glob.t
@@ -3,7 +3,7 @@ Setup:
   $ . $TESTDIR/setup.sh
   $ mkdir -p parent/multi-part
   $ printf 'match1\n' > parent/multi-part/file1.txt
-  $ printf 'parent/multi-*\n' > .gitignore
+  $ printf 'parent/multi-*\n' > .ignore
 
 # Ignore directory specified by glob:
 

--- a/tests/ignore_backups.t
+++ b/tests/ignore_backups.t
@@ -18,8 +18,8 @@ Setup:
   $ printf 'whatever14\n' > ./foo.yml~
   $ printf 'whatever15\n' > ./.foo.yml.swp
   $ printf 'whatever16\n' > ./.foo.yml.swo
-  $ printf '*~\n'         > ./.gitignore
-  $ printf '*.sw[po]\n'   >> ./.gitignore
+  $ printf '*~\n'         > ./.ignore
+  $ printf '*.sw[po]\n'   >> ./.ignore
 
 Ignore all files except foo.yml
 

--- a/tests/ignore_examine_parent_ignorefiles.t
+++ b/tests/ignore_examine_parent_ignorefiles.t
@@ -3,7 +3,7 @@ Setup:
   $ . $TESTDIR/setup.sh
   $ mkdir -p subdir
   $ printf 'match1\n' > subdir/file1.txt
-  $ printf 'file1.txt\n' > .gitignore
+  $ printf 'file1.txt\n' > .ignore
 
 Ignore directory specified by name:
 

--- a/tests/ignore_extensions.t
+++ b/tests/ignore_extensions.t
@@ -1,8 +1,8 @@
 Setup:
 
   $ . $TESTDIR/setup.sh
-  $ printf '*.js\n' > .gitignore
-  $ printf '\n*.test.txt\n' >> .gitignore
+  $ printf '*.js\n' > .ignore
+  $ printf '\n*.test.txt\n' >> .ignore
   $ printf 'targetA\n' > something.js
   $ printf 'targetB\n' > aFile.test.txt
   $ printf 'targetC\n' > aFile.txt

--- a/tests/ignore_vcs.t
+++ b/tests/ignore_vcs.t
@@ -1,0 +1,19 @@
+Setup:
+
+  $ . $TESTDIR/setup.sh
+  $ printf 'whatever1\n' > ./always.txt
+  $ printf 'whatever2\n' > ./git.txt
+  $ printf 'whatever3\n' > ./text.txt
+  $ printf 'git.txt\n' > ./.gitignore
+  $ printf 'text.*\n' > ./.ignore
+
+Obey .gitignore and .ignore patterns:
+
+  $ ag whatever .
+  always.txt:1:whatever1
+
+Ignore .gitignore patterns but not .ignore patterns:
+
+  $ ag -U whatever . | sort
+  always.txt:1:whatever1
+  git.txt:1:whatever2

--- a/the_silver_searcher.spec.in
+++ b/the_silver_searcher.spec.in
@@ -22,7 +22,7 @@ An attempt to make something better than ack (which itself is better than grep).
 Why use Ag?
 * It searches code about 3–5× faster than ack.
 * It ignores file patterns from your .gitignore and .hgignore.
-* If there are files in your source repo you don't want to search, just add their patterns to a .agignore file. *cough* extern *cough*
+* If there are files in your source repo you don't want to search, just add their patterns to a .ignore file. *cough* extern *cough*
 * The command name is 33% shorter than ack!
 
 How is it so fast?


### PR DESCRIPTION
Thanks to discussion on https://news.ycombinator.com/item?id=12564442, @BurntSushi and I agreed on a common file name for ignore patterns. [He's made his PR for ripgrep]( https://github.com/BurntSushi/ripgrep/issues/40). This is ag's counterpart.

To those who worry about change: Please don't! It will be a long time before .agignore is no longer obeyed, if ever.