### PR TITLE
Fix uppercase letters in regex char sets from causing case sensitivity

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -109,7 +109,7 @@ int main(int argc, char **argv) {
     }
 
     if (opts.casing == CASE_SMART) {
-        opts.casing = is_lowercase(opts.query) ? CASE_INSENSITIVE : CASE_SENSITIVE;
+        opts.casing = is_lowercase(opts.query, opts.literal) ? CASE_INSENSITIVE : CASE_SENSITIVE;
     }
 
     if (opts.literal) {

--- a/src/options.c
+++ b/src/options.c
@@ -602,7 +602,7 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
 
     if (file_search_regex) {
         int pcre_opts = 0;
-        if (opts.casing == CASE_INSENSITIVE || (opts.casing == CASE_SMART && is_lowercase(file_search_regex))) {
+        if (opts.casing == CASE_INSENSITIVE || (opts.casing == CASE_SMART && is_lowercase(file_search_regex, opts.literal))) {
             pcre_opts |= PCRE_CASELESS;
         }
         if (opts.word_regexp) {

--- a/src/util.c
+++ b/src/util.c
@@ -447,10 +447,18 @@ int is_wordchar(char ch) {
     return wordchar_table[(unsigned char)ch];
 }
 
-int is_lowercase(const char *s) {
+int is_lowercase(const char *s, _Bool isliteral) {
     int i;
+    _Bool isescaped = FALSE;
+
     for (i = 0; s[i] != '\0'; i++) {
-        if (!isascii(s[i]) || isupper(s[i])) {
+        if (isescaped) {
+            isescaped = FALSE;
+            continue;
+        } else if (s[i] == '\\') {
+            // When isliteral is true, isescaped will never be true
+            isescaped = !isliteral;
+        } else if (!isascii(s[i]) || isupper(s[i])) {
             return FALSE;
         }
     }

--- a/src/util.h
+++ b/src/util.h
@@ -87,7 +87,7 @@ int binary_search(const char *needle, char **haystack, int start, int end);
 void init_wordchar_table(void);
 int is_wordchar(char ch);
 
-int is_lowercase(const char *s);
+int is_lowercase(const char *s, _Bool isliteral);
 
 int is_directory(const char *path, const struct dirent *d);
 int is_symlink(const char *path, const struct dirent *d);

--- a/tests/case_sensitivity.t
+++ b/tests/case_sensitivity.t
@@ -3,6 +3,8 @@ Setup:
   $ . $TESTDIR/setup.sh
   $ printf 'Foo\n' >> ./sample
   $ printf 'bar\n' >> ./sample
+  $ printf '\S\n' >> ./sample
+  $ printf '\s\n' >> ./sample
 
 Smart case by default:
 
@@ -15,6 +17,8 @@ Smart case by default:
   $ ag Foo sample
   1:Foo
   $ ag 'F.o' sample
+  1:Foo
+  $ ag 'fo\S' sample
   1:Foo
 
 Case sensitive mode:
@@ -43,3 +47,10 @@ Case insensitive file regex
 
   $ ag -i  -g 'Samp.*'
   sample
+
+Smart case literal mode
+  $ ag -Q "\S" sample
+  3:\S
+  $ ag -Q "\s" sample
+  3:\S
+  4:\s


### PR DESCRIPTION
Fix https://github.com/ggreer/the_silver_searcher/issues/1247

Changelog
-- Add param to islowercase to tell if the query is literal or regex
-- Ignore escaped uppercase letters in regex queries when checking if lowercase
-- Add tests for functionality of literal and regex smartcase detection
