### PR TITLE
Fix typo in manual page: 'seacrhing' -> 'searching'.

### DIFF
--- a/doc/ag.1
+++ b/doc/ag.1
@@ -184,7 +184,7 @@ Do not parse PATTERN as a regular expression\. Try to match it literally\.
 .
 .TP
 \fB\-r \-\-recurse\fR
-Recurse into directories when seacrhing\. Default is true\.
+Recurse into directories when searching\. Default is true\.
 .
 .TP
 \fB\-s \-\-case\-sensitive\fR


### PR DESCRIPTION
This fixes a typo in the `-r --recurse` option description.
