### PR TITLE
Add .r to R file type

### DIFF
--- a/src/lang.c
+++ b/src/lang.c
@@ -89,7 +89,7 @@ lang_spec_t langs[] = {
     { "rake", { "Rakefile" } },
     { "restructuredtext", { "rst" } },
     { "rs", { "rs" } },
-    { "r", { "R", "Rmd", "Rnw", "Rtex", "Rrst" } },
+    { "r", { "r", "R", "Rmd", "Rnw", "Rtex", "Rrst" } },
     { "rdoc", { "rdoc" } },
     { "ruby", { "rb", "rhtml", "rjs", "rxml", "erb", "rake", "spec" } },
     { "rust", { "rs" } },

--- a/tests/list_file_types.t
+++ b/tests/list_file_types.t
@@ -259,7 +259,7 @@ Language types are output:
         .rs
   
     --r
-        .R  .Rmd  .Rnw  .Rtex  .Rrst
+        .r  .R  .Rmd  .Rnw  .Rtex  .Rrst
   
     --rdoc
         .rdoc


### PR DESCRIPTION
R source files commonly have an `.r` extension (in lowercase).