### PR TITLE
Adding support for .thrift files search by using --thrift

### DIFF
--- a/src/lang.c
+++ b/src/lang.c
@@ -109,6 +109,7 @@ lang_spec_t langs[] = {
     { "swift", { "swift" } },
     { "tcl", { "tcl", "itcl", "itk" } },
     { "tex", { "tex", "cls", "sty" } },
+    { "thrift", { "thrift" } },
     { "tla", { "tla" } },
     { "tt", { "tt", "tt2", "ttml" } },
     { "toml", { "toml" } },

--- a/tests/list_file_types.t
+++ b/tests/list_file_types.t
@@ -318,6 +318,9 @@ Language types are output:
     --tex
         .tex  .cls  .sty
   
+    --thrift
+        .thrift
+  
     --tla
         .tla
   


### PR DESCRIPTION
Adding support to search exclusively on .thrift files by using the --thrift option