### PR TITLE
Support for gradle files

### DIFF
--- a/src/lang.c
+++ b/src/lang.c
@@ -32,7 +32,7 @@ lang_spec_t langs[] = {
     { "gettext", { "po", "pot", "mo" } },
     { "glsl", { "vert", "tesc", "tese", "geom", "frag", "comp" } },
     { "go", { "go" } },
-    { "groovy", { "groovy", "gtmpl", "gpp", "grunit" } },
+    { "groovy", { "groovy", "gtmpl", "gpp", "grunit", "gradle" } },
     { "haml", { "haml" } },
     { "haskell", { "hs", "lhs" } },
     { "hh", { "h" } },

--- a/tests/list_file_types.t
+++ b/tests/list_file_types.t
@@ -88,7 +88,7 @@ Language types are output:
         .go
   
     --groovy
-        .groovy  .gtmpl  .gpp  .grunit
+        .groovy  .gtmpl  .gpp  .grunit  .gradle
   
     --haml
         .haml


### PR DESCRIPTION
Add `.gradle` files to the list of known files to search for when filtering for `--groovy`.