### PR TITLE
Add fusion as possible extension

### DIFF
--- a/src/lang.c
+++ b/src/lang.c
@@ -30,6 +30,7 @@ lang_spec_t langs[] = {
     { "factor", { "factor" } },
     { "fortran", { "f", "f77", "f90", "f95", "f03", "for", "ftn", "fpp" } },
     { "fsharp", { "fs", "fsi", "fsx" } },
+    { "fusion", { "fusion" } },
     { "gettext", { "po", "pot", "mo" } },
     { "glsl", { "vert", "tesc", "tese", "geom", "frag", "comp" } },
     { "go", { "go" } },

--- a/tests/list_file_types.t
+++ b/tests/list_file_types.t
@@ -81,6 +81,9 @@ Language types are output:
     --fsharp
         .fs  .fsi  .fsx
   
+    --fusion
+        .fusion
+  
     --gettext
         .po  .pot  .mo
   


### PR DESCRIPTION
The neos-project(http://neos.io/) has it's own intermediate language called fusion which will be more and more dominant in NeosCMS projects (and maybe also Flow-Framework(the underlying framework)).

So it would be very nice if ag would be able to find contents in this files, I think it would be helpful for many people as the amount of developers for NeosCMS is growing more and more.

Thx!