### PR TITLE
Fix --vimgrep NUL-ing last-line-w/o-newline

### DIFF
--- a/src/print.c
+++ b/src/print.c
@@ -236,6 +236,10 @@ void print_file_matches(const char *path, const char *buf, const size_t buf_len,
                         print_path(path, sep);
                         print_line_number(print_context.line, sep);
                         print_column_number(matches, print_context.last_printed_match, print_context.prev_line_offset, sep);
+                        /* Handle the case of no newline at end of file */
+                        if (buf[i] == 0) {
+                            i--;
+                        }
                         print_line(buf, i, print_context.prev_line_offset);
                     }
                 } else {


### PR DESCRIPTION
On fc78c0d5f74cac25ce70ba99235560d90e97ffdf:
```sh
[the_silver_searcher]$ printf aaa > test_eol/a
[the_silver_searcher]$ (cd test_eol ; ../ag --vimgrep a | hexdump -C)
00000000  61 3a 31 3a 31 3a 61 61  61 00 61 3a 31 3a 32 3a  |a:1:1:aaa.a:1:2:|
00000010  61 61 61 00 61 3a 31 3a  33 3a 61 61 61 00 0a     |aaa.a:1:3:aaa..|
0000001f
```
`00`-s should have not been printed.
Fixes #1022 