### PR TITLE
add support for jsp tag and fragment files

### DIFF
--- a/src/lang.c
+++ b/src/lang.c
@@ -43,7 +43,7 @@ lang_spec_t langs[] = {
     { "java", { "java", "properties" } },
     { "js", { "es6", "js", "jsx", "vue" } },
     { "json", { "json" } },
-    { "jsp", { "jsp", "jspx", "jhtm", "jhtml" } },
+    { "jsp", { "jsp", "jspx", "jhtm", "jhtml", "jspf", "tag", "tagf" } },
     { "julia", { "jl" } },
     { "kotlin", { "kt" } },
     { "less", { "less" } },

--- a/tests/list_file_types.t
+++ b/tests/list_file_types.t
@@ -121,7 +121,7 @@ Language types are output:
         .json
   
     --jsp
-        .jsp  .jspx  .jhtm  .jhtml .jspf .tag .tagf
+        .jsp  .jspx  .jhtm  .jhtml  .jspf  .tag  .tagf
   
     --julia
         .jl

--- a/tests/list_file_types.t
+++ b/tests/list_file_types.t
@@ -121,7 +121,7 @@ Language types are output:
         .json
   
     --jsp
-        .jsp  .jspx  .jhtm  .jhtml
+        .jsp  .jspx  .jhtm  .jhtml .jspf .tag .tagf
   
     --julia
         .jl


### PR DESCRIPTION
[Some java EE projects use .jspf, .tag and .tagf files.](http://docs.oracle.com/javaee/5/tutorial/doc/bnama.html)