### PR TITLE
Add support for ~/.agrc

### DIFF
--- a/doc/ag.1
+++ b/doc/ag.1
@@ -23,6 +23,10 @@ Output results in a format parseable by AckMate \fIhttps://github\.com/protocool
 Set thread affinity (if platform supports it)\. Default is true\.
 .
 .TP
+\fB\-\-agrc=<path\-to\-agrc\-file>\fR
+Use \fIpath\-to\-agrc\-file\fR instead of $AGRC or $HOME/\.agrc for default options\. Specify \fB\-\-no\-agrc\fR to disable reading from an agrc file\. See \fIAGRC\fR for details\.
+.
+.TP
 \fB\-a \-\-all\-types\fR
 Search all files\. This doesn\'t include hidden files, and doesn\'t respect any ignore files\.
 .
@@ -270,6 +274,15 @@ If you want to ignore \.gitignore and \.hgignore, but still take \.ignore into a
 .
 .P
 Use the \fB\-t\fR option to search all text files; \fB\-a\fR to search all files; and \fB\-u\fR to search all, including hidden files\.
+.
+.SH "AGRC"
+To modify the "default" options, ag can read a list of command\-line arguments from an "agrc" file\. One "agrc" file will be selected as the first of 1) the \fB<path>\fR in \fB\-\-agrc=<path>\fR, 2) the environment variable \fBAGRC\fR, or 3) the default \fB$HOME/\.agrc\fR\.
+.
+.P
+If \fB\-\-noagrc\fR is specified, an "agrc" file will not be used\.
+.
+.P
+The "agrc" file should contain a list of command\-line arguments, one per line\. You don\'t need to quote arguments as you would in a shell as the entire line will be considered a single argument\. For long options which take a value, use the form \fB\-\-option=value\fR rather than \fB\-\-option value\fR\.
 .
 .SH "EXAMPLES"
 \fBag printf\fR: Find matches for "printf" in the current directory\.

--- a/doc/ag.1.md
+++ b/doc/ag.1.md
@@ -17,6 +17,10 @@ Recursively search for PATTERN in PATH. Like grep or ack, but faster.
   * `--[no]affinity`:
     Set thread affinity (if platform supports it). Default is true.
 
+  * `--agrc=<path-to-agrc-file>`:
+    Use <path-to-agrc-file> instead of $AGRC or $HOME/.agrc for default options.
+    Specify `--no-agrc` to disable reading from an agrc file. See [AGRC][] for details.
+
   * `-a --all-types`:
     Search all files. This doesn't include hidden files, and doesn't respect any ignore files.
 
@@ -235,6 +239,20 @@ account, use `-U`.
 
 Use the `-t` option to search all text files; `-a` to search all files; and `-u`
 to search all, including hidden files.
+
+## AGRC
+
+To modify the "default" options, ag can read a list of command-line arguments
+from an "agrc" file. One "agrc" file will be selected as the first of 1) the
+`<path>` in `--agrc=<path>`, 2) the environment variable `AGRC`, or 3) the
+default `$HOME/.agrc`.
+
+If `--noagrc` is specified, an "agrc" file will not be used.
+
+The "agrc" file should contain a list of command-line arguments, one per line.
+You don't need to quote arguments as you would in a shell as the entire line
+will be considered a single argument. For long options which take a value, use
+the form `--option=value` rather than `--option value`.
 
 ## EXAMPLES
 

--- a/src/options.c
+++ b/src/options.c
@@ -107,6 +107,11 @@ Search Options:\n\
   -w --word-regexp        Only match whole words\n\
   -W --width NUM          Truncate match lines after NUM characters\n\
   -z --search-zip         Search contents of compressed (e.g., gzip) files\n\
+\n\
+Other Options:\n\
+     --agrc=<agrc-path>   Load options (one per line) from <agrc-path>\n\
+                          (default is $HOME/.agrc)\n\
+     --no-agrc            Don't use an agrc file\n\
 \n");
     printf("File Types:\n\
 The search can be restricted to certain types of files. Example:\n\
@@ -195,6 +200,47 @@ void cleanup_options(void) {
     }
 }
 
+/*
+ * Get a list of options from an ".agrc" file (typically $HOME/.agrc) to be prepended
+ * to the standard argc/argv
+ */
+static void get_opts_from_file(const char *path, int *argc_out, char ***argv_out) {
+    FILE *fp = NULL;
+    int count = 0;
+    int list_size = 10; // initially allocate space for 10 args, will be realloc'd if needed
+    char **list = NULL;
+    char buf[128] = { 0 }; // max length of options in .agrc
+    char *arg = NULL;
+
+    if ((fp = fopen(path, "r")) != NULL) {
+        list = ag_malloc(list_size * sizeof(char *));
+        while (fgets(buf, sizeof(buf), fp)) {
+            // ignore lines which don't start with -
+            if (buf[0] == '-') {
+                // strip trailing newline
+                char *newline = strchr(buf, '\n');
+                if (newline) {
+                    *newline = '\0';
+                }
+                if (count >= list_size) {
+                    // expand buffer if needed
+                    list_size *= 2;
+                    list = ag_realloc(list, list_size * sizeof(char *));
+                }
+                arg = ag_strdup(buf);
+                list[count] = arg;
+                count++;
+                log_debug("Got argument '%s' from agrc", arg);
+            }
+        }
+        fclose(fp);
+    } else {
+        log_debug("Unable to open agrc file '%s'", path);
+    }
+    *argc_out = count;
+    *argv_out = list;
+}
+
 void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
     int ch;
     size_t i;
@@ -215,6 +261,8 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
     size_t lang_count;
     size_t lang_num = 0;
     int has_filetype = 0;
+    int use_agrc = 1;
+    char *agrc_file = NULL;
 
     size_t longopts_len, full_len;
     option_t *longopts;
@@ -230,6 +278,7 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
         { "ackmate-dir-filter", required_argument, NULL, 0 },
         { "affinity", no_argument, &opts.use_thread_affinity, 1 },
         { "after", optional_argument, NULL, 'A' },
+        { "agrc", required_argument, NULL, 0 },
         { "all-text", no_argument, NULL, 't' },
         { "all-types", no_argument, NULL, 'a' },
         { "before", optional_argument, NULL, 'B' },
@@ -270,6 +319,8 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
         /* Accept both --no-* and --no* forms for convenience/BC */
         { "no-affinity", no_argument, &opts.use_thread_affinity, 0 },
         { "noaffinity", no_argument, &opts.use_thread_affinity, 0 },
+        { "no-agrc", no_argument, NULL, 0 },
+        { "noagrc", no_argument, NULL, 0 },
         { "no-break", no_argument, &opts.print_break, 0 },
         { "nobreak", no_argument, &opts.print_break, 0 },
         { "no-color", no_argument, &opts.color, 0 },
@@ -364,7 +415,78 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
         opts.stdout_inode = statbuf.st_ino;
     }
 
+    // Check whether to exclude ~/.agrc by searching argc/argv for --no-agrc or --noagrc
+    // Note, the optstr here must match the optstr used for main argument parsing
+    while ((ch = getopt_long(argc, argv, "A:aB:C:cDG:g:FfHhiLlm:nop:QRrSsvVtuUwW:z0", longopts, &opt_index)) != -1) {
+        if (ch == 'D') {
+            // enable debugging early to allow for debug messages during agrc parsing
+            set_log_level(LOG_LEVEL_DEBUG);
+        } else if (ch == 0) {
+            if (strcmp(longopts[opt_index].name, "agrc") == 0) {
+                use_agrc = 1;
+                if (optarg) {
+                    if (access(optarg, R_OK)) {
+                        die("Can't read agrc file '%s'", optarg);
+                    }
+                    agrc_file = ag_strdup(optarg);
+                }
+                break;
+            } else if ((strcmp(longopts[opt_index].name, "no-agrc") == 0) ||
+                       (strcmp(longopts[opt_index].name, "noagrc") == 0)) {
+                use_agrc = 0;
+                break;
+            }
+        }
+    }
+    log_debug("use_agrc = %d", use_agrc);
+    if (use_agrc) {
+        int agrc_argc;
+        char **agrc_argv;
+
+        if (agrc_file == NULL) {
+            // check for AGRC environment var
+            char *agrc_env = getenv("AGRC");
+            if (agrc_env) {
+                agrc_file = ag_strdup(agrc_env);
+            } else {
+                // default agrc is $HOME/.agrc
+                int agrc_len = strlen(home_dir) + sizeof("/.agrc");
+                agrc_file = ag_malloc(agrc_len);
+                snprintf(agrc_file, agrc_len, "%s/.agrc", home_dir);
+            }
+        }
+        log_debug("Using agrc file '%s'", agrc_file);
+
+        get_opts_from_file(agrc_file, &agrc_argc, &agrc_argv);
+        if (agrc_argc) {
+            // if we get arguments from .agrc, prepend them to argc/argv
+            int new_argc = argc + agrc_argc;
+            char **new_argv = ag_malloc(new_argc * sizeof(char *));
+
+            // leave argv[0] as-is
+            new_argv[0] = argv[0];
+            // prepend args from agrc (starting at argv[1])
+            for (i = 0; i < (size_t)agrc_argc; i++) {
+                new_argv[i + 1] = agrc_argv[i];
+            }
+            // copy the rest of the old argv
+            for (i = 1; i < (size_t)argc; i++) {
+                new_argv[agrc_argc + i] = argv[i];
+            }
+            argc = new_argc;
+            argv = new_argv;
+        }
+        free(agrc_argv);
+    }
+    for (i = 0; i < (size_t)argc; i++) {
+        log_debug("argv[%lu] = '%s'", i, argv[i]);
+    }
+
     char *file_search_regex = NULL;
+    // reset after getopt_long call above
+    optind = 1;
+    opterr = 1;
+    // the optstring here must match the optstring used above when checking for [no]agrc
     while ((ch = getopt_long(argc, argv, "A:aB:C:cDG:g:FfHhiLlm:nop:QRrSsvVtuUwW:z0", longopts, &opt_index)) != -1) {
         switch (ch) {
             case 'A':
@@ -560,6 +682,10 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
                     opts.print_path = PATH_PRINT_NOTHING;
                     opts.stats = 1;
                     break;
+                } else if ((strcmp(longopts[opt_index].name, "agrc") == 0) ||
+                           (strcmp(longopts[opt_index].name, "no-agrc") == 0) ||
+                           (strcmp(longopts[opt_index].name, "noagrc") == 0)) {
+                    break; // no-op as these arguments are handled earlier, but needed to avoid erroring out below
                 }
 
                 /* Continue to usage if we don't recognize the option */

--- a/tests/adjacent_matches.t
+++ b/tests/adjacent_matches.t
@@ -1,7 +1,7 @@
 Setup:
 
   $ . $TESTDIR/setup.sh
-  $ alias ag="$TESTDIR/../ag --noaffinity --workers=1 --parallel --color"
+  $ alias ag="$TESTDIR/../ag --noagrc --noaffinity --workers=1 --parallel --color"
   $ printf 'blahfoofooblah\n' > ./fooblah.txt
 
 Highlights are adjacent:

--- a/tests/agrc.t
+++ b/tests/agrc.t
@@ -1,0 +1,12 @@
+Setup:
+
+  $ . $TESTDIR/setup.sh
+  $ alias ag="$TESTDIR/../ag --noaffinity --nocolor --workers=1 --parallel"
+  $ printf -- '-s\n--ignore=foo.*\n' >agrc
+  $ printf 'hello\nHello\n' >file.txt
+  $ printf 'hello\n' >foo.txt
+
+agrc enables case-sensitive matching and ignores foo.txt:
+
+  $ ag --agrc=agrc hello
+  file.txt:1:hello

--- a/tests/color.t
+++ b/tests/color.t
@@ -2,7 +2,7 @@ Setup. Note that we have to turn --color on manually since ag detects that
 stdout isn't a tty when running in cram.
 
   $ . $TESTDIR/setup.sh
-  $ alias ag="$TESTDIR/../ag --noaffinity --workers=1 --parallel --color"
+  $ alias ag="$TESTDIR/../ag --noagrc --noaffinity --workers=1 --parallel --color"
   $ printf 'foo\n' > ./blah.txt
   $ printf 'bar\n' >> ./blah.txt
 

--- a/tests/count.t
+++ b/tests/count.t
@@ -2,7 +2,7 @@ Setup:
 
   $ . $TESTDIR/setup.sh
   $ unalias ag
-  $ alias ag="$TESTDIR/../ag --noaffinity --nocolor --workers=1"
+  $ alias ag="$TESTDIR/../ag --noagrc --noaffinity --nocolor --workers=1"
   $ printf "blah\n" > blah.txt
   $ printf "blah2\n" >> blah.txt
   $ printf "blah_OTHER\n" > other_file.txt

--- a/tests/passthrough.t
+++ b/tests/passthrough.t
@@ -2,7 +2,7 @@ Setup:
 
   $ . $TESTDIR/setup.sh
   $ unalias ag
-  $ alias ag="$TESTDIR/../ag --noaffinity --nocolor --workers=1"
+  $ alias ag="$TESTDIR/../ag --noagrc --noaffinity --nocolor --workers=1"
   $ printf "foo bar\n" > passthrough_test.txt
   $ printf "zoo zar\n" >> passthrough_test.txt
   $ printf "foo test\n" >> passthrough_test.txt

--- a/tests/pipecontext.t
+++ b/tests/pipecontext.t
@@ -8,7 +8,7 @@ Setup:
 Do not use parallel flag, which disables stream input:
 
   $ unalias ag
-  $ alias ag="$TESTDIR/../ag --nocolor --workers=1"
+  $ alias ag="$TESTDIR/../ag --noagrc --nocolor --workers=1"
 
 B flag on pipe:
 

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -6,4 +6,4 @@
 # --noaffinity is to stop Travis CI from erroring (it runs in containers so pthread_setaffinity_np fails)
 # --workers=1 is to keep all output ordered, to make testing output easier
 # shellcheck disable=2139
-alias ag="$TESTDIR/../ag --noaffinity --nocolor --workers=1 --parallel"
+alias ag="$TESTDIR/../ag --noagrc --noaffinity --nocolor --workers=1 --parallel"


### PR DESCRIPTION
This has been done before by a variety of users, but most of the PRs to add this feature have been dormant for months or years, so here's my implementation.

------
Using shell aliases for ag to change the defaults (such as --color-match)
is ugly and breaks trying to use ag nicely in cases like xargs.
As such, it's very helpful to have a default ".agrc" file which can be
read to apply custom options.

The .agrc file file should contain a list of command-line options, one
per line. Only lines which start with '-' are used, all others are
ignored.

The default agrc file is $HOME/.agrc, but can be overridden with
--agrc=<agrc-file>
--no-agrc or --noagrc are supported to disable reading from agrc.
There is no support yet for multiple agrc files.

Tests have also been updated to pass --noagrc to keep a user's defaults
from failing tests.