### PR TITLE
Add support for Bazel files

### DIFF
--- a/src/lang.c
+++ b/src/lang.c
@@ -13,6 +13,7 @@ lang_spec_t langs[] = {
     { "asp", { "asp", "asa", "aspx", "asax", "ashx", "ascx", "asmx" } },
     { "aspx", { "asp", "asa", "aspx", "asax", "ashx", "ascx", "asmx" } },
     { "batch", { "bat", "cmd" } },
+    { "bazel", { "bazel" } },
     { "bitbake", { "bb", "bbappend", "bbclass", "inc" } },
     { "bro", { "bro", "bif" } },
     { "cc", { "c", "h", "xs" } },

--- a/tests/list_file_types.t
+++ b/tests/list_file_types.t
@@ -29,6 +29,9 @@ Language types are output:
   
     --batch
         .bat  .cmd
+
+    --bazel
+        .bazel
   
     --bitbake
         .bb  .bbappend  .bbclass  .inc


### PR DESCRIPTION
Add support for Bazel files to be able to search targets to be built.