### PR TITLE
zfile: fix build and runtime errors

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,8 +1,12 @@
 ACLOCAL_AMFLAGS = ${ACLOCAL_FLAGS}
 
 bin_PROGRAMS = ag
-ag_SOURCES = src/ignore.c src/ignore.h src/log.c src/log.h src/options.c src/options.h src/print.c src/print_w32.c src/print.h src/scandir.c src/scandir.h src/search.c src/search.h src/lang.c src/lang.h src/util.c src/util.h src/decompress.c src/decompress.h src/uthash.h src/main.c src/zfile.c
+ag_SOURCES = src/ignore.c src/ignore.h src/log.c src/log.h src/options.c src/options.h src/print.c src/print_w32.c src/print.h src/scandir.c src/scandir.h src/search.c src/search.h src/lang.c src/lang.h src/util.c src/util.h src/decompress.c src/decompress.h src/uthash.h src/main.c
 ag_LDADD = ${PCRE_LIBS} ${LZMA_LIBS} ${ZLIB_LIBS} $(PTHREAD_LIBS)
+
+if USE_FOPENCOOKIE
+ag_SOURCES += src/zfile.c src/zfile.h
+endif
 
 dist_man_MANS = doc/ag.1
 

--- a/configure.ac
+++ b/configure.ac
@@ -66,6 +66,11 @@ AC_CHECK_MEMBER([struct dirent.d_namlen], [AC_DEFINE([HAVE_DIRENT_DNAMLEN], [], 
 
 AC_CHECK_FUNCS(fgetln fopencookie getline realpath strlcpy strndup vasprintf madvise posix_fadvise pthread_setaffinity_np pledge)
 
+# Only build zfile.c if we need it
+AM_CONDITIONAL([USE_FOPENCOOKIE], [(test "$ac_cv_func_fopencookie" = "yes") &&
+                                   (test "$ac_cv_header_zlib_h" = "yes" || test "$ac_cv_header_lzma_h" = "yes")])
+AM_COND_IF([USE_FOPENCOOKIE], [AC_DEFINE([USE_FOPENCOOKIE], [], [Use fopencookie streaming in zfile.c])])
+
 AC_CONFIG_FILES([Makefile the_silver_searcher.spec])
 AC_CONFIG_HEADERS([src/config.h])
 

--- a/src/decompress.h
+++ b/src/decompress.h
@@ -19,7 +19,7 @@ ag_compression_type is_zipped(const void *buf, const int buf_len);
 
 void *decompress(const ag_compression_type zip_type, const void *buf, const int buf_len, const char *dir_full_path, int *new_buf_len);
 
-#if HAVE_FOPENCOOKIE
+#ifdef USE_FOPENCOOKIE
 FILE *decompress_open(int fd, const char *mode, ag_compression_type ctype);
 #endif
 

--- a/src/decompress.h
+++ b/src/decompress.h
@@ -20,7 +20,7 @@ ag_compression_type is_zipped(const void *buf, const int buf_len);
 void *decompress(const ag_compression_type zip_type, const void *buf, const int buf_len, const char *dir_full_path, int *new_buf_len);
 
 #ifdef USE_FOPENCOOKIE
-FILE *decompress_open(int fd, const char *mode, ag_compression_type ctype);
+FILE *decompress_open(int fd, const char *mode, ag_compression_type ctype, const char *filepath);
 #endif
 
 #endif

--- a/src/search.c
+++ b/src/search.c
@@ -357,7 +357,7 @@ void search_file(const char *file_full_path) {
     if (opts.search_zip_files) {
         ag_compression_type zip_type = is_zipped(buf, f_len);
         if (zip_type != AG_NO_COMPRESSION) {
-#if HAVE_FOPENCOOKIE
+#ifdef USE_FOPENCOOKIE
             log_debug("%s is a compressed file. stream searching", file_full_path);
             fp = decompress_open(fd, "r", zip_type);
             search_stream(fp, file_full_path);

--- a/src/search.c
+++ b/src/search.c
@@ -359,7 +359,7 @@ void search_file(const char *file_full_path) {
         if (zip_type != AG_NO_COMPRESSION) {
 #ifdef USE_FOPENCOOKIE
             log_debug("%s is a compressed file. stream searching", file_full_path);
-            fp = decompress_open(fd, "r", zip_type);
+            fp = decompress_open(fd, "r", zip_type, file_full_path);
             search_stream(fp, file_full_path);
             fclose(fp);
 #else

--- a/src/zfile.c
+++ b/src/zfile.c
@@ -50,6 +50,7 @@ static const cookie_io_functions_t zfile_io = {
 #define KB (1024)
 struct zfile {
     FILE *in;              // Source FILE stream
+    const char *filepath;  // file path (used only for error printing)
     uint64_t logic_offset, // Logical offset in output (forward seeks)
         decode_offset,     // Where we've decoded to
         actual_len;
@@ -165,7 +166,7 @@ zfile_cookie_cleanup(struct zfile *cookie) {
  * read-only stream.
  */
 FILE *
-decompress_open(int fd, const char *mode, ag_compression_type ctype) {
+decompress_open(int fd, const char *mode, ag_compression_type ctype, const char *filepath) {
     struct zfile *cookie;
     FILE *res, *in;
     int error;
@@ -192,6 +193,7 @@ decompress_open(int fd, const char *mode, ag_compression_type ctype) {
         goto out;
     }
 
+    cookie->filepath = filepath;
     cookie->in = in;
     cookie->logic_offset = 0;
     cookie->decode_offset = 0;
@@ -318,12 +320,12 @@ zfile_read(void *cookie_, char *buf, size_t size) {
             nb = fread(cookie->inbuf, 1, sizeof cookie->inbuf,
                        cookie->in);
             if (ferror(cookie->in)) {
-                warn("error read core");
-                exit(1);
+                log_err("%s: zfile: fread error", cookie->filepath);
+                return -1;
             }
-            if (nb == 0 && feof(cookie->in)) {
-                warn("truncated file");
-                exit(1);
+            if (nb == 0 && !feof(cookie->in)) {
+                log_err("%s: zfile: truncated file", cookie->filepath);
+                return -1;
             }
             if (cookie->ctype == AG_XZ) {
 #ifdef HAVE_LZMA_H
@@ -356,7 +358,7 @@ zfile_read(void *cookie_, char *buf, size_t size) {
 #ifdef HAVE_ZLIB_H
             ret = inflate(&cookie->stream.gz, Z_NO_FLUSH);
             if (ret != Z_OK && ret != Z_STREAM_END) {
-                log_err("Found mem/data error while decompressing zlib stream: %s", zError(ret));
+                log_err("%s: Found mem/data error while decompressing zlib stream: %s", cookie->filepath, zError(ret));
                 return -1;
             }
 #endif
@@ -364,7 +366,7 @@ zfile_read(void *cookie_, char *buf, size_t size) {
 #ifdef HAVE_LZMA_H
             lzret = lzma_code(&cookie->stream.lzma, LZMA_RUN);
             if (lzret != LZMA_OK && lzret != LZMA_STREAM_END) {
-                log_err("Found mem/data error while decompressing xz/lzma stream: %d", lzret);
+                log_err("%s: Found mem/data error while decompressing xz/lzma stream: %d", cookie->filepath, lzret);
                 return -1;
             }
 #endif


### PR DESCRIPTION
As reported in #1147, the build fails if either `zlib.h` or `lzma.h` are unavailable.

Additionally, the feof check in zfile.c is backwards and causes a "truncated file" abort after searching the first zipped file.