### PR TITLE
add protobuf file type

### DIFF
--- a/src/lang.c
+++ b/src/lang.c
@@ -66,6 +66,7 @@ lang_spec_t langs[] = {
     { "php", { "php", "phpt", "php3", "php4", "php5", "phtml" } },
     { "pike", { "pike", "pmod" } },
     { "plone", { "pt", "cpt", "metadata", "cpy", "py", "xml", "zcml" } },
+    { "proto", { "proto" } },
     { "puppet", { "pp" } },
     { "python", { "py" } },
     { "qml", { "qml" } },

--- a/tests/list_file_types.t
+++ b/tests/list_file_types.t
@@ -189,6 +189,9 @@ Language types are output:
     --plone
         .pt  .cpt  .metadata  .cpy  .py  .xml  .zcml
   
+    --proto
+        .proto
+  
     --puppet
         .pp
   


### PR DESCRIPTION
adds support for searching protocol buffer files with .proto extension.