### PR TITLE
Show file name at context line when vimgrep option is specified

### DIFF
--- a/src/print.c
+++ b/src/print.c
@@ -85,7 +85,7 @@ void print_trailing_context(const char *path, const char *buf, size_t n) {
 
     if (print_context.lines_since_last_match != 0 &&
         print_context.lines_since_last_match <= opts.after) {
-        if (opts.print_path == PATH_PRINT_EACH_LINE) {
+        if (opts.print_path == PATH_PRINT_EACH_LINE || opts.vimgrep) {
             print_path(path, ':');
         }
         print_line_number(print_context.line, sep);
@@ -193,7 +193,7 @@ void print_file_matches(const char *path, const char *buf, const size_t buf_len,
                 for (j = (opts.before - lines_to_print); j < opts.before; j++) {
                     print_context.prev_line = (print_context.last_prev_line + j) % opts.before;
                     if (print_context.context_prev_lines[print_context.prev_line] != NULL) {
-                        if (opts.print_path == PATH_PRINT_EACH_LINE) {
+                        if (opts.print_path == PATH_PRINT_EACH_LINE || opts.vimgrep) {
                             print_path(path, ':');
                         }
                         print_line_number(print_context.line - (opts.before - j), sep);


### PR DESCRIPTION
### Problem

When both `--vimgrep` and context option(`-A`, `-B`, `-C`) are specified, file name does not print in context line.

This patch makes that file name also prints at context lines when `--vimgrep` option is specified. 

### Screenshot

####  Original implementation

File name is only printed at matched line.

![before](https://user-images.githubusercontent.com/554281/94568168-23e5f880-02a7-11eb-9564-af6fc18e02ff.png)

#### This PR version

File name is only printed at both matched line and context lines.

![after](https://user-images.githubusercontent.com/554281/94568191-29434300-02a7-11eb-9e36-e9c09f8a3002.png)


