### PR TITLE
Add Zephir support

### DIFF
--- a/src/lang.c
+++ b/src/lang.c
@@ -138,7 +138,8 @@ lang_spec_t langs[] = {
     { "wsdl", { "wsdl" } },
     { "wadl", { "wadl" } },
     { "xml", { "xml", "dtd", "xsl", "xslt", "xsd", "ent", "tld", "plist", "wsdl" } },
-    { "yaml", { "yaml", "yml" } }
+    { "yaml", { "yaml", "yml" } },
+    { "zephir", { "zep" } }
 };
 
 size_t get_lang_count() {

--- a/tests/list_file_types.t
+++ b/tests/list_file_types.t
@@ -408,3 +408,6 @@ Language types are output:
     --yaml
         .yaml  .yml
   
+    --zephir
+        .zep
+  


### PR DESCRIPTION
Hello,

This PR adds Zephir support.


Zephir is an open source, high-level/domain specific language designed to ease the creation and maintainability of extensions for PHP, with a focus on type and memory safety. For more see: https://zephir-lang.com/en
