### PR TITLE
Fix pgo.sh so that it actually does the thing.

### DIFF
--- a/pgo.sh
+++ b/pgo.sh
@@ -4,9 +4,7 @@ set -e
 cd "$(dirname "$0")"
 
 make clean
-CFLAGS="$CFLAGS -fprofile-generate"
-./build.sh
+./build.sh CFLAGS="$CFLAGS -fprofile-generate"
 ./ag example ..
 make clean
-CFLAGS="$CFLAGS -fprofile-use"
-./build.sh
+./build.sh CFLAGS="$CFLAGS -fprofile-correction -fprofile-use"


### PR DESCRIPTION
I noticed that profile guided optimization didn't work on Windows 10 under cygwin. I also tested it in Debian stretch. I moved the CFLAGS to the ./configure so that it works now.

I didn't test to see if it actually made things faster, though I am curious.