### PR TITLE
Add --print-all-files option

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -63,6 +63,8 @@ Output Options:\n\
                           (don't print the matching lines)\n\
   -L --files-without-matches\n\
                           Only print filenames that don't contain matches\n\
+     --all-files          Print headings for all files searched, even those that\n\
+                          don't contain matches\n\
      --[no]numbers        Print line numbers. Default is to omit line numbers\n\
                           when searching streams\n\
   -o --only-matching      Prints only the matching part of the lines\n\
@@ -158,6 +160,7 @@ void init_options(void) {
     opts.path_sep = '\n';
     opts.print_break = TRUE;
     opts.print_path = PATH_PRINT_DEFAULT;
+    opts.print_all_paths = FALSE;
     opts.print_line_numbers = TRUE;
     opts.recurse_dirs = TRUE;
     opts.color_path = ag_strdup(color_path);
@@ -231,6 +234,7 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
         { "ackmate-dir-filter", required_argument, NULL, 0 },
         { "affinity", no_argument, &opts.use_thread_affinity, 1 },
         { "after", optional_argument, NULL, 'A' },
+        { "all-files", no_argument, NULL, 0 },
         { "all-text", no_argument, NULL, 't' },
         { "all-types", no_argument, NULL, 'a' },
         { "before", optional_argument, NULL, 'B' },
@@ -510,7 +514,10 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
                 opts.path_sep = '\0';
                 break;
             case 0: /* Long option */
-                if (strcmp(longopts[opt_index].name, "ackmate-dir-filter") == 0) {
+                if (strcmp(longopts[opt_index].name, "all-files") == 0) {
+                    opts.print_all_paths = TRUE;
+                    break;
+                } else if (strcmp(longopts[opt_index].name, "ackmate-dir-filter") == 0) {
                     compile_study(&opts.ackmate_dir_filter, &opts.ackmate_dir_filter_extra, optarg, 0, 0);
                     break;
                 } else if (strcmp(longopts[opt_index].name, "depth") == 0) {

--- a/src/options.c
+++ b/src/options.c
@@ -63,7 +63,7 @@ Output Options:\n\
                           (don't print the matching lines)\n\
   -L --files-without-matches\n\
                           Only print filenames that don't contain matches\n\
-     --all-files          Print headings for all files searched, even those that\n\
+     --print-all-files    Print headings for all files searched, even those that\n\
                           don't contain matches\n\
      --[no]numbers        Print line numbers. Default is to omit line numbers\n\
                           when searching streams\n\
@@ -234,7 +234,6 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
         { "ackmate-dir-filter", required_argument, NULL, 0 },
         { "affinity", no_argument, &opts.use_thread_affinity, 1 },
         { "after", optional_argument, NULL, 'A' },
-        { "all-files", no_argument, NULL, 0 },
         { "all-text", no_argument, NULL, 't' },
         { "all-types", no_argument, NULL, 'a' },
         { "before", optional_argument, NULL, 'B' },
@@ -308,6 +307,7 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
         { "passthru", no_argument, &opts.passthrough, 1 },
         { "path-to-ignore", required_argument, NULL, 'p' },
         { "print0", no_argument, NULL, '0' },
+        { "print-all-files", no_argument, NULL, 0 },
         { "print-long-lines", no_argument, &opts.print_long_lines, 1 },
         { "recurse", no_argument, NULL, 'r' },
         { "search-binary", no_argument, &opts.search_binary_files, 1 },
@@ -514,10 +514,7 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
                 opts.path_sep = '\0';
                 break;
             case 0: /* Long option */
-                if (strcmp(longopts[opt_index].name, "all-files") == 0) {
-                    opts.print_all_paths = TRUE;
-                    break;
-                } else if (strcmp(longopts[opt_index].name, "ackmate-dir-filter") == 0) {
+                if (strcmp(longopts[opt_index].name, "ackmate-dir-filter") == 0) {
                     compile_study(&opts.ackmate_dir_filter, &opts.ackmate_dir_filter_extra, optarg, 0, 0);
                     break;
                 } else if (strcmp(longopts[opt_index].name, "depth") == 0) {
@@ -545,6 +542,9 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
                     break;
                 } else if (strcmp(longopts[opt_index].name, "pager") == 0) {
                     opts.pager = optarg;
+                    break;
+                } else if (strcmp(longopts[opt_index].name, "print-all-files") == 0) {
+                    opts.print_all_paths = TRUE;
                     break;
                 } else if (strcmp(longopts[opt_index].name, "workers") == 0) {
                     opts.workers = atoi(optarg);

--- a/src/options.h
+++ b/src/options.h
@@ -61,6 +61,7 @@ typedef struct {
     int print_count;
     int print_filename_only;
     int print_path;
+    int print_all_paths;
     int print_line_numbers;
     int print_long_lines; /* TODO: support this in print.c */
     int passthrough;

--- a/src/search.c
+++ b/src/search.c
@@ -174,7 +174,7 @@ multiline_done:
         pthread_mutex_unlock(&stats_mtx);
     }
 
-    if (matches_len > 0) {
+    if (matches_len > 0 || opts.print_all_paths) {
         if (binary == -1 && !opts.print_filename_only) {
             binary = is_binary((const void *)buf, buf_len);
         }

--- a/tests/all_files.t
+++ b/tests/all_files.t
@@ -1,0 +1,16 @@
+Setup:
+
+  $ . $TESTDIR/setup.sh
+  $ printf 'foo\n' > ./foo.txt
+  $ printf 'bar\n' > ./bar.txt
+  $ printf 'baz\n' > ./baz.txt
+
+All files:
+
+  $ ag --all-files --group foo
+  bar.txt
+  
+  baz.txt
+  
+  foo.txt
+  1:foo

--- a/tests/all_files.t
+++ b/tests/all_files.t
@@ -7,10 +7,10 @@ Setup:
 
 All files:
 
-  $ ag --all-files --group foo
-  bar.txt
+  $ ag --all-files --group foo | sort
   
-  baz.txt
   
-  foo.txt
   1:foo
+  bar.txt
+  baz.txt
+  foo.txt

--- a/tests/print_all_files.t
+++ b/tests/print_all_files.t
@@ -7,7 +7,7 @@ Setup:
 
 All files:
 
-  $ ag --all-files --group foo | sort
+  $ ag --print-all-files --group foo | sort
   
   
   1:foo


### PR DESCRIPTION
### Motivation

We'd like to explore using `ag` for Atom's [project search](https://github.com/atom/find-and-replace). But in the project search UI, while the search is in progress, we need to display to the user the number of paths that have been searched so far. None of `ag's` current options would allow us to do that. The `--stats` flag shows the total number of files `ag` searched, but only displays this information *after* the search is complete, whereas we need to update the count in real time while `ag` is still searching.

### Solution

We thought it would make sense to add an option called `--all-files` to include a 'heading' for *every* file that `ag` searches, not just those that contain matches.

For example:

```sh
$ printf 'foo\n' > ./foo.txt
$ printf 'bar\n' > ./bar.txt
$ printf 'baz\n' > ./baz.txt

# Show a heading for `bar.txt` and `baz.txt`, even though they don't contain matches.
$ ag --all-files --group foo
bar.txt

baz.txt
  
foo.txt
1:foo
```

If you have any suggestions about the name of the flag or an alternative solution that would let us know the number of paths searched so far, we'd be glad to make the changes.

Paired with @maxbrunsfeld