### PR TITLE
add support in fortran types for preprocessed files with uppercases

### DIFF
--- a/src/lang.c
+++ b/src/lang.c
@@ -34,7 +34,7 @@ lang_spec_t langs[] = {
     { "elm", { "elm" } },
     { "erlang", { "erl", "hrl" } },
     { "factor", { "factor" } },
-    { "fortran", { "f", "f77", "f90", "f95", "f03", "for", "ftn", "fpp" } },
+    { "fortran", { "f", "F", "f77", "f90", "F90", "f95", "F95", "f03", "F03", "for", "FOR", "ftn", "FTN", "fpp", "FPP" } },
     { "fsharp", { "fs", "fsi", "fsx" } },
     { "gettext", { "po", "pot", "mo" } },
     { "glsl", { "vert", "tesc", "tese", "geom", "frag", "comp" } },

--- a/src/lang.c
+++ b/src/lang.c
@@ -34,7 +34,7 @@ lang_spec_t langs[] = {
     { "elm", { "elm" } },
     { "erlang", { "erl", "hrl" } },
     { "factor", { "factor" } },
-    { "fortran", { "f", "F", "f77", "f90", "F90", "f95", "F95", "f03", "F03", "for", "FOR", "ftn", "FTN", "fpp", "FPP" } },
+    { "fortran", { "f", "F", "f77", "f90", "F90", "f95", "f03", "for", "ftn", "fpp", "FPP" } },
     { "fsharp", { "fs", "fsi", "fsx" } },
     { "gettext", { "po", "pot", "mo" } },
     { "glsl", { "vert", "tesc", "tese", "geom", "frag", "comp" } },

--- a/tests/list_file_types.t
+++ b/tests/list_file_types.t
@@ -94,7 +94,7 @@ Language types are output:
         .factor
   
     --fortran
-        .f  .F  .f77  .f90  .F90  .f95  .F95  .f03  .F03  .for  .FOR  .ftn  .FTN  .fpp  .FPP
+        .f  .F  .f77  .f90  .F90  .f95  .f03  .for  .ftn  .fpp  .FPP
   
     --fsharp
         .fs  .fsi  .fsx

--- a/tests/list_file_types.t
+++ b/tests/list_file_types.t
@@ -94,7 +94,7 @@ Language types are output:
         .factor
   
     --fortran
-        .f  .f77  .f90  .f95  .f03  .for  .ftn  .fpp
+        .f  .F  .f77  .f90  .F90  .f95  .F95  .f03  .F03  .for  .FOR  .ftn  .FTN  .fpp  .FPP
   
     --fsharp
         .fs  .fsi  .fsx


### PR DESCRIPTION
just had fortran files with uppercases extension to enable also preprocessed files