### PR TITLE
stat test reduced to regular files and FIFOs

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -287,7 +287,7 @@ void search_file(const char *file_full_path) {
         log_err("Skipping %s: Mode %u is not a file.", file_full_path, statbuf.st_mode);
         goto cleanup;
     }
-  
+
     print_init_context();
 
     if (statbuf.st_mode & S_IFIFO) {


### PR DESCRIPTION
Stat checks now allow searching only in regular files and FIFOs.
The stat test were duplicated to prevent TOCTOU.
related to issue #745