### PR TITLE
Fix -O detection in $CFLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -25,7 +25,7 @@ AX_PTHREAD(
 )
 
 # Run CFLAGS="-pg" ./configure if you want debug symbols
-if test "`$GREP -c '\b-O' >/dev/null ; echo $?`" = "0" ; then
+if ! echo "$CFLAGS" | "$GREP" '\(^\|[[[:space:]]]\)-O' > /dev/null; then
     CFLAGS="$CFLAGS -O2"
 fi
 


### PR DESCRIPTION
The commit 815d6975ab11c685a78379d9455f8ed14cb034fc (PR #1040) didn't work as expected.
`./configure` hung up in some situations because grep tried to search stdin.
Search pattern was also wrong.