### PR TITLE
Do not output trailing null from a C string for `--vimgrep` and `--ackmate` options

### DIFF
--- a/src/print.c
+++ b/src/print.c
@@ -135,6 +135,10 @@ void print_line(const char *buf, size_t buf_pos, size_t prev_line_offset) {
     if (opts.width > 0 && opts.width < write_chars) {
         write_chars = opts.width;
     }
+    if (buf[prev_line_offset + write_chars - 1] == '\0') {
+        /* A line might not include a new line character. */
+        write_chars--;
+    }
 
     fwrite(buf + prev_line_offset, 1, write_chars, out_fd);
 }

--- a/tests/no_trailing_null.t
+++ b/tests/no_trailing_null.t
@@ -1,0 +1,13 @@
+Setup:
+
+  $ . $TESTDIR/setup.sh
+  $ alias ag="$TESTDIR/../ag --noaffinity --nocolor --workers=1"
+  $ printf bla > ag-input.txt
+
+Terminating null byte isn't printed for lines which don't end with a newline:
+
+  $ ag --vimgrep bla
+  ag-input.txt:1:1:bla
+  $ ag --ackmate bla
+  :ag-input.txt
+  1;0 3:bla


### PR DESCRIPTION
The assumption in the code seems to be that all lines have a terminator, but this isn't always the case.