### PR TITLE
multiline-break: print break(--) between multiline matches

### DIFF
--- a/doc/ag.1.md
+++ b/doc/ag.1.md
@@ -114,6 +114,9 @@ Recursively search for PATTERN in PATH. Like grep or ack, but faster.
 
   * `--[no]multiline`:
     Match regexes across newlines. Enabled by default.
+  
+  * `--[no]multilinebreak, --[no-]multilinebreak, --[no-]multiline-break`:
+    Print a break("--") between two multiline matches. Disable by default.
 
   * `-n --norecurse`:
     Don't recurse into directories.

--- a/src/options.c
+++ b/src/options.c
@@ -163,6 +163,7 @@ void init_options(void) {
     opts.mmap = TRUE;
 #endif
     opts.multiline = TRUE;
+    opts.multiline_break = FALSE;
     opts.width = 0;
     opts.path_sep = '\n';
     opts.print_break = TRUE;
@@ -280,6 +281,8 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
         { "max-count", required_argument, NULL, 'm' },
         { "mmap", no_argument, &opts.mmap, TRUE },
         { "multiline", no_argument, &opts.multiline, TRUE },
+        { "multiline-break", no_argument, &opts.multiline_break, TRUE },
+        { "multilinebreak", no_argument, &opts.multiline_break, TRUE },
         /* Accept both --no-* and --no* forms for convenience/BC */
         { "no-affinity", no_argument, &opts.use_thread_affinity, 0 },
         { "noaffinity", no_argument, &opts.use_thread_affinity, 0 },
@@ -299,6 +302,9 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
         { "nommap", no_argument, &opts.mmap, FALSE },
         { "no-multiline", no_argument, &opts.multiline, FALSE },
         { "nomultiline", no_argument, &opts.multiline, FALSE },
+        { "no-multiline-break", no_argument, &opts.multiline_break, FALSE },
+        { "no-multilinebreak", no_argument, &opts.multiline_break, FALSE },
+        { "nomultilinebreak", no_argument, &opts.multiline_break, FALSE },
         { "no-numbers", no_argument, &opts.print_line_numbers, FALSE },
         { "nonumbers", no_argument, &opts.print_line_numbers, FALSE },
         { "no-pager", no_argument, NULL, 0 },
@@ -742,6 +748,10 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
         opts.print_break = 1;
         group = 1;
         opts.search_stream = 0;
+    }
+
+    if (!opts.multiline) {
+        opts.multiline_break = FALSE;
     }
 
     if (opts.vimgrep) {

--- a/src/options.h
+++ b/src/options.h
@@ -53,6 +53,7 @@ typedef struct {
     int max_search_depth;
     int mmap;
     int multiline;
+    int multiline_break;
     int one_dev;
     int only_matching;
     char path_sep;

--- a/src/print.c
+++ b/src/print.c
@@ -176,7 +176,7 @@ void print_file_matches(const char *path, const char *buf, const size_t buf_len,
         if (cur_match < matches_len && i == matches[cur_match].start) {
             print_context.in_a_match = TRUE;
             /* We found the start of a match */
-            if (cur_match > 0 && blanks_between_matches && print_context.lines_since_last_match > (opts.before + opts.after + 1)) {
+            if (cur_match > 0 && (opts.multiline_break || (blanks_between_matches && print_context.lines_since_last_match > (opts.before + opts.after + 1)))) {
                 fprintf(out_fd, "--\n");
             }
 
@@ -352,8 +352,12 @@ void print_column_number(const match_t matches[], size_t last_printed_match,
 }
 
 void print_file_separator(void) {
-    if (first_file_match == 0 && opts.print_break) {
-        fprintf(out_fd, "\n");
+    if (first_file_match == 0) {
+        if (opts.multiline_break) {
+            fprintf(out_fd, "--\n");
+        } else if (opts.print_break) {
+            fprintf(out_fd, "\n");
+        }
     }
     first_file_match = 0;
 }

--- a/src/uthash.h
+++ b/src/uthash.h
@@ -93,9 +93,9 @@ typedef unsigned char uint8_t;
 #endif
 
 /* initial number of buckets */
-#define HASH_INITIAL_NUM_BUCKETS 32     /* initial number of buckets        */
+#define HASH_INITIAL_NUM_BUCKETS 32 /* initial number of buckets        */
 #define HASH_INITIAL_NUM_BUCKETS_LOG2 5 /* lg2 of initial number of buckets */
-#define HASH_BKT_CAPACITY_THRESH 10     /* expand when bucket count reaches */
+#define HASH_BKT_CAPACITY_THRESH 10 /* expand when bucket count reaches */
 
 /* calculate the element whose hash handle address is hhe */
 #define ELMT_FROM_HH(tbl, hhp) ((void *)(((char *)(hhp)) - ((tbl)->hho)))

--- a/tests/multiline_break.t
+++ b/tests/multiline_break.t
@@ -1,0 +1,290 @@
+Setup:
+
+  $ . $TESTDIR/setup.sh
+  $ printf "\nvoid a(){}\nvoid b(){\n  a;\n  b;\n  c;\n  d;\n}\nvoid c(){\n  e;\n  f;\n  g;\n  h;\n  i;\n  g;\n  k;\n}\nvoid d(){\n}\nvoid x(){}\nvoid y(){}\n\nvoid z(){}\n" > foobar.c
+
+Ensure --multiline-break is correct:
+  $ ag --multiline-break  '(.*?((?::{2})?(?:\b[A-Za-z_]\w*(?::{2}))*[~]?[A-Za-z_]\w*)(?:\s)*(?:\([^()]*([^()]*\((?-1)*\)[^()]*|[^()]*\([^()]*\)[^()]*)*[^()]*\))(?:\s)*(?:{[^{}]*([^{}]*{(?-1)*}[^{}]*|[^{}]*{[^{}]*}[^{}]*)*[^{}]*}))'  
+  foobar.c:2:void a(){}
+  --
+  foobar.c:3:void b(){
+  foobar.c:4:  a;
+  foobar.c:5:  b;
+  foobar.c:6:  c;
+  foobar.c:7:  d;
+  foobar.c:8:}
+  --
+  foobar.c:9:void c(){
+  foobar.c:10:  e;
+  foobar.c:11:  f;
+  foobar.c:12:  g;
+  foobar.c:13:  h;
+  foobar.c:14:  i;
+  foobar.c:15:  g;
+  foobar.c:16:  k;
+  foobar.c:17:}
+  --
+  foobar.c:18:void d(){
+  foobar.c:19:}
+  --
+  foobar.c:20:void x(){}
+  --
+  foobar.c:21:void y(){}
+  --
+  foobar.c:23:void z(){}
+
+
+Ensure --multilinebreak is correct:
+  $ ag --multilinebreak  '(.*?((?::{2})?(?:\b[A-Za-z_]\w*(?::{2}))*[~]?[A-Za-z_]\w*)(?:\s)*(?:\([^()]*([^()]*\((?-1)*\)[^()]*|[^()]*\([^()]*\)[^()]*)*[^()]*\))(?:\s)*(?:{[^{}]*([^{}]*{(?-1)*}[^{}]*|[^{}]*{[^{}]*}[^{}]*)*[^{}]*}))'  
+  foobar.c:2:void a(){}
+  --
+  foobar.c:3:void b(){
+  foobar.c:4:  a;
+  foobar.c:5:  b;
+  foobar.c:6:  c;
+  foobar.c:7:  d;
+  foobar.c:8:}
+  --
+  foobar.c:9:void c(){
+  foobar.c:10:  e;
+  foobar.c:11:  f;
+  foobar.c:12:  g;
+  foobar.c:13:  h;
+  foobar.c:14:  i;
+  foobar.c:15:  g;
+  foobar.c:16:  k;
+  foobar.c:17:}
+  --
+  foobar.c:18:void d(){
+  foobar.c:19:}
+  --
+  foobar.c:20:void x(){}
+  --
+  foobar.c:21:void y(){}
+  --
+  foobar.c:23:void z(){}
+
+Ensure --multilinebreak --multiline is correct:
+  $ ag --multilinebreak --multiline '(.*?((?::{2})?(?:\b[A-Za-z_]\w*(?::{2}))*[~]?[A-Za-z_]\w*)(?:\s)*(?:\([^()]*([^()]*\((?-1)*\)[^()]*|[^()]*\([^()]*\)[^()]*)*[^()]*\))(?:\s)*(?:{[^{}]*([^{}]*{(?-1)*}[^{}]*|[^{}]*{[^{}]*}[^{}]*)*[^{}]*}))'  
+  foobar.c:2:void a(){}
+  --
+  foobar.c:3:void b(){
+  foobar.c:4:  a;
+  foobar.c:5:  b;
+  foobar.c:6:  c;
+  foobar.c:7:  d;
+  foobar.c:8:}
+  --
+  foobar.c:9:void c(){
+  foobar.c:10:  e;
+  foobar.c:11:  f;
+  foobar.c:12:  g;
+  foobar.c:13:  h;
+  foobar.c:14:  i;
+  foobar.c:15:  g;
+  foobar.c:16:  k;
+  foobar.c:17:}
+  --
+  foobar.c:18:void d(){
+  foobar.c:19:}
+  --
+  foobar.c:20:void x(){}
+  --
+  foobar.c:21:void y(){}
+  --
+  foobar.c:23:void z(){}
+
+Ensure --multiline-break --multiline is correct:
+  $ ag --multiline-break --multiline '(.*?((?::{2})?(?:\b[A-Za-z_]\w*(?::{2}))*[~]?[A-Za-z_]\w*)(?:\s)*(?:\([^()]*([^()]*\((?-1)*\)[^()]*|[^()]*\([^()]*\)[^()]*)*[^()]*\))(?:\s)*(?:{[^{}]*([^{}]*{(?-1)*}[^{}]*|[^{}]*{[^{}]*}[^{}]*)*[^{}]*}))'  
+  foobar.c:2:void a(){}
+  --
+  foobar.c:3:void b(){
+  foobar.c:4:  a;
+  foobar.c:5:  b;
+  foobar.c:6:  c;
+  foobar.c:7:  d;
+  foobar.c:8:}
+  --
+  foobar.c:9:void c(){
+  foobar.c:10:  e;
+  foobar.c:11:  f;
+  foobar.c:12:  g;
+  foobar.c:13:  h;
+  foobar.c:14:  i;
+  foobar.c:15:  g;
+  foobar.c:16:  k;
+  foobar.c:17:}
+  --
+  foobar.c:18:void d(){
+  foobar.c:19:}
+  --
+  foobar.c:20:void x(){}
+  --
+  foobar.c:21:void y(){}
+  --
+  foobar.c:23:void z(){}
+
+
+Ensure --nomultilinebreak --multiline is correct:
+  $ ag --nomultilinebreak --multiline '(.*?((?::{2})?(?:\b[A-Za-z_]\w*(?::{2}))*[~]?[A-Za-z_]\w*)(?:\s)*(?:\([^()]*([^()]*\((?-1)*\)[^()]*|[^()]*\([^()]*\)[^()]*)*[^()]*\))(?:\s)*(?:{[^{}]*([^{}]*{(?-1)*}[^{}]*|[^{}]*{[^{}]*}[^{}]*)*[^{}]*}))'  
+  foobar.c:2:void a(){}
+  foobar.c:3:void b(){
+  foobar.c:4:  a;
+  foobar.c:5:  b;
+  foobar.c:6:  c;
+  foobar.c:7:  d;
+  foobar.c:8:}
+  foobar.c:9:void c(){
+  foobar.c:10:  e;
+  foobar.c:11:  f;
+  foobar.c:12:  g;
+  foobar.c:13:  h;
+  foobar.c:14:  i;
+  foobar.c:15:  g;
+  foobar.c:16:  k;
+  foobar.c:17:}
+  foobar.c:18:void d(){
+  foobar.c:19:}
+  foobar.c:20:void x(){}
+  foobar.c:21:void y(){}
+  foobar.c:23:void z(){}
+
+
+Ensure --no-multiline-break --multiline is correct:
+  $ ag --no-multiline-break --multiline '(.*?((?::{2})?(?:\b[A-Za-z_]\w*(?::{2}))*[~]?[A-Za-z_]\w*)(?:\s)*(?:\([^()]*([^()]*\((?-1)*\)[^()]*|[^()]*\([^()]*\)[^()]*)*[^()]*\))(?:\s)*(?:{[^{}]*([^{}]*{(?-1)*}[^{}]*|[^{}]*{[^{}]*}[^{}]*)*[^{}]*}))'  
+  foobar.c:2:void a(){}
+  foobar.c:3:void b(){
+  foobar.c:4:  a;
+  foobar.c:5:  b;
+  foobar.c:6:  c;
+  foobar.c:7:  d;
+  foobar.c:8:}
+  foobar.c:9:void c(){
+  foobar.c:10:  e;
+  foobar.c:11:  f;
+  foobar.c:12:  g;
+  foobar.c:13:  h;
+  foobar.c:14:  i;
+  foobar.c:15:  g;
+  foobar.c:16:  k;
+  foobar.c:17:}
+  foobar.c:18:void d(){
+  foobar.c:19:}
+  foobar.c:20:void x(){}
+  foobar.c:21:void y(){}
+  foobar.c:23:void z(){}
+
+Ensure --nomultilinebreak is correct:
+  $ ag --nomultilinebreak  '(.*?((?::{2})?(?:\b[A-Za-z_]\w*(?::{2}))*[~]?[A-Za-z_]\w*)(?:\s)*(?:\([^()]*([^()]*\((?-1)*\)[^()]*|[^()]*\([^()]*\)[^()]*)*[^()]*\))(?:\s)*(?:{[^{}]*([^{}]*{(?-1)*}[^{}]*|[^{}]*{[^{}]*}[^{}]*)*[^{}]*}))'  
+  foobar.c:2:void a(){}
+  foobar.c:3:void b(){
+  foobar.c:4:  a;
+  foobar.c:5:  b;
+  foobar.c:6:  c;
+  foobar.c:7:  d;
+  foobar.c:8:}
+  foobar.c:9:void c(){
+  foobar.c:10:  e;
+  foobar.c:11:  f;
+  foobar.c:12:  g;
+  foobar.c:13:  h;
+  foobar.c:14:  i;
+  foobar.c:15:  g;
+  foobar.c:16:  k;
+  foobar.c:17:}
+  foobar.c:18:void d(){
+  foobar.c:19:}
+  foobar.c:20:void x(){}
+  foobar.c:21:void y(){}
+  foobar.c:23:void z(){}
+
+Ensure --no-multiline-break --multiline is correct:
+  $ ag --no-multiline-break --multiline '(.*?((?::{2})?(?:\b[A-Za-z_]\w*(?::{2}))*[~]?[A-Za-z_]\w*)(?:\s)*(?:\([^()]*([^()]*\((?-1)*\)[^()]*|[^()]*\([^()]*\)[^()]*)*[^()]*\))(?:\s)*(?:{[^{}]*([^{}]*{(?-1)*}[^{}]*|[^{}]*{[^{}]*}[^{}]*)*[^{}]*}))'  
+  foobar.c:2:void a(){}
+  foobar.c:3:void b(){
+  foobar.c:4:  a;
+  foobar.c:5:  b;
+  foobar.c:6:  c;
+  foobar.c:7:  d;
+  foobar.c:8:}
+  foobar.c:9:void c(){
+  foobar.c:10:  e;
+  foobar.c:11:  f;
+  foobar.c:12:  g;
+  foobar.c:13:  h;
+  foobar.c:14:  i;
+  foobar.c:15:  g;
+  foobar.c:16:  k;
+  foobar.c:17:}
+  foobar.c:18:void d(){
+  foobar.c:19:}
+  foobar.c:20:void x(){}
+  foobar.c:21:void y(){}
+  foobar.c:23:void z(){}
+
+Ensure --no-multiline-break --nomultiline is correct:
+  $ ag --no-multiline-break --nomultiline '(.*?((?::{2})?(?:\b[A-Za-z_]\w*(?::{2}))*[~]?[A-Za-z_]\w*)(?:\s)*(?:\([^()]*([^()]*\((?-1)*\)[^()]*|[^()]*\([^()]*\)[^()]*)*[^()]*\))(?:\s)*(?:{[^{}]*([^{}]*{(?-1)*}[^{}]*|[^{}]*{[^{}]*}[^{}]*)*[^{}]*}))'  
+  foobar.c:2:void a(){}
+  foobar.c:20:void x(){}
+  foobar.c:21:void y(){}
+  foobar.c:23:void z(){}
+
+Ensure --noheading  --multilinebreak is correct:
+  $ ag --noheading  --multilinebreak  '(.*?((?::{2})?(?:\b[A-Za-z_]\w*(?::{2}))*[~]?[A-Za-z_]\w*)(?:\s)*(?:\([^()]*([^()]*\((?-1)*\)[^()]*|[^()]*\([^()]*\)[^()]*)*[^()]*\))(?:\s)*(?:{[^{}]*([^{}]*{(?-1)*}[^{}]*|[^{}]*{[^{}]*}[^{}]*)*[^{}]*}))'  
+  foobar.c:2:void a(){}
+  --
+  foobar.c:3:void b(){
+  foobar.c:4:  a;
+  foobar.c:5:  b;
+  foobar.c:6:  c;
+  foobar.c:7:  d;
+  foobar.c:8:}
+  --
+  foobar.c:9:void c(){
+  foobar.c:10:  e;
+  foobar.c:11:  f;
+  foobar.c:12:  g;
+  foobar.c:13:  h;
+  foobar.c:14:  i;
+  foobar.c:15:  g;
+  foobar.c:16:  k;
+  foobar.c:17:}
+  --
+  foobar.c:18:void d(){
+  foobar.c:19:}
+  --
+  foobar.c:20:void x(){}
+  --
+  foobar.c:21:void y(){}
+  --
+  foobar.c:23:void z(){}
+
+Ensure --noheading  --multiline-break is correct:
+  $ ag --noheading  --multiline-break  '(.*?((?::{2})?(?:\b[A-Za-z_]\w*(?::{2}))*[~]?[A-Za-z_]\w*)(?:\s)*(?:\([^()]*([^()]*\((?-1)*\)[^()]*|[^()]*\([^()]*\)[^()]*)*[^()]*\))(?:\s)*(?:{[^{}]*([^{}]*{(?-1)*}[^{}]*|[^{}]*{[^{}]*}[^{}]*)*[^{}]*}))'  
+  foobar.c:2:void a(){}
+  --
+  foobar.c:3:void b(){
+  foobar.c:4:  a;
+  foobar.c:5:  b;
+  foobar.c:6:  c;
+  foobar.c:7:  d;
+  foobar.c:8:}
+  --
+  foobar.c:9:void c(){
+  foobar.c:10:  e;
+  foobar.c:11:  f;
+  foobar.c:12:  g;
+  foobar.c:13:  h;
+  foobar.c:14:  i;
+  foobar.c:15:  g;
+  foobar.c:16:  k;
+  foobar.c:17:}
+  --
+  foobar.c:18:void d(){
+  foobar.c:19:}
+  --
+  foobar.c:20:void x(){}
+  --
+  foobar.c:21:void y(){}
+  --
+  foobar.c:23:void z(){}


### PR DESCRIPTION
Ag is my favourite and most-frequently used command for searching source code everyday.  I written a calltree.pl to show calling graph or backtrace in Linux utility tree style, which is based on ag. In order to parse cpp function defintions, I need a tool to recognize nested parentheses and nested braces,  but both perl and ack get stuck with nested regex. To my excitement, ag is so clever to deal with nested regex, it has not stuck!!!.  However, output of multiline matches is mixed together without a separator line. for an example:

**my cpp file: foobar.c**

```cpp
void a(){}
void b(){
  a;
  b;
  c;
  d;
}
void c(){
  e;
  f;
  g;
  h;
  i;
  g;
  k;
}
void d(){
}
void x(){}
void y(){}

void z(){}
```
**use ag to recognize**

```
ag  --noheading '(.*?((?::{2})?(?:\b[A-Za-z_]\w*(?::{2}))*[~]?[A-Za-z_]\w*)(?:\s)*(?:\([^()]*([^()]*\((?-1)*\)[^()]*|[^()]*\([^()]*\)[^()]*)*[^()]*\))(?:\s)*(?:{[^{}]*([^{}]*{(?-1)*}[^{}]*|[^{}]*{[^{}]*}[^{}]*)*[^{}]*}))' |perl -lne 'print "  $_"'
  foobar.c:2:void a(){}
  foobar.c:3:void b(){
  foobar.c:4:  a;
  foobar.c:5:  b;
  foobar.c:6:  c;
  foobar.c:7:  d;
  foobar.c:8:}
  foobar.c:9:void c(){
  foobar.c:10:  e;
  foobar.c:11:  f;
  foobar.c:12:  g;
  foobar.c:13:  h;
  foobar.c:14:  i;
  foobar.c:15:  g;
  foobar.c:16:  k;
  foobar.c:17:}
  foobar.c:18:void d(){
  foobar.c:19:}
  foobar.c:20:void x(){}
  foobar.c:21:void y(){}
  foobar.c:23:void z(){}
```

so, I add a multiline_break cmd option to ag, which only work in multiline match mode,  and in default, multiline_break is disabled. so the option don't disrupt other options.

**multiline_break output**

```
/ag  --multiline-break '(.*?((?::{2})?(?:\b[A-Za-z_]\w*(?::{2}))*[~]?[A-Za-z_]\w*)(?:\s)*(?:\([^()]*([^()]*\((?-1)*\)[^()]*|[^()]*\([^()]*\)[^()]*)*[^()]*\))(?:\s)*(?:{[^{}]*([^{}]*{(?-1)*}[^{}]*|[^{}]*{[^{}]*}[^{}]*)*[^{}]*}))' |perl -lne 'print "  $_"'
  foobar.c:2:void a(){}
  --
  foobar.c:3:void b(){
  foobar.c:4:  a;
  foobar.c:5:  b;
  foobar.c:6:  c;
  foobar.c:7:  d;
  foobar.c:8:}
  --
  foobar.c:9:void c(){
  foobar.c:10:  e;
  foobar.c:11:  f;
  foobar.c:12:  g;
  foobar.c:13:  h;
  foobar.c:14:  i;
  foobar.c:15:  g;
  foobar.c:16:  k;
  foobar.c:17:}
  --
  foobar.c:18:void d(){
  foobar.c:19:}
  --
  foobar.c:20:void x(){}
  --
  foobar.c:21:void y(){}
  --
  foobar.c:23:void z(){}
```