### PR TITLE
Add .edn file type for clojure files

### DIFF
--- a/src/lang.c
+++ b/src/lang.c
@@ -18,7 +18,7 @@ lang_spec_t langs[] = {
     { "cc", { "c", "h", "xs" } },
     { "cfmx", { "cfc", "cfm", "cfml" } },
     { "chpl", { "chpl" } },
-    { "clojure", { "clj", "cljs", "cljc", "cljx" } },
+    { "clojure", { "clj", "cljs", "cljc", "cljx", "edn" } },
     { "coffee", { "coffee", "cjsx" } },
     { "config", { "config" } },
     { "coq", { "coq", "g", "v" } },

--- a/tests/list_file_types.t
+++ b/tests/list_file_types.t
@@ -46,7 +46,7 @@ Language types are output:
         .chpl
   
     --clojure
-        .clj  .cljs  .cljc  .cljx
+        .clj  .cljs  .cljc  .cljx  .edn
   
     --coffee
         .coffee  .cjsx


### PR DESCRIPTION
It's common that you'd want edn files to show up in your clojure
searching.

https://github.com/edn-format/edn