### PR TITLE
Fix testsuite for Linux tmpfs and Line numbering/output when searching named pipes

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -134,7 +134,7 @@ int main(int argc, char **argv) {
         compile_study(&opts.re, &opts.re_extra, opts.query, pcre_opts, study_opts);
     }
 
-    if (opts.search_stream) {
+    if (opts.search_stdin) {
         search_stream(stdin, "");
     } else {
         for (i = 0; i < workers_len; i++) {

--- a/src/options.c
+++ b/src/options.c
@@ -298,7 +298,7 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
         { "print-long-lines", no_argument, &opts.print_long_lines, 1 },
         { "recurse", no_argument, NULL, 'r' },
         { "search-binary", no_argument, &opts.search_binary_files, 1 },
-        { "search-files", no_argument, &opts.search_stream, 0 },
+        { "search-files", no_argument, &opts.search_stdin, 0 },
         { "search-zip", no_argument, &opts.search_zip_files, 1 },
         { "silent", no_argument, NULL, 0 },
         { "skip-vcs-ignores", no_argument, NULL, 'U' },
@@ -337,7 +337,7 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
     rv = fstat(fileno(stdin), &statbuf);
     if (rv == 0) {
         if (S_ISFIFO(statbuf.st_mode) || S_ISREG(statbuf.st_mode)) {
-            opts.search_stream = 1;
+            opts.search_stdin = 1;
         }
     }
 
@@ -711,19 +711,19 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
         opts.color = 0;
         opts.print_break = 1;
         group = 1;
-        opts.search_stream = 0;
+        opts.search_stdin = 0;
     }
 
     if (opts.vimgrep) {
         opts.color = 0;
         opts.print_break = 0;
         group = 1;
-        opts.search_stream = 0;
+        opts.search_stdin = 0;
         opts.print_path = PATH_PRINT_NOTHING;
     }
 
     if (opts.parallel) {
-        opts.search_stream = 0;
+        opts.search_stdin = 0;
     }
 
     if (!(opts.print_path != PATH_PRINT_DEFAULT || opts.print_break == 0)) {
@@ -735,7 +735,7 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
         }
     }
 
-    if (opts.search_stream) {
+    if (opts.search_stdin) {
         opts.print_break = 0;
         opts.print_path = PATH_PRINT_NOTHING;
         if (opts.print_line_numbers != 2) {
@@ -789,7 +789,7 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
 #endif
         }
         /* Make sure we search these paths instead of stdin. */
-        opts.search_stream = 0;
+        opts.search_stdin = 0;
     } else {
         path = ag_strdup(".");
         *paths = ag_malloc(sizeof(char *) * 2);

--- a/src/options.h
+++ b/src/options.h
@@ -72,7 +72,7 @@ typedef struct {
     int search_binary_files;
     int search_zip_files;
     int search_hidden_files;
-    int search_stream; /* true if tail -F blah | ag */
+    int search_stdin; /* true if tail -F blah | ag */
     int stats;
     size_t stream_line_num; /* This should totally not be in here */
     int match_found;        /* This should totally not be in here */

--- a/src/print.c
+++ b/src/print.c
@@ -141,7 +141,8 @@ void print_binary_file_matches(const char *path) {
     fprintf(out_fd, "Binary file %s matches.\n", path);
 }
 
-void print_file_matches(const char *path, const char *buf, const size_t buf_len, const match_t matches[], const size_t matches_len) {
+void print_file_matches(const char *path, int searching_a_stream,
+        const char *buf, const size_t buf_len, const match_t matches[], const size_t matches_len) {
     size_t cur_match = 0;
     ssize_t lines_to_print = 0;
     char sep = '-';
@@ -213,7 +214,7 @@ void print_file_matches(const char *path, const char *buf, const size_t buf_len,
 
         if (i == buf_len || buf[i] == '\n') {
             if (print_context.lines_since_last_match == 0) {
-                if (opts.print_path == PATH_PRINT_EACH_LINE && !opts.search_stream) {
+                if (opts.print_path == PATH_PRINT_EACH_LINE && !searching_a_stream) {
                     print_path(path, ':');
                 }
                 if (opts.ackmate) {
@@ -305,7 +306,7 @@ void print_file_matches(const char *path, const char *buf, const size_t buf_len,
                 }
             }
 
-            if (opts.search_stream) {
+            if (searching_a_stream) {
                 break;
             }
 
@@ -315,7 +316,7 @@ void print_file_matches(const char *path, const char *buf, const size_t buf_len,
             print_context.prev_line_offset = i + 1; /* skip the newline */
 
             /* File doesn't end with a newline. Print one so the output is pretty. */
-            if (i == buf_len && buf[i - 1] != '\n' && !opts.search_stream) {
+            if (i == buf_len && buf[i - 1] != '\n' && !searching_a_stream) {
                 fputc('\n', out_fd);
             }
         }

--- a/src/print.c
+++ b/src/print.c
@@ -142,7 +142,7 @@ void print_binary_file_matches(const char *path) {
 }
 
 void print_file_matches(const char *path, int searching_a_stream,
-        const char *buf, const size_t buf_len, const match_t matches[], const size_t matches_len) {
+                        const char *buf, const size_t buf_len, const match_t matches[], const size_t matches_len) {
     size_t cur_match = 0;
     ssize_t lines_to_print = 0;
     char sep = '-';

--- a/src/print.h
+++ b/src/print.h
@@ -11,7 +11,8 @@ void print_path(const char *path, const char sep);
 void print_path_count(const char *path, const char sep, const size_t count);
 void print_line(const char *buf, size_t buf_pos, size_t prev_line_offset);
 void print_binary_file_matches(const char *path);
-void print_file_matches(const char *path, const char *buf, const size_t buf_len, const match_t matches[], const size_t matches_len);
+void print_file_matches(const char *path, int searching_a_stream,
+                         const char *buf, const size_t buf_len, const match_t matches[], const size_t matches_len);
 void print_line_number(size_t line, const char sep);
 void print_column_number(const match_t matches[], size_t last_printed_match,
                          size_t prev_line_offset, const char sep);

--- a/src/print.h
+++ b/src/print.h
@@ -12,7 +12,7 @@ void print_path_count(const char *path, const char sep, const size_t count);
 void print_line(const char *buf, size_t buf_pos, size_t prev_line_offset);
 void print_binary_file_matches(const char *path);
 void print_file_matches(const char *path, int searching_a_stream,
-                         const char *buf, const size_t buf_len, const match_t matches[], const size_t matches_len);
+                        const char *buf, const size_t buf_len, const match_t matches[], const size_t matches_len);
 void print_line_number(size_t line, const char sep);
 void print_column_number(const match_t matches[], size_t last_printed_match,
                          size_t prev_line_offset, const char sep);

--- a/src/search.c
+++ b/src/search.c
@@ -1,5 +1,5 @@
-#include "print.h"
 #include "search.h"
+#include "print.h"
 #include "scandir.h"
 
 void search_buf(const char *buf, const size_t buf_len,
@@ -188,7 +188,7 @@ multiline_done:
             print_binary_file_matches(dir_full_path);
         } else {
             print_file_matches(dir_full_path, searching_a_stream,
-                    buf, buf_len, matches, matches_len);
+                               buf, buf_len, matches, matches_len);
         }
         pthread_mutex_unlock(&print_mtx);
         opts.match_found = 1;

--- a/src/search.h
+++ b/src/search.h
@@ -66,7 +66,7 @@ typedef struct {
 symdir_t *symhash;
 
 void search_buf(const char *buf, const size_t buf_len,
-                const char *dir_full_path);
+                const char *dir_full_path, int searching_a_stream);
 void search_stream(FILE *stream, const char *path);
 void search_file(const char *file_full_path);
 

--- a/tests/empty_match.t
+++ b/tests/empty_match.t
@@ -13,10 +13,10 @@ A genuine zero-length match should succeed:
   1:foo
 
 Empty files should be listed with --unrestricted --files-with-matches (-ul)
-  $ ag -lu --stats | sed '$d' # Remove the last line about timing which will differ
-  empty.txt
-  nonempty.txt
-  2 matches
+  $ ag -lu --stats | sed '$d' | sort # Remove the last line about timing which will differ
   2 files contained matches
   2 files searched
+  2 matches
   4 bytes searched
+  empty.txt
+  nonempty.txt


### PR DESCRIPTION
Instead of the global `opts.search_stream`,
use `opts.search_stdin`, and `searching_a_stream` arguments.

Fixes https://github.com/ggreer/the_silver_searcher/issues/988