### PR TITLE
Default to no color when $TERM is dumb

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -143,9 +143,14 @@ void print_version(void) {
 }
 
 void init_options(void) {
+    char *term = getenv("TERM");
+
     memset(&opts, 0, sizeof(opts));
     opts.casing = CASE_DEFAULT;
     opts.color = TRUE;
+    if (strcmp(term, "dumb") == 0) {
+        opts.color = FALSE;
+    }
     opts.color_win_ansi = FALSE;
     opts.max_matches_per_file = 0;
     opts.max_search_depth = DEFAULT_MAX_SEARCH_DEPTH;


### PR DESCRIPTION
Although this is not required by any standard i'm aware of, it's a good idea to avoid spamming dumb terminals with escape sequences by default

Ref:
https://en.wikipedia.org/wiki/Computer_terminal#Dumb_terminals