### PR TITLE
Add necessary dependencies in case build on CentOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ or
     * CentOS:
 
             yum -y groupinstall "Development Tools"
-            yum -y install pcre-devel xz-devel
+            yum -y install pcre-devel xz-devel zlib-devel
     * openSUSE:
 
             zypper source-install --build-deps-only the_silver_searcher


### PR DESCRIPTION
# Problem
Build fails when build on CentOS.

OS version: `CentOS Linux release 7.5.1804 (Core)`

# Commands to encounter build error
```bash
yum -y groupinstall "Development Tools"
yum -y install pcre-devel xz-devel
./build.sh
```

# Error log
```
config.status: executing depfiles commands
  CC       src/log.o
  CC       src/ignore.o
  CC       src/options.o
  CC       src/print.o
  CC       src/print_w32.o
  CC       src/scandir.o
  CC       src/search.o
  CC       src/lang.o
  CC       src/util.o
  CC       src/decompress.o
  CC       src/main.o
  CC       src/zfile.o
src/zfile.c:63:9: error: unknown type name 'z_stream'
         z_stream gz;
         ^
src/zfile.c: In function 'zfile_cookie_init':
src/zfile.c:80:9: warning: unused variable 'rc' [-Wunused-variable]
     int rc;
         ^
src/zfile.c: In function 'zfile_read':
src/zfile.c:221:11: error: 'Z_OK' undeclared (first use in this function)
     ret = Z_OK;
           ^
src/zfile.c:221:11: note: each undeclared identifier is reported only once for each function it appears in
src/zfile.c:73:61: error: request for member 'next_out' in something not a structure or union
 #define CNEXT_OUT(c) ((c)->ctype == AG_GZIP ? (c)->stream.gz.next_out : (c)->stream.lzma.next_out)
                                                             ^
src/zfile.c:231:16: note: in expansion of macro 'CNEXT_OUT'
         while (CNEXT_OUT(cookie) >
                ^
src/zfile.c:73:61: error: request for member 'next_out' in something not a structure or union
 #define CNEXT_OUT(c) ((c)->ctype == AG_GZIP ? (c)->stream.gz.next_out : (c)->stream.lzma.next_out)
                                                             ^
src/zfile.c:233:27: note: in expansion of macro 'CNEXT_OUT'
             size_t left = CNEXT_OUT(cookie) -
                           ^
In file included from src/zfile.c:10:0:
src/zfile.c:272:33: error: request for member 'next_out' in something not a structure or union
         assert(cookie->stream.gz.next_out ==
                                 ^
src/zfile.c:276:49: error: 'Z_STREAM_END' undeclared (first use in this function)
             (cookie->ctype == AG_GZIP && ret == Z_STREAM_END)) {
                                                 ^
src/zfile.c:72:61: error: request for member 'avail_in' in something not a structure or union
 #define CAVAIL_IN(c) ((c)->ctype == AG_GZIP ? (c)->stream.gz.avail_in : (c)->stream.lzma.avail_in)
                                                             ^
src/zfile.c:282:13: note: in expansion of macro 'CAVAIL_IN'
         if (CAVAIL_IN(cookie) == 0) {
             ^
src/zfile.c:297:34: error: request for member 'avail_in' in something not a structure or union
                 cookie->stream.gz.avail_in = nb;
                                  ^
src/zfile.c:298:34: error: request for member 'next_in' in something not a structure or union
                 cookie->stream.gz.next_in = cookie->inbuf;
                                  ^
src/zfile.c:307:30: error: request for member 'next_out' in something not a structure or union
             cookie->stream.gz.next_out = cookie->outbuf;
                              ^
src/zfile.c:308:30: error: request for member 'avail_out' in something not a structure or union
             cookie->stream.gz.avail_out = sizeof cookie->outbuf;
                              ^
src/zfile.c:313:13: warning: implicit declaration of function 'inflate' [-Wimplicit-function-declaration]
             ret = inflate(&cookie->stream.gz, Z_NO_FLUSH);
             ^
src/zfile.c:313:47: error: 'Z_NO_FLUSH' undeclared (first use in this function)
             ret = inflate(&cookie->stream.gz, Z_NO_FLUSH);
                                               ^
src/zfile.c:315:17: warning: implicit declaration of function 'zError' [-Wimplicit-function-declaration]
                 log_err("Found mem/data error while decompressing zlib stream: %s", zError(ret));
                 ^
src/zfile.c:73:61: error: request for member 'next_out' in something not a structure or union
 #define CNEXT_OUT(c) ((c)->ctype == AG_GZIP ? (c)->stream.gz.next_out : (c)->stream.lzma.next_out)
                                                             ^
src/zfile.c:325:20: note: in expansion of macro 'CNEXT_OUT'
         inflated = CNEXT_OUT(cookie) - &cookie->outbuf[0];
                    ^
make: *** [src/zfile.o] Error 1
make: *** Waiting for unfinished jobs....
```

# Countermeasure
Install `zlib-devel` like the following:
```bash
yum -y install zlib-devel
```