### PR TITLE
util: buf_getline: validate index of the next byte before reading it

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -617,7 +617,7 @@ ssize_t getline(char **lineptr, size_t *n, FILE *stream) {
 ssize_t buf_getline(const char **line, const char *buf, const size_t buf_len, const size_t buf_offset) {
     const char *cur = buf + buf_offset;
     ssize_t i;
-    for (i = 0; cur[i] != '\n' && (buf_offset + i < buf_len); i++) {
+    for (i = 0; (buf_offset + i < buf_len) && cur[i] != '\n'; i++) {
     }
     *line = cur;
     return i;


### PR DESCRIPTION
buf_getline dereferences cur[i] before checking that i is a valid index
in the buffer. Under the right circumstances, this can cause
a segmentation fault.

The right circumstances are:
  * multiline search disabled (the only way buf_getline is called)
  * file size is an exact multiple of the page size (4096 bytes)
  * end of file has no trailing newline
  * searching a directory (not just a single file on the command line)
  * using several worker threads

(I don't think the last two points are directly related to this bug, but
I couldn't reproduce it otherwise)

Address Sanitizer catches this consistently as a heap overflow if run
when mmap is disabled.

Swap the order of the for loop's condition checks so that i is validated
before dereferencing cur[i].

Signed-off-by: Allen Wild <allenwild93@gmail.com>