### PR TITLE
Update bash completion script to reflect v2.0 changes

### DIFF
--- a/ag.bashcomp.sh
+++ b/ag.bashcomp.sh
@@ -67,7 +67,7 @@ _ag() {
     --parallel
     --passthrough
     --passthru
-    --path-to-agignore
+    --path-to-ignore
     --print-long-lines
     --print0
     --recurse
@@ -106,7 +106,7 @@ _ag() {
     --ignore-dir) # directory completion
               _filedir -d
               return 0;;
-    --path-to-agignore) # file completion
+    --path-to-ignore) # file completion
               _filedir
               return 0;;
     --pager) # command completion


### PR DESCRIPTION
While `--path-to-ignore` works when using `ag`, tab completion in bash (i.e. `ag --pa<TAB><TAB>`) shows `--path-to-agignore` as a possible option. This PR modifies the completion script to use `--path-to-ignore`, like the ["Advanced Usage" wiki page](https://github.com/ggreer/the_silver_searcher/wiki/Advanced-Usage#ignore) suggests.