### PR TITLE
Better support for ignore inversions

### DIFF
--- a/tests/ignore_dont_invert_if_whole_directory_is_excluded.t
+++ b/tests/ignore_dont_invert_if_whole_directory_is_excluded.t
@@ -1,0 +1,13 @@
+Setup:
+
+  $ . $TESTDIR/setup.sh
+  $ mkdir -p ./a/b ./a/c
+  $ printf '/a\n' >> ./.gitignore
+  $ printf '!a/dontprintme.txt\n' >> ./.gitignore
+  $ printf 'blah1\n' > ./printme.txt
+  $ printf 'blah2\n' > ./a/dontprintme.txt
+
+Ignore .gitignore negation inside subdir if whole subdir is ignored:
+
+  $ ag blah
+  printme.txt:1:blah1

--- a/tests/ignore_invert_subdirs.t
+++ b/tests/ignore_invert_subdirs.t
@@ -1,0 +1,13 @@
+Setup:
+
+  $ . $TESTDIR/setup.sh
+  $ mkdir -p ./a/b ./a/c
+  $ printf '/a/*\n' >> ./.gitignore
+  $ printf '!a/printme.txt\n' >> ./.gitignore
+  $ printf 'blah1\n' > ./a/printme.txt
+  $ printf 'blah2\n' > ./a/dontprintme.txt
+
+Ignore .gitignore patterns but not .ignore patterns:
+
+  $ ag blah
+  a/printme.txt:1:blah1


### PR DESCRIPTION
This PR changes the approach to ignore file handling.

The current approach is 100% oriented towards performance, but unfortunately it loses very important pieces of "negate" functionality, because negations were applied only once and only if other ignore rules didn't match. This goes against the [gitignore spec](https://git-scm.com/docs/gitignore) where the negation lines are specifically designed to override all preceding rules.

There's a test attached to this change which describes a use case that was previously not working as it should. With this PR the test passes:
```
$ cat .gitignore
/a/*
!a/printme.txt
$ cat a/printme.txt
blah1
$ cat a/dontprintme.txt
blah2
$ ag blah
a/printme.txt:1:blah1
```

It is still not perfect, e.g. the example above won't work if the negation rule starts with a slash, `!/a/printme.txt`, because I was not sure about the right way to do this. Regardless, I hope it is enough to get the ball rolling and arrive to the final version eventually.