### PR TITLE
Support procfs and sysfs on Linux (addresses #446)

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -9,6 +9,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifdef __linux__
+#include <sys/statfs.h>
+#include <linux/magic.h>
+#endif
 #ifdef _WIN32
 #include <windows.h>
 #else

--- a/tests/procfs.t
+++ b/tests/procfs.t
@@ -1,0 +1,17 @@
+Setup:
+
+  $ . "${TESTDIR}/setup.sh"
+
+Should support searching procfs on Linux.
+
+  $ test_procfs() {
+  >   # This test only applies to Linux — skip it if we don't have that
+  >   uname | grep -qiF 'linux' || exit 80
+  >   # Can't see how this would happen, but just in case
+  >   grep -qsE '[0-9]' /proc/uptime || exit 80
+  >   # /proc/uptime on Linux looks like this: 532030.52 1054207.60
+  >   ag '^[\d.]+\s+[\d.]+$' /proc/uptime
+  >   return 0
+  > }
+  $ test_procfs
+  1:[\d.]+\s+[\d.]+ (re)


### PR DESCRIPTION
Hey again. I was trying to use `ag` to search `/proc` on Linux (maybe for the first time, since i never noticed a problem before), and discovered that it can't actually do that. Someone made a ticket for it a while ago, #446. It wasn't super hard to add support for them — though i'm worried you might find it too hacky... 🙍

Let me know what you think. I'm open to suggestions if it is in fact a weird way of doing it.