### PR TITLE
Allow -g/-G and filetypes to be used together

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -197,6 +197,13 @@ void cleanup_options(void) {
     if (opts.file_search_regex_extra) {
         pcre_free(opts.file_search_regex_extra);
     }
+
+    if (opts.filetype_regex) {
+        pcre_free(opts.filetype_regex);
+    }
+    if (opts.filetype_regex_extra) {
+        pcre_free(opts.filetype_regex_extra);
+    }
 }
 
 void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
@@ -617,7 +624,7 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
     if (has_filetype) {
         num_exts = combine_file_extensions(ext_index, lang_num, &extensions);
         lang_regex = make_lang_regex(extensions, num_exts);
-        compile_study(&opts.file_search_regex, &opts.file_search_regex_extra, lang_regex, 0, 0);
+        compile_study(&opts.filetype_regex, &opts.filetype_regex_extra, lang_regex, 0, 0);
     }
 
     if (extensions) {

--- a/src/options.h
+++ b/src/options.h
@@ -37,6 +37,8 @@ typedef struct {
     int match_files;
     pcre *file_search_regex;
     pcre_extra *file_search_regex_extra;
+    pcre *filetype_regex;
+    pcre_extra *filetype_regex_extra;
     int color;
     char *color_line_number;
     char *color_match;

--- a/src/search.c
+++ b/src/search.c
@@ -1,6 +1,7 @@
 #include "search.h"
 #include "print.h"
 #include "scandir.h"
+#include <stdbool.h>
 
 void search_buf(const char *buf, const size_t buf_len,
                 const char *dir_full_path) {
@@ -583,14 +584,26 @@ void search_dir(ignores *ig, const char *base_path, const char *path, const int 
         }
 
         if (!is_directory(path, dir)) {
-            if (opts.file_search_regex) {
-                rc = pcre_exec(opts.file_search_regex, NULL, dir_full_path, strlen(dir_full_path),
-                               0, 0, offset_vector, 3);
-                if (rc < 0) { /* no match */
+            if (opts.file_search_regex || opts.filetype_regex) {
+                bool filename_matched = true;
+                if (opts.file_search_regex) {
+                    rc = pcre_exec(opts.file_search_regex, NULL, dir_full_path, strlen(dir_full_path),
+                                   0, 0, offset_vector, 3);
+                    if (rc < 0)
+                        filename_matched = false;
+                }
+                if (opts.filetype_regex) {
+                    rc = pcre_exec(opts.filetype_regex, NULL, dir_full_path, strlen(dir_full_path),
+                                   0, 0, offset_vector, 3);
+                    if (rc < 0)
+                        filename_matched = false;
+                }
+
+                if (!filename_matched) { /* no match */
                     log_debug("Skipping %s due to file_search_regex.", dir_full_path);
                     goto cleanup;
                 } else if (opts.match_files) {
-                    log_debug("match_files: file_search_regex matched for %s.", dir_full_path);
+                    log_debug("match_files: file_search_regex/filetype_regex matched for %s.", dir_full_path);
                     pthread_mutex_lock(&print_mtx);
                     print_path(dir_full_path, opts.path_sep);
                     pthread_mutex_unlock(&print_mtx);


### PR DESCRIPTION
Use dedicated file_search_regex and filetype_regex options, requiring
both to be matched to search a file.

For example, this allows searching C and ASM files with 'init' in the name:
    ag --cc --asm -G init <some string>

Fixes: #1195 (https://github.com/ggreer/the_silver_searcher/issues/1195)