### PR TITLE
Fix broken link of ack.vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ or:
 
 Which has the same effect but will report every match on the line.
 
+[ack.vim]: https://github.com/mileszs/ack.vim
+
 ### Emacs
 
 You can use [ag.el][] as an Emacs front-end to Ag. See also: [helm-ag].


### PR DESCRIPTION
Seems like the link to ack.vim was dropped at https://github.com/ggreer/the_silver_searcher/commit/787d9e3261b0b4b07a31d6d8f7dbf67713b1ddea , so putting it back.