### PR TITLE
Fix cleanup when mmap returns MAP_FAILED

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -319,6 +319,7 @@ void search_file(const char *file_full_path) {
         buf = mmap(0, f_len, PROT_READ, MAP_PRIVATE, fd, 0);
         if (buf == MAP_FAILED) {
             log_err("File %s failed to load: %s.", file_full_path, strerror(errno));
+            buf = NULL;
             goto cleanup;
         }
 #if HAVE_MADVISE


### PR DESCRIPTION
MAP_FAILED != NULL, which means that, when that error is returned,
the code was trying to munmap it.

We now set buf = NULL before going to cleanup.