### PR TITLE
Add --as-text option

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -102,6 +102,7 @@ Search Options:\n\
                           uppercase characters (Enabled by default)\n\
      --search-binary      Search binary files for matches\n\
   -t --all-text           Search all text files (doesn't include hidden files)\n\
+     --as-text            Process binary files as if they were text\n\
   -u --unrestricted       Search all files (ignore .ignore, .gitignore, etc.;\n\
                           searches binary and hidden files as well)\n\
   -U --skip-vcs-ignores   Ignore VCS ignore files\n\
@@ -167,6 +168,7 @@ void init_options(void) {
     opts.color_match = ag_strdup(color_match);
     opts.color_line_number = ag_strdup(color_line_number);
     opts.use_thread_affinity = TRUE;
+    opts.search_as_text = FALSE;
 }
 
 void cleanup_options(void) {
@@ -236,6 +238,7 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
         { "affinity", no_argument, &opts.use_thread_affinity, 1 },
         { "after", optional_argument, NULL, 'A' },
         { "all-text", no_argument, NULL, 't' },
+        { "as-text", no_argument, &opts.search_as_text, TRUE },
         { "all-types", no_argument, NULL, 'a' },
         { "before", optional_argument, NULL, 'B' },
         { "break", no_argument, &opts.print_break, 1 },

--- a/src/options.h
+++ b/src/options.h
@@ -74,6 +74,7 @@ typedef struct {
     int search_zip_files;
     int search_hidden_files;
     int search_stream; /* true if tail -F blah | ag */
+    int search_as_text;
     int stats;
     size_t stream_line_num; /* This should totally not be in here */
     int match_found;        /* This should totally not be in here */

--- a/src/search.c
+++ b/src/search.c
@@ -7,7 +7,7 @@ void search_buf(const char *buf, const size_t buf_len,
     int binary = -1; /* 1 = yes, 0 = no, -1 = don't know */
     size_t buf_offset = 0;
 
-    if (opts.search_stream) {
+    if (opts.search_as_text || opts.search_stream) {
         binary = 0;
     } else if (!opts.search_binary_files) {
         binary = is_binary((const void *)buf, buf_len);


### PR DESCRIPTION
This PR adds a new `--as-text` option, which is equivalent to the `--text` option in GNU Grep.

Without this option, `ag` sometimes interprets cp1251-encoded sources as binaries. Effectively, the new option disables the binary detection heuristic, which makes perfect sense for situations where `ag` is asked to perform search only in files with a specific extension (corresponding to a particular language).