### PR TITLE
Add es6 to js file type

### DIFF
--- a/src/lang.c
+++ b/src/lang.c
@@ -40,7 +40,7 @@ lang_spec_t langs[] = {
     { "ini", { "ini" } },
     { "jade", { "jade" } },
     { "java", { "java", "properties" } },
-    { "js", { "js", "jsx", "vue" } },
+    { "js", { "es6", "js", "jsx", "vue" } },
     { "json", { "json" } },
     { "jsp", { "jsp", "jspx", "jhtm", "jhtml" } },
     { "julia", { "jl" } },

--- a/tests/list_file_types.t
+++ b/tests/list_file_types.t
@@ -112,7 +112,7 @@ Language types are output:
         .java  .properties
   
     --js
-        .js  .jsx  .vue
+        .es6  .js  .jsx  .vue
   
     --json
         .json


### PR DESCRIPTION
We use the `.es6` file extension for our JS files at Namely (and others do, too), would like to be able to quickly search them via `ag`.