### PR TITLE
Fix for bug #1158

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -213,7 +213,7 @@ int main(int argc, char **argv) {
         double time_diff = ((long)stats.time_end.tv_sec * 1000000 + stats.time_end.tv_usec) -
                            ((long)stats.time_start.tv_sec * 1000000 + stats.time_start.tv_usec);
         time_diff /= 1000000;
-        printf("%ld matches\n%ld files contained matches\n%ld files searched\n%ld bytes searched\n%f seconds\n",
+        printf("%ld matches\n%ld files contained matches\n%ld files searched\n%lld bytes searched\n%f seconds\n",
                stats.total_matches, stats.total_file_matches, stats.total_files, stats.total_bytes, time_diff);
         pthread_mutex_destroy(&stats_mtx);
     }

--- a/src/util.h
+++ b/src/util.h
@@ -42,7 +42,7 @@ typedef struct {
 } match_t;
 
 typedef struct {
-    long total_bytes;
+    long long total_bytes;
     long total_files;
     long total_matches;
     long total_file_matches;


### PR DESCRIPTION
A very simple fix, using a 64-bits variable for the stats.total_bytes field.