### PR TITLE
zfile: define off64_t to fix cygwin build (Fix #1126)

### DIFF
--- a/src/zfile.c
+++ b/src/zfile.c
@@ -3,6 +3,10 @@
 #endif
 #include <sys/types.h>
 
+#ifdef __CYGWIN__
+typedef _off64_t off64_t;
+#endif
+
 #include <assert.h>
 #include <err.h>
 #include <errno.h>


### PR DESCRIPTION
Cygwin defines _off64_t, so typedef off64_t to that.