### PR TITLE
options: fix segfault when TERM or HOME isn't set

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -150,7 +150,7 @@ void init_options(void) {
     memset(&opts, 0, sizeof(opts));
     opts.casing = CASE_DEFAULT;
     opts.color = TRUE;
-    if (strcmp(term, "dumb") == 0) {
+    if (term && !strcmp(term, "dumb")) {
         opts.color = FALSE;
     }
     opts.color_win_ansi = FALSE;
@@ -713,8 +713,10 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
                 const char *config_home = getenv("XDG_CONFIG_HOME");
                 if (config_home) {
                     ag_asprintf(&gitconfig_res, "%s/%s", config_home, "git/ignore");
-                } else {
+                } else if (home_dir) {
                     ag_asprintf(&gitconfig_res, "%s/%s", home_dir, ".config/git/ignore");
+                } else {
+                    gitconfig_res = ag_strdup("");
                 }
             }
             log_debug("global core.excludesfile: %s", gitconfig_res);

--- a/tests/empty_environment.t
+++ b/tests/empty_environment.t
@@ -1,0 +1,9 @@
+Setup:
+
+  $ . $TESTDIR/setup.sh
+  $ printf "hello world\n" >test.txt
+
+Verify ag runs with an empty environment:
+
+  $ env -i $TESTDIR/../ag --noaffinity --nocolor --workers=1 --parallel hello
+  test.txt:1:hello world

--- a/tests/list_file_types.t
+++ b/tests/list_file_types.t
@@ -29,7 +29,7 @@ Language types are output:
   
     --batch
         .bat  .cmd
-
+  
     --bazel
         .bazel
   


### PR DESCRIPTION
Regression from 3289ab8fba2141211487ef0572c995b122b5ad7b, if TERM isn't
set in the environment, getenv returns NULL which we shouldn't strcmp.
Similarly guard against using home_dir if it's null when looking for
global gitignore files.

This can be reproduced and tested with `env -i ./ag foo`.