### PR TITLE
Inverted ignores with slash-pattern

### DIFF
--- a/tests/ignore_invert.t
+++ b/tests/ignore_invert.t
@@ -3,10 +3,17 @@ Setup:
   $ . $TESTDIR/setup.sh
   $ printf 'blah1\n' > ./printme.txt
   $ printf 'blah2\n' > ./dontprintme.c
-  $ printf '*\n' > ./.ignore
-  $ printf '!*.txt\n' >> ./.ignore
+  $ printf '*\n' > ./.wildcard-ignore
+  $ printf '!*.txt\n' >> ./.wildcard-ignore
+  $ printf '/*\n' > ./.rooted-ignore
+  $ printf '!*.txt\n' >> ./.rooted-ignore
 
-Ignore .gitignore patterns but not .ignore patterns:
+Inverted ignore with wildcard:
 
-  $ ag blah
+  $ ag -p .wildcard-ignore blah
+  printme.txt:1:blah1
+
+Inverted ignore with rooted wildcard:
+
+  $ ag -p .rooted-ignore blah
   printme.txt:1:blah1


### PR DESCRIPTION
These commits contain a failing test and a fix for the bug described in #1285.

There are several possible solutions. The one I propose in this patch feels like it will have the smallest impact on performance. Only one branch and one word-sized write is added. I have not benchmarked this so no promises.

One alternative is to just move the inverted test to before the abs_path tests. That would be faster if the inverted test succeeds, but slower if does not. 