### PR TITLE
Use "<NUL" for "git config"

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -698,7 +698,7 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
         char *gitconfig_res = NULL;
 
 #ifdef _WIN32
-        gitconfig_file = popen("git config -z --path --get core.excludesfile 2>NUL", "r");
+        gitconfig_file = popen("git config -z --path --get core.excludesfile 2>NUL <NUL", "r");
 #else
         gitconfig_file = popen("git config -z --path --get core.excludesfile 2>/dev/null", "r");
 #endif


### PR DESCRIPTION
the-silversearcher does not work when use pipe with external command on Windows.

```
C:\Temp> ag foo | vim -
```

This seems to be a bug of git that it break terminal sequences. This fix use "<NUL" to fix this behavior.