### PR TITLE
Support both --no-<option> and --no<option> (addresses #980)

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -260,20 +260,30 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
         { "max-count", required_argument, NULL, 'm' },
         { "mmap", no_argument, &opts.mmap, TRUE },
         { "multiline", no_argument, &opts.multiline, TRUE },
-        /* "no-" is deprecated. Remove these eventually. */
-        { "no-numbers", no_argument, &opts.print_line_numbers, FALSE },
-        { "no-recurse", no_argument, NULL, 'n' },
+        /* Accept both --no-* and --no* forms for convenience/BC */
+        { "no-affinity", no_argument, &opts.use_thread_affinity, 0 },
         { "noaffinity", no_argument, &opts.use_thread_affinity, 0 },
+        { "no-break", no_argument, &opts.print_break, 0 },
         { "nobreak", no_argument, &opts.print_break, 0 },
+        { "no-color", no_argument, &opts.color, 0 },
         { "nocolor", no_argument, &opts.color, 0 },
+        { "no-filename", no_argument, NULL, 0 },
         { "nofilename", no_argument, NULL, 0 },
+        { "no-follow", no_argument, &opts.follow_symlinks, 0 },
         { "nofollow", no_argument, &opts.follow_symlinks, 0 },
+        { "no-group", no_argument, &group, 0 },
         { "nogroup", no_argument, &group, 0 },
+        { "no-heading", no_argument, &opts.print_path, PATH_PRINT_EACH_LINE },
         { "noheading", no_argument, &opts.print_path, PATH_PRINT_EACH_LINE },
+        { "no-mmap", no_argument, &opts.mmap, FALSE },
         { "nommap", no_argument, &opts.mmap, FALSE },
+        { "no-multiline", no_argument, &opts.multiline, FALSE },
         { "nomultiline", no_argument, &opts.multiline, FALSE },
+        { "no-numbers", no_argument, &opts.print_line_numbers, FALSE },
         { "nonumbers", no_argument, &opts.print_line_numbers, FALSE },
+        { "no-pager", no_argument, NULL, 0 },
         { "nopager", no_argument, NULL, 0 },
+        { "no-recurse", no_argument, NULL, 'n' },
         { "norecurse", no_argument, NULL, 'n' },
         { "null", no_argument, NULL, '0' },
         { "numbers", no_argument, &opts.print_line_numbers, 2 },
@@ -505,9 +515,17 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
                 } else if (strcmp(longopts[opt_index].name, "ignore") == 0) {
                     add_ignore_pattern(root_ignores, optarg);
                     break;
+                } else if (strcmp(longopts[opt_index].name, "no-filename") == 0) {
+                    opts.print_path = PATH_PRINT_NOTHING;
+                    opts.print_line_numbers = FALSE;
+                    break;
                 } else if (strcmp(longopts[opt_index].name, "nofilename") == 0) {
                     opts.print_path = PATH_PRINT_NOTHING;
                     opts.print_line_numbers = FALSE;
+                    break;
+                } else if (strcmp(longopts[opt_index].name, "no-pager") == 0) {
+                    out_fd = stdout;
+                    opts.pager = NULL;
                     break;
                 } else if (strcmp(longopts[opt_index].name, "nopager") == 0) {
                     out_fd = stdout;

--- a/src/options.c
+++ b/src/options.c
@@ -515,19 +515,13 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
                 } else if (strcmp(longopts[opt_index].name, "ignore") == 0) {
                     add_ignore_pattern(root_ignores, optarg);
                     break;
-                } else if (strcmp(longopts[opt_index].name, "no-filename") == 0) {
+                } else if (strcmp(longopts[opt_index].name, "no-filename") == 0 ||
+                           strcmp(longopts[opt_index].name, "nofilename") == 0) {
                     opts.print_path = PATH_PRINT_NOTHING;
                     opts.print_line_numbers = FALSE;
                     break;
-                } else if (strcmp(longopts[opt_index].name, "nofilename") == 0) {
-                    opts.print_path = PATH_PRINT_NOTHING;
-                    opts.print_line_numbers = FALSE;
-                    break;
-                } else if (strcmp(longopts[opt_index].name, "no-pager") == 0) {
-                    out_fd = stdout;
-                    opts.pager = NULL;
-                    break;
-                } else if (strcmp(longopts[opt_index].name, "nopager") == 0) {
+                } else if (strcmp(longopts[opt_index].name, "no-pager") == 0 ||
+                           strcmp(longopts[opt_index].name, "nopager") == 0) {
                     out_fd = stdout;
                     opts.pager = NULL;
                     break;

--- a/tests/negated_options.t
+++ b/tests/negated_options.t
@@ -1,0 +1,28 @@
+Setup:
+
+  $ . "${TESTDIR}/setup.sh"
+
+Should accept both --no-<option> and --no<option> forms.
+
+(Here we're just parsing out all of the options listed in the `ag` usage help
+that can be negated with 'no', and checking to make sure that each of them works
+with either form. This is slightly convoluted, but it should ensure that any
+options added in the future meet this requirement — assuming they're added to
+the usage help, anyway.)
+
+  $ test_negated_options() {
+  >   ag --help 2>&1 |
+  >   grep -oiE -- '--\[no-?\][a-z0-9_-]+' |
+  >   cut -d ']' -f '2' |
+  >   sort -u |
+  >   while read option; do
+  >     # The point here is that if the option we're testing is illegal, `ag`
+  >     # will catch it on invocation and dump the usage help, causing the test
+  >     # to produce output and thus fail
+  >     printf 'foo\n' | ag "--no-${option}" -v '^foo$' 2>&1
+  >     printf 'foo\n' | ag "--no${option}"  -v '^foo$' 2>&1
+  >   done
+  >   return 0
+  > }
+  $ test_negated_options
+


### PR DESCRIPTION
This PR addresses feature request #980.

ETA: Added some annotations to the diff, please review

ETA2: I left all of the documentation as it was (they all say `--[no]option`) — let me know if you want me to change that though