### PR TITLE
Install bash completion to correct location

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,7 +6,7 @@ ag_LDADD = ${PCRE_LIBS} ${LZMA_LIBS} ${ZLIB_LIBS} $(PTHREAD_LIBS)
 
 dist_man_MANS = doc/ag.1
 
-bashcompdir = $(pkgdatadir)/completions
+bashcompdir = $(datadir)/bash-completion/completions
 dist_bashcomp_DATA = ag.bashcomp.sh
 zshcompdir = $(datadir)/zsh/site-functions
 dist_zshcomp_DATA = _the_silver_searcher


### PR DESCRIPTION
By default, bash completions are installed to
$dataroot/bash-completion/completions, so we should install there
instead.

Ref:
https://github.com/scop/bash-completion/blob/master/bash-completion-config.cmake.in