### PR TITLE
Fix glob pattern requiring leading slash

### DIFF
--- a/src/uthash.h
+++ b/src/uthash.h
@@ -93,9 +93,9 @@ typedef unsigned char uint8_t;
 #endif
 
 /* initial number of buckets */
-#define HASH_INITIAL_NUM_BUCKETS 32     /* initial number of buckets        */
+#define HASH_INITIAL_NUM_BUCKETS 32 /* initial number of buckets        */
 #define HASH_INITIAL_NUM_BUCKETS_LOG2 5 /* lg2 of initial number of buckets */
-#define HASH_BKT_CAPACITY_THRESH 10     /* expand when bucket count reaches */
+#define HASH_BKT_CAPACITY_THRESH 10 /* expand when bucket count reaches */
 
 /* calculate the element whose hash handle address is hhe */
 #define ELMT_FROM_HH(tbl, hhp) ((void *)(((char *)(hhp)) - ((tbl)->hho)))


### PR DESCRIPTION
This changeset fixes #1060. 

The problem described in #1060 is caused by the fact that a pattern only gets checked as a slash pattern when it starts with a `/`. See [src/ignore.c:245](https://github.com/ggreer/the_silver_searcher/blob/master/src/ignore.c#L245).

There still are some things left to do. 

- [ ] `local_pattern` needs to be freed. In trying to do so, I ran into `free(): invalid pointer` errors.
- [ ] The `/` prepend should only be applied when the pattern is_fnmatch, doesn't start with `*.`, `/` or `!`. 