### PR TITLE
Add sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ or
 
 * Ubuntu >= 13.10 (Saucy) or Debian >= 8 (Jessie)
 
-        apt-get install silversearcher-ag
+      sudo  apt-get install silversearcher-ag
 * Fedora 21 and lower
 
         yum install the_silver_searcher


### PR DESCRIPTION
`apt-get` needs `sudo` to install on Debian/Ubuntu.