### PR TITLE
Add -1 / --single-match option to only return the first result

### DIFF
--- a/doc/ag.1.md
+++ b/doc/ag.1.md
@@ -216,6 +216,10 @@ Recursively search for PATTERN in PATH. Like grep or ack, but faster.
     this allows `xargs -0 <command>` to correctly process filenames containing
     spaces or newlines.
 
+    * `-1 --single-match`:
+    Stops after reporting first match per thread.
+    This is different from --max-count=1 or -m 1, where only one match per file is shown.
+
 
 ## FILE TYPES
 

--- a/src/main.c
+++ b/src/main.c
@@ -196,6 +196,9 @@ int main(int argc, char **argv) {
 #endif
             search_dir(ig, base_paths[i], paths[i], 0, s.st_dev);
             cleanup_ignore(ig);
+            if (done_adding_files) {
+                break;
+            }
         }
         pthread_mutex_lock(&work_queue_mtx);
         done_adding_files = TRUE;

--- a/src/options.c
+++ b/src/options.c
@@ -110,6 +110,8 @@ Search Options:\n\
   -w --word-regexp        Only match whole words\n\
   -W --width NUM          Truncate match lines after NUM characters\n\
   -z --search-zip         Search contents of compressed (e.g., gzip) files\n\
+  -1 --single-match       Stops after reporting first match per thread.\n\
+                          This is different from --max-count=1 or -m 1, where only one match per file is shown.\n\
 \n");
     printf("File Types:\n\
 The search can be restricted to certain types of files. Example:\n\
@@ -167,6 +169,7 @@ void init_options(void) {
     opts.color_match = ag_strdup(color_match);
     opts.color_line_number = ag_strdup(color_line_number);
     opts.use_thread_affinity = TRUE;
+    opts.single_match = FALSE;
 }
 
 void cleanup_options(void) {
@@ -315,6 +318,7 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
         { "search-files", no_argument, &opts.search_stream, 0 },
         { "search-zip", no_argument, &opts.search_zip_files, 1 },
         { "silent", no_argument, NULL, 0 },
+        { "single-match", no_argument, &opts.single_match, 0 },
         { "skip-vcs-ignores", no_argument, NULL, 'U' },
         { "smart-case", no_argument, NULL, 'S' },
         { "stats", no_argument, &opts.stats, 1 },
@@ -372,7 +376,7 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
     }
 
     char *file_search_regex = NULL;
-    while ((ch = getopt_long(argc, argv, "A:aB:C:cDG:g:FfHhiLlm:nop:QRrSsvVtuUwW:z0", longopts, &opt_index)) != -1) {
+    while ((ch = getopt_long(argc, argv, "A:aB:C:cDG:g:FfHhiLlm:nop:QRrSsvVtuUwW:z01", longopts, &opt_index)) != -1) {
         switch (ch) {
             case 'A':
                 if (optarg) {
@@ -514,6 +518,9 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
             case '0':
                 opts.path_sep = '\0';
                 break;
+            case '1':
+                opts.single_match = TRUE;
+                break;
             case 0: /* Long option */
                 if (strcmp(longopts[opt_index].name, "ackmate-dir-filter") == 0) {
                     compile_study(&opts.ackmate_dir_filter, &opts.ackmate_dir_filter_extra, optarg, 0, 0);
@@ -569,6 +576,9 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
                     opts.print_filename_only = 1;
                     opts.print_path = PATH_PRINT_NOTHING;
                     opts.stats = 1;
+                    break;
+                } else if (strcmp(longopts[opt_index].name, "single-match") == 0) {
+                    opts.single_match = TRUE;
                     break;
                 }
 

--- a/src/options.h
+++ b/src/options.h
@@ -88,6 +88,7 @@ typedef struct {
     size_t width;
     int word_regexp;
     int workers;
+    int single_match;
 } cli_options;
 
 /* global options. parse_options gives it sane values, everything else reads from it */

--- a/src/search.c
+++ b/src/search.c
@@ -2,10 +2,11 @@
 #include "print.h"
 #include "scandir.h"
 
-void search_buf(const char *buf, const size_t buf_len,
+int search_buf(const char *buf, const size_t buf_len,
                 const char *dir_full_path) {
     int binary = -1; /* 1 = yes, 0 = no, -1 = don't know */
     size_t buf_offset = 0;
+    int continue_search = TRUE;
 
     if (opts.search_stream) {
         binary = 0;
@@ -13,7 +14,7 @@ void search_buf(const char *buf, const size_t buf_len,
         binary = is_binary((const void *)buf, buf_len);
         if (binary) {
             log_debug("File %s is binary. Skipping...", dir_full_path);
-            return;
+            return continue_search;
         }
     }
 
@@ -92,6 +93,12 @@ void search_buf(const char *buf, const size_t buf_len,
             matches_len++;
             match_ptr += opts.query_len;
 
+            if (opts.single_match == TRUE) {
+                log_debug("Match found. Ending search (1).");
+                continue_search = FALSE;
+                break;
+            }
+
             if (opts.max_matches_per_file > 0 && matches_len >= opts.max_matches_per_file) {
                 log_err("Too many matches in %s. Skipping the rest of this file.", dir_full_path);
                 break;
@@ -114,6 +121,12 @@ void search_buf(const char *buf, const size_t buf_len,
                 matches[matches_len].start = offset_vector[0];
                 matches[matches_len].end = offset_vector[1];
                 matches_len++;
+
+                if (opts.single_match == TRUE) {
+                    log_debug("Match found. Ending search (2).");
+                    continue_search = FALSE;
+                    break;
+                }
 
                 if (opts.max_matches_per_file > 0 && matches_len >= opts.max_matches_per_file) {
                     log_err("Too many matches in %s. Skipping the rest of this file.", dir_full_path);
@@ -146,6 +159,12 @@ void search_buf(const char *buf, const size_t buf_len,
                     matches[matches_len].start = offset_vector[0] + line_to_buf;
                     matches[matches_len].end = offset_vector[1] + line_to_buf;
                     matches_len++;
+
+                    if (opts.single_match == TRUE) {
+                        log_debug("Match found. Ending search (multiline).");
+                        continue_search = FALSE;
+                        goto multiline_done;
+                    }
 
                     if (opts.max_matches_per_file > 0 && matches_len >= opts.max_matches_per_file) {
                         log_err("Too many matches in %s. Skipping the rest of this file.", dir_full_path);
@@ -214,6 +233,8 @@ multiline_done:
     if (matches_size > 0) {
         free(matches);
     }
+
+    return continue_search;
 }
 
 /* TODO: this will only match single lines. multi-line regexes silently don't match */
@@ -222,29 +243,34 @@ void search_stream(FILE *stream, const char *path) {
     ssize_t line_len = 0;
     size_t line_cap = 0;
     size_t i;
+    int continue_search = TRUE;
 
     print_init_context();
 
     for (i = 1; (line_len = getline(&line, &line_cap, stream)) > 0; i++) {
         opts.stream_line_num = i;
-        search_buf(line, line_len, path);
+        continue_search = search_buf(line, line_len, path);
         if (line[line_len - 1] == '\n') {
             line_len--;
         }
         print_trailing_context(path, line, line_len);
+        if (continue_search == FALSE){
+            break;
+        };
     }
 
     free(line);
     print_cleanup_context();
 }
 
-void search_file(const char *file_full_path) {
+int search_file(const char *file_full_path) {
     int fd = -1;
     off_t f_len = 0;
     char *buf = NULL;
     struct stat statbuf;
     int rv = 0;
     FILE *fp = NULL;
+    int continue_search = TRUE;
 
     rv = stat(file_full_path, &statbuf);
     if (rv != 0) {
@@ -302,7 +328,7 @@ void search_file(const char *file_full_path) {
 
     if (f_len == 0) {
         if (opts.query[0] == '.' && opts.query_len == 1 && !opts.literal && opts.search_all_files) {
-            search_buf(buf, f_len, file_full_path);
+            continue_search = search_buf(buf, f_len, file_full_path);
         } else {
             log_debug("Skipping %s: file is empty.", file_full_path);
         }
@@ -369,14 +395,14 @@ void search_file(const char *file_full_path) {
                 log_err("Cannot decompress zipped file %s", file_full_path);
                 goto cleanup;
             }
-            search_buf(_buf, _buf_len, file_full_path);
+            continue_search = search_buf(_buf, _buf_len, file_full_path);
             free(_buf);
 #endif
             goto cleanup;
         }
     }
 
-    search_buf(buf, f_len, file_full_path);
+    continue_search = search_buf(buf, f_len, file_full_path);
 
 cleanup:
 
@@ -397,6 +423,7 @@ cleanup:
     if (fd != -1) {
         close(fd);
     }
+return continue_search;
 }
 
 void *search_file_worker(void *i) {
@@ -421,7 +448,10 @@ void *search_file_worker(void *i) {
         }
         pthread_mutex_unlock(&work_queue_mtx);
 
-        search_file(queue_item->path);
+        if (search_file(queue_item->path) == FALSE) {
+            done_adding_files = TRUE;
+            work_queue = NULL;
+        }
         free(queue_item->path);
         free(queue_item);
     }

--- a/src/search.h
+++ b/src/search.h
@@ -66,10 +66,10 @@ typedef struct {
 
 symdir_t *symhash;
 
-void search_buf(const char *buf, const size_t buf_len,
+int search_buf(const char *buf, const size_t buf_len,
                 const char *dir_full_path);
 void search_stream(FILE *stream, const char *path);
-void search_file(const char *file_full_path);
+int search_file(const char *file_full_path);
 
 void *search_file_worker(void *i);
 

--- a/tests/single_match.t
+++ b/tests/single_match.t
@@ -1,0 +1,17 @@
+Setup:
+
+  $ . $TESTDIR/setup.sh
+  $ printf 'Hello, "Hello, world" programs output "Hello, world".\n' > ./test_single_match.txt
+  $ printf '"Hello, world" programs are simple programs.\n' >> ./test_single_match.txt
+  $ printf 'They illustrate the most basic syntax of a programming language\n' >> ./test_single_match.txt
+  $ printf 'In javascript: alert("Hello, world!");\n' >> ./test_single_match.txt
+
+Search for lines matching "hello" in test_single_match.txt (should only return first match):
+
+  $ ag --single-match hello
+  test_single_match.txt:1:Hello, "Hello, world" programs output "Hello, world".
+
+Search for lines matching "hello" in test_single_match.txt (should only return first match):
+
+  $ ag -1 hello
+  test_single_match.txt:1:Hello, "Hello, world" programs output "Hello, world".


### PR DESCRIPTION
Equivalent to ack's -1 option. Added for performance reasons in script that is only checking for the presence of a pattern.