### PR TITLE
Fix PCRE assertions causing case-sensitive search

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -460,7 +460,8 @@ int is_lowercase(const char *s) {
     int i;
     for (i = 0; s[i] != '\0'; i++) {
         if (s[i] == '\\') {
-            i++;
+            if (s[i + 1] != '\0')
+                i++;
         } else {
             if (!isascii(s[i]) || isupper(s[i])) {
                 return FALSE;

--- a/src/util.c
+++ b/src/util.c
@@ -459,8 +459,12 @@ int is_wordchar(char ch) {
 int is_lowercase(const char *s) {
     int i;
     for (i = 0; s[i] != '\0'; i++) {
-        if (!isascii(s[i]) || isupper(s[i])) {
-            return FALSE;
+        if (s[i] == '\\') {
+            i++;
+        } else {
+            if (!isascii(s[i]) || isupper(s[i])) {
+                return FALSE;
+            }
         }
     }
     return TRUE;

--- a/tests/case_sensitivity.t
+++ b/tests/case_sensitivity.t
@@ -3,11 +3,14 @@ Setup:
   $ . $TESTDIR/setup.sh
   $ printf 'Foo\n' >> ./sample
   $ printf 'bar\n' >> ./sample
+  $ printf '  Baz bun\n' >> ./sample
 
 Smart case by default:
 
   $ ag foo sample
   1:Foo
+  $ ag '\Wbaz' sample
+  3:  Baz bun
   $ ag FOO sample
   [1]
   $ ag 'f.o' sample


### PR DESCRIPTION
As reported by @djowett-ftw in #1431, using `ag` with a uppercase PCRE assertion (like `\W` or `\B`) without explicitly ignoring case would cause a case sensitive result.

I added a test to confirm the same and when looking over the code, this seems to be a problem with the default Smart Case behaviour, which relies upon the case of the search query:
(main.c 111:5)
```c
    if (opts.casing == CASE_SMART) {
        opts.casing = is_lowercase(opts.query) ? CASE_INSENSITIVE : CASE_SENSITIVE;
    }
```
I changed the `is_lowercase` function to escape a character following a backslash from case detection.

EDIT: At first, I thought just escaping the next character was not enough but, it seems that it works just fine.