### PR TITLE
Minimize malloc calls in ag_scandir

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -578,8 +578,6 @@ void search_dir(ignores *ig, const char *base_path, const char *path, const int 
         }
 
     cleanup:
-        free(dir);
-        dir = NULL;
         if (queue_item == NULL) {
             free(dir_full_path);
             dir_full_path = NULL;
@@ -588,6 +586,7 @@ void search_dir(ignores *ig, const char *base_path, const char *path, const int 
 
 search_dir_cleanup:
     check_symloop_leave(&current_dirkey);
+    free(dir_list[0]);
     free(dir_list);
     dir_list = NULL;
 }


### PR DESCRIPTION
Previously, `malloc(3)` was called for every entry in a dir,
results were accumulated, and freed in a loop after a dir was done.

Implement dedicated array to minimize malloc calls.
Each dir now only does one malloc, one free, and several realloc's.

This should have better cache density.
At least, it cannot be slower.

Inspired-by: https://speakerdeck.com/alex/why-python-ruby-and-javascript-are-slow