### PR TITLE
Change bro filetype support to zeek.

### DIFF
--- a/src/lang.c
+++ b/src/lang.c
@@ -15,7 +15,6 @@ lang_spec_t langs[] = {
     { "batch", { "bat", "cmd" } },
     { "bazel", { "bazel" } },
     { "bitbake", { "bb", "bbappend", "bbclass", "inc" } },
-    { "bro", { "bro", "bif" } },
     { "cc", { "c", "h", "xs" } },
     { "cfmx", { "cfc", "cfm", "cfml" } },
     { "chpl", { "chpl" } },
@@ -142,6 +141,7 @@ lang_spec_t langs[] = {
     { "wadl", { "wadl" } },
     { "xml", { "xml", "dtd", "xsl", "xslt", "xsd", "ent", "tld", "plist", "wsdl" } },
     { "yaml", { "yaml", "yml" } },
+    { "zeek", { "zeek", "bro", "bif" } },
     { "zephir", { "zep" } }
 };
 


### PR DESCRIPTION
The Bro project is now called Zeek, which has caused the file extensions to be renamed from `.bro` to `.zeek`.  Change the `FILE TYPES` support to reflect this rename.