### PR TITLE
Added GLSL file types

### DIFF
--- a/src/lang.c
+++ b/src/lang.c
@@ -30,6 +30,7 @@ lang_spec_t langs[] = {
     { "fortran", { "f", "f77", "f90", "f95", "f03", "for", "ftn", "fpp" } },
     { "fsharp", { "fs", "fsi", "fsx" } },
     { "gettext", { "po", "pot", "mo" } },
+    { "glsl", { "vert", "tesc", "tese", "geom", "frag", "comp" } },
     { "go", { "go" } },
     { "groovy", { "groovy", "gtmpl", "gpp", "grunit" } },
     { "haml", { "haml" } },

--- a/tests/list_file_types.t
+++ b/tests/list_file_types.t
@@ -81,6 +81,9 @@ Language types are output:
     --gettext
         .po  .pot  .mo
   
+    --glsl
+        .vert  .tesc  .tese  .geom  .frag  .comp
+  
     --go
         .go
   


### PR DESCRIPTION
Added GLSL file types based on official GLSL validator names, i.e. ".vert", ".tesc", ".tese", ".geom", ".frag", ".comp".