### PR TITLE
README: Windows installation using Scoop added

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ or
 * Win32/64
 
   Unofficial daily builds are [available](https://github.com/k-takata/the_silver_searcher-win32).
+  
+  Available as community-maintained package via [Scoop](http://scoop.sh/) command-line installer:
+
+        scoop install ag
+
 * MSYS2
 
         pacman -S mingw-w64-{i686,x86_64}-ag


### PR DESCRIPTION
Added an description of 1 more installation possibility for `Windows` users.

`ag` can be installed as a package from [Scoop](http://scoop.sh/) command-line installer.