### PR TITLE
Fix --filename with single file searches

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -522,7 +522,7 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
                     opts.max_search_depth = atoi(optarg);
                     break;
                 } else if (strcmp(longopts[opt_index].name, "filename") == 0) {
-                    opts.print_path = PATH_PRINT_DEFAULT;
+                    opts.print_path = PATH_PRINT_FORCED;
                     opts.print_line_numbers = TRUE;
                     break;
                 } else if (strcmp(longopts[opt_index].name, "ignore-dir") == 0) {

--- a/src/options.h
+++ b/src/options.h
@@ -21,6 +21,7 @@ enum case_behavior {
 enum path_print_behavior {
     PATH_PRINT_DEFAULT,           /* PRINT_TOP if > 1 file being searched, else PRINT_NOTHING */
     PATH_PRINT_DEFAULT_EACH_LINE, /* PRINT_EACH_LINE if > 1 file being searched, else PRINT_NOTHING */
+    PATH_PRINT_FORCED,
     PATH_PRINT_TOP,
     PATH_PRINT_EACH_LINE,
     PATH_PRINT_NOTHING

--- a/src/print.c
+++ b/src/print.c
@@ -158,7 +158,7 @@ void print_file_matches(const char *path, const char *buf, const size_t buf_len,
 
     print_file_separator();
 
-    if (opts.print_path == PATH_PRINT_DEFAULT) {
+    if (opts.print_path == PATH_PRINT_DEFAULT || opts.print_path == PATH_PRINT_FORCED) {
         opts.print_path = PATH_PRINT_TOP;
     } else if (opts.print_path == PATH_PRINT_DEFAULT_EACH_LINE) {
         opts.print_path = PATH_PRINT_EACH_LINE;

--- a/tests/single_file_match.t
+++ b/tests/single_file_match.t
@@ -1,0 +1,15 @@
+Setup:
+
+  $ . $TESTDIR/setup.sh
+  $ printf 'foo\n' > ./foo.txt
+
+Without filename argument:
+
+  $ ag foo foo.txt
+  1:foo
+
+With filename argument:
+
+  $ ag --filename foo foo.txt
+  foo.txt
+  1:foo


### PR DESCRIPTION
Previously if you passed the --filename argument when searching a single
file, the value of print_path would be overwritten. This adds a new
PATH_PRINT_FORCED option for when users specifically pass --filename
(versus it being set by the default) so that it will not get
overwritten. I've also added a test to cover this case

Fixes https://github.com/ggreer/the_silver_searcher/issues/972