### PR TITLE
fix compile warnings on GCC10

### DIFF
--- a/src/decompress.c
+++ b/src/decompress.c
@@ -22,7 +22,7 @@ const uint8_t LZMA_HEADER_SOMETIMES[3] = { 0x5D, 0x00, 0x00 };
  *
  * zpipe.c: example of proper use of zlib's inflate() and deflate()
  *    Not copyrighted -- provided to the public domain
- *    Version 1.4  11 December 2005  Mark Adler 
+ *    Version 1.4  11 December 2005  Mark Adler
  */
 static void *decompress_zlib(const void *buf, const int buf_len,
                              const char *dir_full_path, int *new_buf_len) {
@@ -48,8 +48,7 @@ static void *decompress_zlib(const void *buf, const int buf_len,
     }
 
     stream.avail_in = buf_len;
-    /* Explicitly cast away the const-ness of buf */
-    stream.next_in = (Bytef *)buf;
+    stream.next_in = buf;
 
     pagesize = getpagesize();
     result_size = ((buf_len + pagesize - 1) & ~(pagesize - 1));
@@ -221,7 +220,7 @@ ag_compression_type is_zipped(const void *buf, const int buf_len) {
     /* Zip magic numbers
      * compressed file: { 0x1F, 0x9B }
      * http://en.wikipedia.org/wiki/Compress
-     * 
+     *
      * gzip file:       { 0x1F, 0x8B }
      * http://www.gzip.org/zlib/rfc-gzip.html#file-format
      *

--- a/src/lang.c
+++ b/src/lang.c
@@ -186,8 +186,7 @@ size_t combine_file_extensions(size_t *extension_index, size_t len, char **exts)
      * file types to search, you'd better search all the files.
      * */
     size_t ext_capacity = 100;
-    (*exts) = (char *)ag_malloc(ext_capacity * SINGLE_EXT_LEN);
-    memset((*exts), 0, ext_capacity * SINGLE_EXT_LEN);
+    (*exts) = (char *)ag_calloc(ext_capacity, SINGLE_EXT_LEN);
     size_t num_of_extensions = 0;
 
     size_t i;
@@ -199,7 +198,7 @@ size_t combine_file_extensions(size_t *extension_index, size_t len, char **exts)
                 break;
             }
             char *pos = (*exts) + num_of_extensions * SINGLE_EXT_LEN;
-            strncpy(pos, ext, strlen(ext));
+            memcpy(pos, ext, strlen(ext));
             ++num_of_extensions;
             ext = langs[extension_index[i]].extensions[++j];
         } while (ext);


### PR DESCRIPTION
src/lang.c: In function ‘combine_file_extensions’:
src/lang.c:201:13: warning: ‘strncpy’ output truncated before terminating nul
copying as many bytes from a string as its length [-Wstringop-truncation]
  201 |             strncpy(pos, ext, strlen(ext));
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Fix by using memcpy rather than strncpy with n=strlen(src) to avoid this
warning. Also in the same function, use calloc rather than malloc
follwed by memset to 0.

src/decompress.c: In function ‘decompress_zlib’:
src/decompress.c:52:22: warning: cast discards ‘const’ qualifier from
pointer target type [-Wcast-qual]
   52 |     stream.next_in = (Bytef *)buf;
      |                      ^

Don't explicitly cast away the const-ness of buf, because we explicitly
define ZLIB_CONST=1 which makes next_in const (as of zlib versions
dating back to late 2011).