### PR TITLE
Document use of '--' to end option parsing (addresses #982 &al.)

### DIFF
--- a/doc/ag.1
+++ b/doc/ag.1
@@ -277,5 +277,8 @@ Use the \fB\-t\fR option to search all text files; \fB\-a\fR to search all files
 .P
 \fBag foo /bar/\fR: Find matches for "foo" in path /bar/\.
 .
+.P
+\fBag \-\- \-\-foo\fR: Find matches for "\-\-foo" in the current directory\. (As with most UNIX command line utilities, "\-\-" is used to signify that the remaining arguments should not be treated as options\.)
+.
 .SH "SEE ALSO"
 grep(1)

--- a/doc/ag.1.md
+++ b/doc/ag.1.md
@@ -244,6 +244,11 @@ to search all, including hidden files.
 `ag foo /bar/`:
   Find matches for "foo" in path /bar/.
 
+`ag -- --foo`:
+  Find matches for "--foo" in the current directory. (As with most UNIX command
+  line utilities, "--" is used to signify that the remaining arguments should
+  not be treated as options.)
+
 ## SEE ALSO
 
 grep(1)


### PR DESCRIPTION
I was looking through the list of issues and i noticed that people very regularly get confused about how to search for patterns beginning with a hyphen. The latest is #982, where someone suggested adding a note to the man page. That's all this PR does.