### PR TITLE
Remove svn ignore code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Ag is quite stable now. Most changes are new features, minor bug fixes, or perfo
 
     ag test_blah ~/code/  4.67s user 4.58s system 286% cpu 3.227 total
 
-Ack and Ag found the same results, but Ag was 34x faster (3.2 seconds vs 110 seconds). My `~/code` directory is about 8GB. Thanks to git/hg/svn-ignore, Ag only searched 700MB of that.
+Ack and Ag found the same results, but Ag was 34x faster (3.2 seconds vs 110 seconds). My `~/code` directory is about 8GB. Thanks to git/hg/ignore, Ag only searched 700MB of that.
 
 There are also [graphs of performance across releases](http://geoff.greer.fm/ag/speed/).
 

--- a/doc/ag.1.md
+++ b/doc/ag.1.md
@@ -180,7 +180,7 @@ Recursively search for PATTERN in PATH. Like grep or ack, but faster.
     binary and hidden files as well.
 
   * `-U --skip-vcs-ignores`:
-    Ignore VCS ignore files (.gitignore, .hgignore, svn:ignore), but still
+    Ignore VCS ignore files (.gitignore, .hgignore), but still
     use .ignore.
 
   * `-v --invert-match`:
@@ -226,12 +226,11 @@ or `xhtml`. For a list of supported types, run `ag --list-file-types`.
 
 By default, ag will ignore files whose names match patterns in .gitignore,
 .hgignore, or .ignore. These files can be anywhere in the directories being
-searched. Ag also ignores files matched by the svn:ignore property if `svn
---version` is 1.6 or older.  Finally, ag looks in $HOME/.agignore for ignore
-patterns. Binary files are ignored by default as well.
+searched. Binary files are ignored by default as well. Finally, ag looks in
+$HOME/.agignore for ignore patterns.
 
-If you want to ignore .gitignore, .hgignore, and svn:ignore, but still take
-.ignore into account, use `-U`.
+If you want to ignore .gitignore and .hgignore, but still take .ignore into
+account, use `-U`.
 
 Use the `-t` option to search all text files; `-a` to search all files; and `-u`
 to search all, including hidden files.

--- a/src/ignore.h
+++ b/src/ignore.h
@@ -4,10 +4,6 @@
 #include <dirent.h>
 #include <sys/types.h>
 
-#define SVN_DIR_PROP_BASE "dir-prop-base"
-#define SVN_DIR ".svn"
-#define SVN_PROP_IGNORE "svn:ignore"
-
 struct ignores {
     char **extensions; /* File extensions to ignore */
     size_t extensions_len;
@@ -42,7 +38,6 @@ void cleanup_ignore(ignores *ig);
 void add_ignore_pattern(ignores *ig, const char *pattern);
 
 void load_ignore_patterns(ignores *ig, const char *path);
-void load_svn_ignore_patterns(ignores *ig, const char *path);
 
 int filename_filter(const char *path, const struct dirent *dir, void *baton);
 

--- a/src/options.c
+++ b/src/options.c
@@ -102,7 +102,7 @@ Search Options:\n\
   -u --unrestricted       Search all files (ignore .ignore, .gitignore, etc.;\n\
                           searches binary and hidden files as well)\n\
   -U --skip-vcs-ignores   Ignore VCS ignore files\n\
-                          (.gitignore, .hgignore, .svnignore; still obey .ignore)\n\
+                          (.gitignore, .hgignore; still obey .ignore)\n\
   -v --invert-match\n\
   -w --word-regexp        Only match whole words\n\
   -W --width NUM          Truncate match lines after NUM characters\n\

--- a/src/search.c
+++ b/src/search.c
@@ -481,11 +481,7 @@ void search_dir(ignores *ig, const char *base_path, const char *path, const int 
     for (i = 0; opts.skip_vcs_ignores ? (i <= 1) : (ignore_pattern_files[i] != NULL); i++) {
         ignore_file = ignore_pattern_files[i];
         ag_asprintf(&dir_full_path, "%s/%s", path, ignore_file);
-        if (strcmp(SVN_DIR, ignore_file) == 0) {
-            load_svn_ignore_patterns(ig, dir_full_path);
-        } else {
-            load_ignore_patterns(ig, dir_full_path);
-        }
+        load_ignore_patterns(ig, dir_full_path);
         free(dir_full_path);
         dir_full_path = NULL;
     }


### PR DESCRIPTION
It only parsed the old format (svn v1.6 and earlier). Nobody uses ancient subversion anymore.

New svn uses a sqlite db for ignore props. Adding support for that would be onerous.