### PR TITLE
Skip symlinks to named pipes

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -516,7 +516,7 @@ int is_symlink(const char *path, const struct dirent *d) {
 
 int is_named_pipe(const char *path, const struct dirent *d) {
 #ifdef HAVE_DIRENT_DTYPE
-    if (d->d_type != DT_UNKNOWN) {
+    if (d->d_type != DT_UNKNOWN && d->d_type != DT_LNK) {
         return d->d_type == DT_FIFO || d->d_type == DT_SOCK;
     }
 #endif


### PR DESCRIPTION
The `d_type` field contains the type as `lstat` would put it, but when checking for a named pipe we need the `stat` behavior. This solution is essentially the same as done in `is_directory`.

Fixes #1272