### PR TITLE
Support for special file names, CMake, Makefiles and Rakefiles

### DIFF
--- a/src/lang.c
+++ b/src/lang.c
@@ -5,132 +5,153 @@
 #include "util.h"
 
 lang_spec_t langs[] = {
-    { "actionscript", { "as", "mxml" } },
-    { "ada", { "ada", "adb", "ads" } },
-    { "asm", { "asm", "s" } },
-    { "batch", { "bat", "cmd" } },
-    { "bitbake", { "bb", "bbappend", "bbclass", "inc" } },
-    { "bro", { "bro", "bif" } },
-    { "cc", { "c", "h", "xs" } },
-    { "cfmx", { "cfc", "cfm", "cfml" } },
-    { "chpl", { "chpl" } },
-    { "clojure", { "clj", "cljs", "cljc", "cljx" } },
-    { "coffee", { "coffee", "cjsx" } },
-    { "cpp", { "cpp", "cc", "C", "cxx", "m", "hpp", "hh", "h", "H", "hxx", "tpp" } },
-    { "crystal", { "cr", "ecr" } },
-    { "csharp", { "cs" } },
-    { "css", { "css" } },
-    { "cython", { "pyx", "pxd", "pxi" } },
-    { "delphi", { "pas", "int", "dfm", "nfm", "dof", "dpk", "dpr", "dproj", "groupproj", "bdsgroup", "bdsproj" } },
-    { "ebuild", { "ebuild", "eclass" } },
-    { "elisp", { "el" } },
-    { "elixir", { "ex", "eex", "exs" } },
-    { "elm", { "elm" } },
-    { "erlang", { "erl", "hrl" } },
-    { "factor", { "factor" } },
-    { "fortran", { "f", "f77", "f90", "f95", "f03", "for", "ftn", "fpp" } },
-    { "fsharp", { "fs", "fsi", "fsx" } },
-    { "gettext", { "po", "pot", "mo" } },
-    { "glsl", { "vert", "tesc", "tese", "geom", "frag", "comp" } },
-    { "go", { "go" } },
-    { "groovy", { "groovy", "gtmpl", "gpp", "grunit", "gradle" } },
-    { "haml", { "haml" } },
-    { "haskell", { "hs", "lhs" } },
-    { "haxe", { "hx" } },
-    { "hh", { "h" } },
-    { "html", { "htm", "html", "shtml", "xhtml" } },
-    { "ini", { "ini" } },
-    { "jade", { "jade" } },
-    { "java", { "java", "properties" } },
-    { "js", { "es6", "js", "jsx", "vue" } },
-    { "json", { "json" } },
-    { "jsp", { "jsp", "jspx", "jhtm", "jhtml", "jspf", "tag", "tagf" } },
-    { "julia", { "jl" } },
-    { "kotlin", { "kt" } },
-    { "less", { "less" } },
-    { "liquid", { "liquid" } },
-    { "lisp", { "lisp", "lsp" } },
-    { "log", { "log" } },
-    { "lua", { "lua" } },
-    { "m4", { "m4" } },
-    { "make", { "Makefiles", "mk", "mak" } },
-    { "mako", { "mako" } },
-    { "markdown", { "markdown", "mdown", "mdwn", "mkdn", "mkd", "md" } },
-    { "mason", { "mas", "mhtml", "mpl", "mtxt" } },
-    { "matlab", { "m" } },
-    { "mathematica", { "m", "wl" } },
-    { "md", { "markdown", "mdown", "mdwn", "mkdn", "mkd", "md" } },
-    { "mercury", { "m", "moo" } },
-    { "nim", { "nim" } },
-    { "objc", { "m", "h" } },
-    { "objcpp", { "mm", "h" } },
-    { "ocaml", { "ml", "mli", "mll", "mly" } },
-    { "octave", { "m" } },
-    { "parrot", { "pir", "pasm", "pmc", "ops", "pod", "pg", "tg" } },
-    { "perl", { "pl", "pm", "pm6", "pod", "t" } },
-    { "php", { "php", "phpt", "php3", "php4", "php5", "phtml" } },
-    { "pike", { "pike", "pmod" } },
-    { "plist", { "plist" } },
-    { "plone", { "pt", "cpt", "metadata", "cpy", "py", "xml", "zcml" } },
-    { "proto", { "proto" } },
-    { "puppet", { "pp" } },
-    { "python", { "py" } },
-    { "qml", { "qml" } },
-    { "racket", { "rkt", "ss", "scm" } },
-    { "rake", { "Rakefile" } },
-    { "restructuredtext", { "rst" } },
-    { "rs", { "rs" } },
-    { "r", { "R", "Rmd", "Rnw", "Rtex", "Rrst" } },
-    { "rdoc", { "rdoc" } },
-    { "ruby", { "rb", "rhtml", "rjs", "rxml", "erb", "rake", "spec" } },
-    { "rust", { "rs" } },
-    { "salt", { "sls" } },
-    { "sass", { "sass", "scss" } },
-    { "scala", { "scala" } },
-    { "scheme", { "scm", "ss" } },
-    { "shell", { "sh", "bash", "csh", "tcsh", "ksh", "zsh", "fish" } },
-    { "smalltalk", { "st" } },
-    { "sml", { "sml", "fun", "mlb", "sig" } },
-    { "sql", { "sql", "ctl" } },
-    { "stylus", { "styl" } },
-    { "swift", { "swift" } },
-    { "tcl", { "tcl", "itcl", "itk" } },
-    { "tex", { "tex", "cls", "sty" } },
-    { "tt", { "tt", "tt2", "ttml" } },
-    { "toml", { "toml" } },
-    { "ts", { "ts", "tsx" } },
-    { "twig", { "twig" } },
-    { "vala", { "vala", "vapi" } },
-    { "vb", { "bas", "cls", "frm", "ctl", "vb", "resx" } },
-    { "velocity", { "vm", "vtl", "vsl" } },
-    { "verilog", { "v", "vh", "sv" } },
-    { "vhdl", { "vhd", "vhdl" } },
-    { "vim", { "vim" } },
-    { "wix", { "wxi", "wxs" } },
-    { "wsdl", { "wsdl" } },
-    { "wadl", { "wadl" } },
-    { "xml", { "xml", "dtd", "xsl", "xslt", "ent", "tld", "plist" } },
-    { "yaml", { "yaml", "yml" } }
+    { "actionscript", { "as", "mxml" }, {} },
+    { "ada", { "ada", "adb", "ads" }, {} },
+    { "asm", { "asm", "s" }, {} },
+    { "batch", { "bat", "cmd" }, {} },
+    { "bitbake", { "bb", "bbappend", "bbclass", "inc" }, {} },
+    { "bro", { "bro", "bif" }, {} },
+    { "cc", { "c", "h", "xs" }, {} },
+    { "cfmx", { "cfc", "cfm", "cfml" }, {} },
+    { "chpl", { "chpl" }, {} },
+    { "clojure", { "clj", "cljs", "cljc", "cljx" }, {} },
+    { "cmake", { "cmake" }, { "CMakeLists.txt" } },
+    { "coffee", { "coffee", "cjsx" }, {} },
+    { "cpp", { "cpp", "cc", "C", "cxx", "m", "hpp", "hh", "h", "H", "hxx", "tpp" }, {} },
+    { "crystal", { "cr", "ecr" }, {} },
+    { "csharp", { "cs" }, {} },
+    { "css", { "css" }, {} },
+    { "cython", { "pyx", "pxd", "pxi" }, {} },
+    { "delphi", { "pas", "int", "dfm", "nfm", "dof", "dpk", "dpr", "dproj", "groupproj", "bdsgroup", "bdsproj" }, {} },
+    { "ebuild", { "ebuild", "eclass" }, {} },
+    { "elisp", { "el" }, {} },
+    { "elixir", { "ex", "eex", "exs" }, {} },
+    { "elm", { "elm" }, {} },
+    { "erlang", { "erl", "hrl" }, {} },
+    { "factor", { "factor" }, {} },
+    { "fortran", { "f", "f77", "f90", "f95", "f03", "for", "ftn", "fpp" }, {} },
+    { "fsharp", { "fs", "fsi", "fsx" }, {} },
+    { "gettext", { "po", "pot", "mo" }, {} },
+    { "glsl", { "vert", "tesc", "tese", "geom", "frag", "comp" }, {} },
+    { "go", { "go" }, {} },
+    { "groovy", { "groovy", "gtmpl", "gpp", "grunit", "gradle" }, {} },
+    { "haml", { "haml" }, {} },
+    { "haskell", { "hs", "lhs" }, {} },
+    { "haxe", { "hx" }, {} },
+    { "hh", { "h" }, {} },
+    { "html", { "htm", "html", "shtml", "xhtml" }, {} },
+    { "ini", { "ini" }, {} },
+    { "jade", { "jade" }, {} },
+    { "java", { "java", "properties" }, {} },
+    { "js", { "es6", "js", "jsx", "vue" }, {} },
+    { "json", { "json" }, {} },
+    { "jsp", { "jsp", "jspx", "jhtm", "jhtml", "jspf", "tag", "tagf" }, {} },
+    { "julia", { "jl" }, {} },
+    { "kotlin", { "kt" }, {} },
+    { "less", { "less" }, {} },
+    { "liquid", { "liquid" }, {} },
+    { "lisp", { "lisp", "lsp" }, {} },
+    { "log", { "log" }, {} },
+    { "lua", { "lua" }, {} },
+    { "m4", { "m4" }, {} },
+    { "make", { "Makefiles", "mk", "mak" }, { "Makefile" } },
+    { "mako", { "mako" }, {} },
+    { "markdown", { "markdown", "mdown", "mdwn", "mkdn", "mkd", "md" }, {} },
+    { "mason", { "mas", "mhtml", "mpl", "mtxt" }, {} },
+    { "matlab", { "m" }, {} },
+    { "mathematica", { "m", "wl" }, {} },
+    { "md", { "markdown", "mdown", "mdwn", "mkdn", "mkd", "md" }, {} },
+    { "mercury", { "m", "moo" }, {} },
+    { "nim", { "nim" }, {} },
+    { "objc", { "m", "h" }, {} },
+    { "objcpp", { "mm", "h" }, {} },
+    { "ocaml", { "ml", "mli", "mll", "mly" }, {} },
+    { "octave", { "m" }, {} },
+    { "parrot", { "pir", "pasm", "pmc", "ops", "pod", "pg", "tg" }, {} },
+    { "perl", { "pl", "pm", "pm6", "pod", "t" }, {} },
+    { "php", { "php", "phpt", "php3", "php4", "php5", "phtml" }, {} },
+    { "pike", { "pike", "pmod" }, {} },
+    { "plist", { "plist" }, {} },
+    { "plone", { "pt", "cpt", "metadata", "cpy", "py", "xml", "zcml" }, {} },
+    { "proto", { "proto" }, {} },
+    { "puppet", { "pp" }, {} },
+    { "python", { "py" }, {} },
+    { "qml", { "qml" }, {} },
+    { "racket", { "rkt", "ss", "scm" }, {} },
+    { "rake", {}, { "Rakefile" } },
+    { "restructuredtext", { "rst" }, {} },
+    { "rs", { "rs" }, {} },
+    { "r", { "R", "Rmd", "Rnw", "Rtex", "Rrst" }, {} },
+    { "rdoc", { "rdoc" }, {} },
+    { "ruby", { "rb", "rhtml", "rjs", "rxml", "erb", "rake", "spec" }, {} },
+    { "rust", { "rs" }, {} },
+    { "salt", { "sls" }, {} },
+    { "sass", { "sass", "scss" }, {} },
+    { "scala", { "scala" }, {} },
+    { "scheme", { "scm", "ss" }, {} },
+    { "shell", { "sh", "bash", "csh", "tcsh", "ksh", "zsh", "fish" }, {} },
+    { "smalltalk", { "st" }, {} },
+    { "sml", { "sml", "fun", "mlb", "sig" }, {} },
+    { "sql", { "sql", "ctl" }, {} },
+    { "stylus", { "styl" }, {} },
+    { "swift", { "swift" }, {} },
+    { "tcl", { "tcl", "itcl", "itk" }, {} },
+    { "tex", { "tex", "cls", "sty" }, {} },
+    { "tt", { "tt", "tt2", "ttml" }, {} },
+    { "toml", { "toml" }, {} },
+    { "ts", { "ts", "tsx" }, {} },
+    { "twig", { "twig" }, {} },
+    { "vala", { "vala", "vapi" }, {} },
+    { "vb", { "bas", "cls", "frm", "ctl", "vb", "resx" }, {} },
+    { "velocity", { "vm", "vtl", "vsl" }, {} },
+    { "verilog", { "v", "vh", "sv" }, {} },
+    { "vhdl", { "vhd", "vhdl" }, {} },
+    { "vim", { "vim" }, {} },
+    { "wix", { "wxi", "wxs" }, {} },
+    { "wsdl", { "wsdl" }, {} },
+    { "wadl", { "wadl" }, {} },
+    { "xml", { "xml", "dtd", "xsl", "xslt", "ent", "tld", "plist" }, {} },
+    { "yaml", { "yaml", "yml" }, {} }
 };
 
 size_t get_lang_count() {
     return sizeof(langs) / sizeof(lang_spec_t);
 }
 
-char *make_lang_regex(char *ext_array, size_t num_exts) {
+char *make_lang_regex(char *ext_array, size_t num_exts, char *name_array, size_t num_names) {
     int regex_capacity = 100;
     char *regex = ag_malloc(regex_capacity);
-    int regex_length = 3;
+    int regex_length = 0;
     int subsequent = 0;
-    char *extension;
     size_t i;
 
-    strcpy(regex, "\\.(");
+    if (num_exts > 0) {
+        regex_length = 4;
+        strcpy(regex, "(\\.(");
 
-    for (i = 0; i < num_exts; ++i) {
-        extension = ext_array + i * SINGLE_EXT_LEN;
-        int extension_length = strlen(extension);
-        while (regex_length + extension_length + 3 + subsequent > regex_capacity) {
+        for (i = 0; i < num_exts; ++i) {
+            const char *extension = ext_array + i * SINGLE_EXT_LEN;
+            int extension_length = strlen(extension);
+            while (regex_length + extension_length + 3 + subsequent > regex_capacity) {
+                regex_capacity *= 2;
+                regex = ag_realloc(regex, regex_capacity);
+            }
+            if (subsequent) {
+                regex[regex_length++] = '|';
+            } else {
+                subsequent = 1;
+            }
+            strcpy(regex + regex_length, extension);
+            regex_length += extension_length;
+        }
+
+        regex[regex_length++] = ')';
+    }
+
+    for (i = 0; i < num_names; ++i) {
+        const char *name = name_array + i * SINGLE_NAME_LEN;
+        int name_length = strlen(name);
+        while (regex_length + name_length + 3 + subsequent > regex_capacity) {
             regex_capacity *= 2;
             regex = ag_realloc(regex, regex_capacity);
         }
@@ -139,30 +160,39 @@ char *make_lang_regex(char *ext_array, size_t num_exts) {
         } else {
             subsequent = 1;
         }
-        strcpy(regex + regex_length, extension);
-        regex_length += extension_length;
+        regex[regex_length++] = '/';
+        strcpy(regex + regex_length, name);
+        regex_length += name_length;
     }
 
-    regex[regex_length++] = ')';
+    if (num_exts > 0)
+        regex[regex_length++] = ')';
     regex[regex_length++] = '$';
     regex[regex_length++] = 0;
+
     return regex;
 }
 
-size_t combine_file_extensions(size_t *extension_index, size_t len, char **exts) {
+void combine_file_extensions(size_t *extension_index, size_t len,
+                             size_t *num_extensions, char **exts,
+                             size_t *num_names, char **names) {
     /* Keep it fixed as 100 for the reason that if you have more than 100
      * file types to search, you'd better search all the files.
      * */
-    size_t ext_capacity = 100;
+    static const size_t ext_capacity = 100;
+    static const size_t name_capacity = 100;
     (*exts) = (char *)ag_malloc(ext_capacity * SINGLE_EXT_LEN);
     memset((*exts), 0, ext_capacity * SINGLE_EXT_LEN);
+    (*names) = (char *)ag_malloc(ext_capacity * SINGLE_NAME_LEN);
+    memset((*names), 0, name_capacity * SINGLE_NAME_LEN);
     size_t num_of_extensions = 0;
+    size_t num_of_names = 0;
 
     size_t i;
     for (i = 0; i < len; ++i) {
         size_t j = 0;
         const char *ext = langs[extension_index[i]].extensions[j];
-        do {
+        while (ext) {
             if (num_of_extensions == ext_capacity) {
                 break;
             }
@@ -170,8 +200,21 @@ size_t combine_file_extensions(size_t *extension_index, size_t len, char **exts)
             strncpy(pos, ext, strlen(ext));
             ++num_of_extensions;
             ext = langs[extension_index[i]].extensions[++j];
-        } while (ext);
+        }
+
+        j = 0;
+        const char *name = langs[extension_index[i]].names[j];
+        while (name) {
+            if (num_of_names == name_capacity) {
+                break;
+            }
+            char *pos = (*names) + num_of_names * SINGLE_NAME_LEN;
+            strncpy(pos, name, strlen(name));
+            ++num_of_names;
+            name = langs[extension_index[i]].names[++j];
+        }
     }
 
-    return num_of_extensions;
+    *num_extensions = num_of_extensions;
+    *num_names = num_of_names;
 }

--- a/src/lang.h
+++ b/src/lang.h
@@ -4,9 +4,13 @@
 #define MAX_EXTENSIONS 12
 #define SINGLE_EXT_LEN 20
 
+#define MAX_NAMES 12
+#define SINGLE_NAME_LEN 20
+
 typedef struct {
     const char *name;
     const char *extensions[MAX_EXTENSIONS];
+    const char *names[MAX_NAMES];
 } lang_spec_t;
 
 extern lang_spec_t langs[];
@@ -22,15 +26,18 @@ into a regular expression of the form \.(extension1|extension2...)$
 
 Caller is responsible for freeing the returned string.
 */
-char *make_lang_regex(char *ext_array, size_t num_exts);
+char *make_lang_regex(char *ext_array, size_t num_exts, char *name_array, size_t num_names);
 
 
 /**
-Combine multiple file type extensions into one array.
+Combine multiple file type extensions and names into one arrays.
 
-The combined result is returned through *exts*;
-*exts* is one-dimension array, which can contain up to 100 extensions;
-The number of extensions that *exts* actually contain is returned.
+The combined result is returned through *exts* and *names*;
+both are one-dimension arrays, which can contain up to 100 extensions;
+The number of extensions that *exts* and *names* contain are returned
+through num_extensions and num_names.
 */
-size_t combine_file_extensions(size_t *extension_index, size_t len, char **exts);
+void combine_file_extensions(size_t *extension_index, size_t len,
+                             size_t *num_extensions, char **exts,
+                             size_t *num_names, char **names);
 #endif

--- a/src/lang.h
+++ b/src/lang.h
@@ -2,10 +2,7 @@
 #define LANG_H
 
 #define MAX_EXTENSIONS 12
-#define SINGLE_EXT_LEN 20
-
 #define MAX_NAMES 12
-#define SINGLE_NAME_LEN 20
 
 typedef struct {
     const char *name;
@@ -26,18 +23,18 @@ into a regular expression of the form \.(extension1|extension2...)$
 
 Caller is responsible for freeing the returned string.
 */
-char *make_lang_regex(char *ext_array, size_t num_exts, char *name_array, size_t num_names);
+char *make_lang_regex(const char **ext_array, size_t num_exts, const char **name_array, size_t num_names);
 
 
 /**
-Combine multiple file type extensions and names into one arrays.
+Combine multiple file type extensions and names into arrays.
 
 The combined result is returned through *exts* and *names*;
-both are one-dimension arrays, which can contain up to 100 extensions;
+both are pointer to string arrays, which can contain up to 100 extensions;
 The number of extensions that *exts* and *names* contain are returned
 through num_extensions and num_names.
 */
 void combine_file_extensions(size_t *extension_index, size_t len,
-                             size_t *num_extensions, char **exts,
-                             size_t *num_names, char **names);
+                             size_t *num_extensions, const char ***exts,
+                             size_t *num_names, const char ***names);
 #endif

--- a/src/options.c
+++ b/src/options.c
@@ -225,9 +225,9 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
     option_t *longopts;
     char *lang_regex = NULL;
     size_t *ext_index = NULL;
-    char *extensions = NULL;
+    const char **extensions = NULL;
     size_t num_exts = 0;
-    char *names = NULL;
+    const char **names = NULL;
     size_t num_names = 0;
 
     init_options();

--- a/src/options.c
+++ b/src/options.c
@@ -227,6 +227,8 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
     size_t *ext_index = NULL;
     char *extensions = NULL;
     size_t num_exts = 0;
+    char *names = NULL;
+    size_t num_names = 0;
 
     init_options();
 
@@ -614,13 +616,16 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
     }
 
     if (has_filetype) {
-        num_exts = combine_file_extensions(ext_index, lang_num, &extensions);
-        lang_regex = make_lang_regex(extensions, num_exts);
+        combine_file_extensions(ext_index, lang_num, &num_exts, &extensions, &num_names, &names);
+        lang_regex = make_lang_regex(extensions, num_exts, names, num_names);
         compile_study(&opts.file_search_regex, &opts.file_search_regex_extra, lang_regex, 0, 0);
     }
 
     if (extensions) {
         free(extensions);
+    }
+    if (names) {
+        free(names);
     }
     free(ext_index);
     if (lang_regex) {
@@ -663,6 +668,9 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
         for (lang_index = 0; lang_index < lang_count; lang_index++) {
             printf("  --%s\n    ", langs[lang_index].name);
             int j;
+            for (j = 0; j < MAX_NAMES && langs[lang_index].names[j]; j++) {
+                printf("  %s", langs[lang_index].names[j]);
+            }
             for (j = 0; j < MAX_EXTENSIONS && langs[lang_index].extensions[j]; j++) {
                 printf("  .%s", langs[lang_index].extensions[j]);
             }

--- a/tests/list_file_types.t
+++ b/tests/list_file_types.t
@@ -36,6 +36,9 @@ Language types are output:
     --clojure
         .clj  .cljs  .cljc  .cljx
   
+    --cmake
+        CMakeLists.txt  .cmake
+  
     --coffee
         .coffee  .cjsx
   
@@ -151,7 +154,7 @@ Language types are output:
         .m4
   
     --make
-        .Makefiles  .mk  .mak
+        Makefile  .Makefiles  .mk  .mak
   
     --mako
         .mako
@@ -223,7 +226,7 @@ Language types are output:
         .rkt  .ss  .scm
   
     --rake
-        .Rakefile
+        Rakefile
   
     --restructuredtext
         .rst


### PR DESCRIPTION
This PR adds special filenames to go with extensions, to add support for CMakeLists.txt, Makefile, Rakefile and possible other special files.

A second commit reduces copying and fixes potential buffer overrun if a single filename/extension takes over SINGLE_EXT_LEN or more or a single language has more than MAX_EXTENSIONS extensions, which would overwrite the zero byte or null pointer at end of array.