### PR TITLE
Update RHEL/CentOS installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,10 @@ or
 * Fedora 22+
 
         dnf install the_silver_searcher
-* RHEL7+
+* RHEL/CentOS 6+
 
-        yum install epel-release.noarch the_silver_searcher
+        yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-$(rpm --eval %rhel).noarch.rpm
+        yum install the_silver_searcher
 * Gentoo
 
         emerge -a sys-apps/the_silver_searcher
@@ -79,10 +80,6 @@ or
 * openSUSE
 
         zypper install the_silver_searcher
-
-* CentOS
-
-        yum install the_silver_searcher
 
 * NixOS/Nix/Nixpkgs
 


### PR DESCRIPTION
This updates the RHEL installation instructions to resolve a number of issues.  Most importantly, the command didn't work before unless you already had epel-release installed.  It has to be installed before yum can see the_silver_searcher, so it needs to be a separate command.  Another important detail is that epel-release is only available in the default repositories of CentOS, not RHEL, so installing it by name doesn't work out the box.  A better approach is to use the convenience "latest" link provided by the EPEL project.  Finally, clarify that this works on both RHEL and CentOS, and for version 6 and up.