### PR TITLE
Boyer moore algorithm ignore case refactor

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -45,18 +45,17 @@ void search_buf(const char *buf, const size_t buf_len,
         matches_len = 1;
     } else if (opts.literal) {
         const char *match_ptr = buf;
-        strncmp_fp ag_strnstr_fp = get_strstr(opts.casing);
 
         while (buf_offset < buf_len) {
 /* hash_strnstr only for little-endian platforms that allow unaligned access */
 #if defined(__i386__) || defined(__x86_64__)
             /* Decide whether to fall back on boyer-moore */
             if ((size_t)opts.query_len < 2 * sizeof(uint16_t) - 1 || opts.query_len >= UCHAR_MAX)
-                match_ptr = ag_strnstr_fp(match_ptr, opts.query, buf_len - buf_offset, opts.query_len, alpha_skip_lookup, find_skip_lookup);
+                match_ptr = boyer_moore_strnstr(match_ptr, opts.query, buf_len - buf_offset, opts.query_len, alpha_skip_lookup, find_skip_lookup, opts.casing == CASE_INSENSITIVE);
             else
                 match_ptr = hash_strnstr(match_ptr, opts.query, buf_len - buf_offset, opts.query_len, h_table, opts.casing == CASE_SENSITIVE);
 #else
-            match_ptr = ag_strnstr_fp(match_ptr, opts.query, buf_len - buf_offset, opts.query_len, alpha_skip_lookup, find_skip_lookup);
+            match_ptr = boyer_moore_strnstr(match_ptr, opts.query, buf_len - buf_offset, opts.query_len, alpha_skip_lookup, find_skip_lookup, opts.casing == CASE_INSENSITIVE);
 #endif
 
             if (match_ptr == NULL) {

--- a/src/util.c
+++ b/src/util.c
@@ -176,30 +176,12 @@ void generate_hash(const char *find, const size_t f_len, uint8_t *h_table, const
 
 /* Boyer-Moore strstr */
 const char *boyer_moore_strnstr(const char *s, const char *find, const size_t s_len, const size_t f_len,
-                                const size_t alpha_skip_lookup[], const size_t *find_skip_lookup) {
+                                const size_t alpha_skip_lookup[], const size_t *find_skip_lookup, const int case_insensitive) {
     ssize_t i;
     size_t pos = f_len - 1;
 
     while (pos < s_len) {
-        for (i = f_len - 1; i >= 0 && s[pos] == find[i]; pos--, i--) {
-        }
-        if (i < 0) {
-            return s + pos + 1;
-        }
-        pos += ag_max(alpha_skip_lookup[(unsigned char)s[pos]], find_skip_lookup[i]);
-    }
-
-    return NULL;
-}
-
-/* Copy-pasted from above. Yes I know this is bad. One day I might even fix it. */
-const char *boyer_moore_strncasestr(const char *s, const char *find, const size_t s_len, const size_t f_len,
-                                    const size_t alpha_skip_lookup[], const size_t *find_skip_lookup) {
-    ssize_t i;
-    size_t pos = f_len - 1;
-
-    while (pos < s_len) {
-        for (i = f_len - 1; i >= 0 && tolower(s[pos]) == find[i]; pos--, i--) {
+        for (i = f_len - 1; i >= 0 && case_insensitive ? tolower(s[pos]) : s[pos] == find[i]; pos--, i--) {
         }
         if (i < 0) {
             return s + pos + 1;
@@ -244,17 +226,6 @@ const char *hash_strnstr(const char *s, const char *find, const size_t s_len, co
     next_start:;
     }
     return NULL;
-}
-
-
-strncmp_fp get_strstr(enum case_behavior casing) {
-    strncmp_fp ag_strncmp_fp = &boyer_moore_strnstr;
-
-    if (casing == CASE_INSENSITIVE) {
-        ag_strncmp_fp = &boyer_moore_strncasestr;
-    }
-
-    return ag_strncmp_fp;
 }
 
 size_t invert_matches(const char *buf, const size_t buf_len, match_t matches[], size_t matches_len) {

--- a/src/util.h
+++ b/src/util.h
@@ -47,8 +47,6 @@ typedef struct {
 
 ag_stats stats;
 
-typedef const char *(*strncmp_fp)(const char *, const char *, const size_t, const size_t, const size_t[], const size_t *);
-
 /* Union to translate between chars and words without violating strict aliasing */
 typedef union {
     char as_chars[sizeof(uint16_t)];
@@ -67,12 +65,8 @@ void generate_hash(const char *find, const size_t f_len, uint8_t *H, const int c
 size_t ag_max(size_t a, size_t b);
 
 const char *boyer_moore_strnstr(const char *s, const char *find, const size_t s_len, const size_t f_len,
-                                const size_t alpha_skip_lookup[], const size_t *find_skip_lookup);
-const char *boyer_moore_strncasestr(const char *s, const char *find, const size_t s_len, const size_t f_len,
-                                    const size_t alpha_skip_lookup[], const size_t *find_skip_lookup);
+                                const size_t alpha_skip_lookup[], const size_t *find_skip_lookup, const int case_insensitive);
 const char *hash_strnstr(const char *s, const char *find, const size_t s_len, const size_t f_len, uint8_t *h_table, const int case_sensitive);
-
-strncmp_fp get_strstr(enum case_behavior opts);
 
 size_t invert_matches(const char *buf, const size_t buf_len, match_t matches[], size_t matches_len);
 void realloc_matches(match_t **matches, size_t *matches_size, size_t matches_len);


### PR DESCRIPTION
I unifyed the boyer-moore algorithm to get another parameter as ignore-case flag, now the code is clearer and there's no need of func proxy anymore