### PR TITLE
midipix support

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -154,7 +154,7 @@ int main(int argc, char **argv) {
             }
 #if defined(HAVE_PTHREAD_SETAFFINITY_NP) && (defined(USE_CPU_SET) || defined(HAVE_SYS_CPUSET_H))
             if (opts.use_thread_affinity) {
-#ifdef __linux__
+#if defined(__linux__) || defined(__midipix__)
                 cpu_set_t cpu_set;
 #elif __FreeBSD__
                 cpuset_t cpu_set;


### PR DESCRIPTION
midipix uses the musl libc, which provides the same bits as on linux.