### PR TITLE
Include file names & line numbers when searching paths, even if stream is present

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -765,14 +765,6 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
         }
     }
 
-    if (opts.search_stream) {
-        opts.print_break = 0;
-        opts.print_path = PATH_PRINT_NOTHING;
-        if (opts.print_line_numbers != 2) {
-            opts.print_line_numbers = 0;
-        }
-    }
-
     if (accepts_query && argc > 0) {
         if (!needs_query && strlen(argv[0]) == 0) {
             // use default query
@@ -851,6 +843,14 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
     }
     (*paths)[i] = NULL;
     (*base_paths)[i] = NULL;
+
+    if (opts.search_stream) {
+        opts.print_break = 0;
+        opts.print_path = PATH_PRINT_NOTHING;
+        if (opts.print_line_numbers != 2) {
+            opts.print_line_numbers = 0;
+        }
+    }
 
 #ifdef _WIN32
     windows_use_ansi(opts.color_win_ansi);

--- a/tests/passthrough.t
+++ b/tests/passthrough.t
@@ -10,7 +10,7 @@ Setup:
 No impact on non-stream:
 
   $ ag --passthrough zoo passthrough_test.txt
-  zoo zar
+  2:zoo zar
 
 Match stream with --passthrough:
 

--- a/tests/stream_with_paths.t
+++ b/tests/stream_with_paths.t
@@ -1,0 +1,19 @@
+Setup:
+
+  $ . $TESTDIR/setup.sh
+  $ unalias ag
+  $ alias ag="$TESTDIR/../ag --noaffinity --nocolor --workers=1"
+  $ echo foo > ./stream_with_path.txt
+  $ echo foo > ./stream_with_path_2.txt
+  $ echo bar > ./stream_with_path_3.txt
+
+Search for "foo" in paths passed as arguments:
+
+  $ echo | ag foo stream_with_path.txt stream_with_path_3.txt
+  stream_with_path.txt:1:foo
+
+  $ echo | ag --nofilename foo stream_with_path.txt stream_with_path_3.txt
+  foo
+
+  $ echo | ag --nonumbers foo stream_with_path.txt stream_with_path_3.txt
+  stream_with_path.txt:foo


### PR DESCRIPTION
When a stream is present but file paths as passed as arguments, ag searches the paths, but previously it would output the matching lines without file names or line numbers.

Fixes #108 
Fixes #753 
Fixes #911 
Fixes #943 
Fixes #997 
Fixes #1250 

After I started making this PR, I realized it was basically a copy of #945 . It would be nice to get this fixed.