### PR TITLE
Add "twig" to languages

### DIFF
--- a/src/lang.c
+++ b/src/lang.c
@@ -95,6 +95,7 @@ lang_spec_t langs[] = {
     { "tt", { "tt", "tt2", "ttml" } },
     { "toml", { "toml" } },
     { "ts", { "ts", "tsx" } },
+    { "twig", { "twig" } },
     { "vala", { "vala", "vapi" } },
     { "vb", { "bas", "cls", "frm", "ctl", "vb", "resx" } },
     { "velocity", { "vm", "vtl", "vsl" } },

--- a/tests/list_file_types.t
+++ b/tests/list_file_types.t
@@ -276,6 +276,9 @@ Language types are output:
     --ts
         .ts  .tsx
   
+    --twig
+        .twig
+  
     --vala
         .vala  .vapi
   


### PR DESCRIPTION
Here is a proposal to add `twig` files, a template file for [twig](http://twig.sensiolabs.org/).

By the way, Isn't it a little "overkill" to add this in the language file,  because it's a very particular file type ?

I did not found a proper way to declare a custom file type just for my usage.