### PR TITLE
Fix for ignoring *.min.js

### DIFF
--- a/src/ignore.c
+++ b/src/ignore.c
@@ -117,7 +117,7 @@ void add_ignore_pattern(ignores *ig, const char *pattern) {
     char ***patterns_p;
     size_t *patterns_len;
     if (is_fnmatch(pattern)) {
-        if (pattern[0] == '*' && pattern[1] == '.' && !(is_fnmatch(pattern + 2))) {
+        if (pattern[0] == '*' && pattern[1] == '.' && !strchr(pattern + 2, '.') && !is_fnmatch(pattern + 2)) {
             patterns_p = &(ig->extensions);
             patterns_len = &(ig->extensions_len);
             pattern += 2;


### PR DESCRIPTION
Problem:

* If `*.` is found at the beginning of the expression, the rest of the expression is considered an *extension*, and gets added to `ig->extensions`.
* When a file `jquery.min.js` is being processed, the silver searcher tries matching the extension `js` with the items from `ig->extensions`.
* Thus `min.js` will never match any extension.

Solution:

* Don't add a string to `ig->extensions` if that string still contains another `.`.

Performance impact:

* Unknown. I haven't measured.

Related issues:

* https://github.com/ggreer/the_silver_searcher/issues/710
* https://github.com/ggreer/the_silver_searcher/issues/755
* https://github.com/ggreer/the_silver_searcher/pull/834 (the failing test from that PR should hopefully be fixed with this PR)