### PR TITLE
Support terraform file type

### DIFF
--- a/src/lang.c
+++ b/src/lang.c
@@ -110,7 +110,7 @@ lang_spec_t langs[] = {
     { "stylus", { "styl" } },
     { "swift", { "swift" } },
     { "tcl", { "tcl", "itcl", "itk" } },
-    { "terraform", { "tf" } },
+    { "terraform", { "tf", "tfvars" } },
     { "tex", { "tex", "cls", "sty" } },
     { "thrift", { "thrift" } },
     { "tla", { "tla" } },

--- a/src/lang.c
+++ b/src/lang.c
@@ -110,6 +110,7 @@ lang_spec_t langs[] = {
     { "stylus", { "styl" } },
     { "swift", { "swift" } },
     { "tcl", { "tcl", "itcl", "itk" } },
+    { "terraform", { "tf" } },
     { "tex", { "tex", "cls", "sty" } },
     { "thrift", { "thrift" } },
     { "tla", { "tla" } },

--- a/tests/list_file_types.t
+++ b/tests/list_file_types.t
@@ -321,6 +321,9 @@ Language types are output:
     --tcl
         .tcl  .itcl  .itk
   
+    --terraform
+        .tf
+  
     --tex
         .tex  .cls  .sty
   

--- a/tests/list_file_types.t
+++ b/tests/list_file_types.t
@@ -322,7 +322,7 @@ Language types are output:
         .tcl  .itcl  .itk
   
     --terraform
-        .tf
+        .tf  .tfvars
   
     --tex
         .tex  .cls  .sty


### PR DESCRIPTION
So you can limit searches to .tf files with --terraform.

Thanks.