### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ sudo: false
 branches:
   only:
     - master
+    - ppc64le
+arch:
+  - amd64
+  - ppc64le
 
 compiler:
   - clang


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch on behalf of IBM . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/the_silver_searcher/builds/207936345 . I believe it is ready for the final review and merge.
Please have a look on it.

Thanks !!