### PR TITLE
escape usage in markdown

### DIFF
--- a/doc/ag.1.md
+++ b/doc/ag.1.md
@@ -3,7 +3,7 @@ ag(1) -- The Silver Searcher. Like ack, but faster.
 
 ## SYNOPSIS
 
-`ag` [<file-type>] [<options>] PATTERN [PATH]
+`ag` [\<file-type>] [\<options>] PATTERN [PATH]
 
 ## DESCRIPTION
 


### PR DESCRIPTION
Usage doesn't render properly on Github unless we escape the `<>`