### PR TITLE
Use C99 and fix some pedantic warnings

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,8 +1,12 @@
 ACLOCAL_AMFLAGS = ${ACLOCAL_FLAGS}
 
 bin_PROGRAMS = ag
-ag_SOURCES = src/ignore.c src/ignore.h src/log.c src/log.h src/options.c src/options.h src/print.c src/print_w32.c src/print.h src/scandir.c src/scandir.h src/search.c src/search.h src/lang.c src/lang.h src/util.c src/util.h src/decompress.c src/decompress.h src/uthash.h src/main.c src/zfile.c
+ag_SOURCES = src/ignore.c src/ignore.h src/log.c src/log.h src/options.c src/options.h src/print.c src/print.h src/scandir.c src/scandir.h src/search.c src/search.h src/lang.c src/lang.h src/util.c src/util.h src/decompress.c src/decompress.h src/uthash.h src/main.c src/zfile.c
 ag_LDADD = ${PCRE_LIBS} ${LZMA_LIBS} ${ZLIB_LIBS} $(PTHREAD_LIBS)
+
+if WINDOWS
+ag_SOURCES += src/print_w32 c
+endif
 
 dist_man_MANS = doc/ag.1
 

--- a/configure.ac
+++ b/configure.ac
@@ -8,6 +8,7 @@ AC_INIT(
 AM_INIT_AUTOMAKE([no-define foreign subdir-objects])
 
 AC_PROG_CC
+AC_PROG_CC_C99
 AM_PROG_CC_C_O
 AC_PREREQ([2.59])
 AC_PROG_GREP
@@ -30,7 +31,7 @@ if ! echo "$CFLAGS" | "$GREP" '\(^\|[[[:space:]]]\)-O' > /dev/null; then
 fi
 
 CFLAGS="$CFLAGS $PTHREAD_CFLAGS $PCRE_CFLAGS -Wall -Wextra -Wformat=2 -Wno-format-nonliteral -Wshadow"
-CFLAGS="$CFLAGS -Wpointer-arith -Wcast-qual -Wmissing-prototypes -Wno-missing-braces -std=gnu89 -D_GNU_SOURCE"
+CFLAGS="$CFLAGS -Wpointer-arith -Wcast-qual -Wmissing-prototypes -Wno-missing-braces -D_GNU_SOURCE"
 LDFLAGS="$LDFLAGS"
 
 case $host in

--- a/configure.ac
+++ b/configure.ac
@@ -34,10 +34,19 @@ CFLAGS="$CFLAGS $PTHREAD_CFLAGS $PCRE_CFLAGS -Wall -Wextra -Wformat=2 -Wno-forma
 CFLAGS="$CFLAGS -Wpointer-arith -Wcast-qual -Wmissing-prototypes -Wno-missing-braces -D_GNU_SOURCE"
 LDFLAGS="$LDFLAGS"
 
-case $host in
+AC_CANONICAL_HOST
+is_windows=
+case ${host_os} in
 *mingw*)
     AC_CHECK_LIB(shlwapi, main,, AC_MSG_ERROR(libshlwapi missing))
+    is_windows=yes
+;;
+*cygwin*)
+    is_windows=yes
+;;
 esac
+
+AM_CONDITIONAL([WINDOWS], [test "x$is_windows" = "xyes"])
 
 LIBS="$PTHREAD_LIBS $LIBS"
 

--- a/src/ignore.c
+++ b/src/ignore.c
@@ -39,7 +39,7 @@ const char *ignore_pattern_files[] = {
 
 int is_empty(ignores *ig) {
     return (ig->extensions_len + ig->names_len + ig->slash_names_len + ig->regexes_len + ig->slash_regexes_len == 0);
-};
+}
 
 ignores *init_ignore(ignores *parent, const char *dirname, const size_t dirname_len) {
     ignores *ig = ag_malloc(sizeof(ignores));

--- a/src/print.c
+++ b/src/print.c
@@ -226,7 +226,7 @@ void print_file_matches(const char *path, const char *buf, const size_t buf_len,
                     print_line_number(print_context.line, ';');
                     for (; print_context.last_printed_match < cur_match; print_context.last_printed_match++) {
                         size_t start = matches[print_context.last_printed_match].start - print_context.line_preceding_current_match_offset;
-                        fprintf(out_fd, "%lu %lu",
+                        fprintf(out_fd, "%zu %zu",
                                 start,
                                 matches[print_context.last_printed_match].end - matches[print_context.last_printed_match].start);
                         print_context.last_printed_match == cur_match - 1 ? fputc(':', out_fd) : fputc(',', out_fd);


### PR DESCRIPTION
We were clearly using C99, but we had the compiler set to use gnu89. There were no warnings because GCC implements C99 features in gnu89 mode as extensions.

Using this will probably improve compatibility with other compilers as well.

I also fixed a few pedantic warnings:
  - src/ignore.c: Removed semicolon after function.
  - src/print.c: Fixed `size_t` being printf'd as `%lu` instead of `%zu`.
  - configure.ac, Makefile.am: Made src/print_w32.c compile only on Windows because ISO C doesn't allow empty source files, which would happen if `_WIN32` was not defined.