### PR TITLE
Add installation of dependencies with Arch

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ Run the relevant [`setup-*.exe`](https://cygwin.com/install.html), and select "t
 
             yum -y groupinstall "Development Tools"
             yum -y install pcre-devel xz-devel
+    * Arch
+
+            pacman -S automake pkg-config pcre xz
     * Windows: It's complicated. See [this wiki page](https://github.com/ggreer/the_silver_searcher/wiki/Windows).
 2. Run the build script (which just runs aclocal, automake, etc):
 


### PR DESCRIPTION
The names of the packages are the same as in OS X:

```
$ sudo pacman -S automake pkg-config pcre xz
warning: automake-1.15-2 is up to date -- reinstalling
warning: pkg-config-0.29.1-2 is up to date -- reinstalling
warning: pcre-8.39-1 is up to date -- reinstalling
warning: xz-5.2.2-1 is up to date -- reinstalling
```