### PR TITLE
Create autogen.sh script

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -e
+cd "$(dirname "$0")"
+
+AC_SEARCH_OPTS=""
+# For those of us with pkg-config and other tools in /usr/local
+PATH=$PATH:/usr/local/bin
+
+# This is to make life easier for people who installed pkg-config in /usr/local
+# but have autoconf/make/etc in /usr/. AKA most mac users
+if [ -d "/usr/local/share/aclocal" ]
+then
+    AC_SEARCH_OPTS="-I /usr/local/share/aclocal"
+fi
+
+# shellcheck disable=2086
+aclocal $AC_SEARCH_OPTS
+autoconf
+autoheader
+automake --add-missing

--- a/build.sh
+++ b/build.sh
@@ -1,22 +1,8 @@
 #!/bin/sh
 
-cd "$(dirname "$0")" || exit 1
+set -e
+cd "$(dirname "$0")"
 
-AC_SEARCH_OPTS=""
-# For those of us with pkg-config and other tools in /usr/local
-PATH=$PATH:/usr/local/bin
-
-# This is to make life easier for people who installed pkg-config in /usr/local
-# but have autoconf/make/etc in /usr/. AKA most mac users
-if [ -d "/usr/local/share/aclocal" ]
-then
-    AC_SEARCH_OPTS="-I /usr/local/share/aclocal"
-fi
-
-# shellcheck disable=2086
-aclocal $AC_SEARCH_OPTS && \
-autoconf && \
-autoheader && \
-automake --add-missing && \
-./configure "$@" && \
+./autogen.sh
+./configure "$@"
 make -j4


### PR DESCRIPTION
Many autotools-based projects have an autogen.sh script which handles
creating the configure script properly. The existing build.sh does this
but doesn't offer a way to just run autotools without configure/make.

Here I split the first part of build.sh into autogen.sh and then call
autogen.sh from build.sh. Using "set -e" cleans up the script a bit to
avoid a long chain of "&&"s