### PR TITLE
Remove .agignore

### DIFF
--- a/src/ignore.c
+++ b/src/ignore.c
@@ -30,8 +30,6 @@ const char *evil_hardcoded_ignore_files[] = {
 
 /* Warning: changing the first two strings will break skip_vcs_ignores. */
 const char *ignore_pattern_files[] = {
-    /* Warning: .agignore will one day be removed in favor of .ignore */
-    ".agignore",
     ".ignore",
     ".gitignore",
     ".git/info/exclude",

--- a/src/search.c
+++ b/src/search.c
@@ -499,7 +499,7 @@ void search_dir(ignores *ig, const char *base_path, const char *path, const int 
     }
 
     /* find .*ignore files to load ignore patterns from */
-    for (i = 0; opts.skip_vcs_ignores ? (i <= 1) : (ignore_pattern_files[i] != NULL); i++) {
+    for (i = 0; opts.skip_vcs_ignores ? (i == 0) : (ignore_pattern_files[i] != NULL); i++) {
         ignore_file = ignore_pattern_files[i];
         ag_asprintf(&dir_full_path, "%s/%s", path, ignore_file);
         load_ignore_patterns(ig, dir_full_path);


### PR DESCRIPTION
`.ignore` is the canonical file to read patterns from.

This increases performance (since it tries to open one less file in each dir), but it breaks backwards compatibility, and so requires bumping to v2.0.