### PR TITLE
Fix for multiple extensions in ignore patterns

### DIFF
--- a/src/ignore.c
+++ b/src/ignore.c
@@ -317,17 +317,6 @@ int filename_filter(const char *path, const struct dirent *dir, void *baton) {
     scandir_baton_t *scandir_baton = (scandir_baton_t *)baton;
     const char *path_start = scandir_baton->path_start;
 
-    const char *extension = strchr(filename, '.');
-    if (extension) {
-        if (extension[1]) {
-            // The dot is not the last character, extension starts at the next one
-            ++extension;
-        } else {
-            // No extension
-            extension = NULL;
-        }
-    }
-
 #ifdef HAVE_DIRENT_DNAMLEN
     size_t filename_len = dir->d_namlen;
 #else
@@ -345,11 +334,29 @@ int filename_filter(const char *path, const struct dirent *dir, void *baton) {
     const ignores *ig = scandir_baton->ig;
 
     while (ig != NULL) {
+        const char *extension = strchr(filename, '.');
         if (extension) {
+            if (extension[1]) {
+                // The dot is not the last character, extension starts at the next one
+                ++extension;
+            } else {
+                // No extension
+                extension = NULL;
+            }
+        }
+
+        while (extension) {
             int match_pos = binary_search(extension, ig->extensions, 0, ig->extensions_len);
             if (match_pos >= 0) {
                 log_debug("file %s ignored because name matches extension %s", filename, ig->extensions[match_pos]);
                 return 0;
+            }
+
+            // Extension could actually contain multiple extensions, for example min.js.map
+            extension = strchr(extension, '.');
+            if (extension) {
+                // Move past the dot
+                ++extension;
             }
         }
 

--- a/tests/ignore_extensions.t
+++ b/tests/ignore_extensions.t
@@ -12,6 +12,7 @@ Setup:
   $ printf 'targetE\n' > subdir/anotherFile.test.txt
   $ printf 'targetF\n' > subdir/anotherFile.txt
   $ printf 'targetH\n' > subdir/somethingElse.min.js
+  $ printf 'targetI\n' > subdir/anotherFile.some.test.txt
 
 Ignore patterns with single extension in root directory:
 
@@ -52,3 +53,8 @@ Do not ignore patterns with partial extensions in subdirectory:
 
   $ ag "targetF"
   subdir/anotherFile.txt:1:targetF
+
+*.test.txt ignores *.some.test.txt
+
+  $ ag "targetI"
+  [1]


### PR DESCRIPTION
When using an ignore pattern with multiple extension components (e.g. `*.min.js`), files which end with that pattern, but whose name includes more extension-like components (e.g. `bootstrap.bundle.min.js`) are not ignored.