### PR TITLE
Link to documentation in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ There are also [graphs of performance across releases](http://geoff.greer.fm/ag/
 
 I've written several blog posts showing how I've improved performance. These include how I [added pthreads](http://geoff.greer.fm/2012/09/07/the-silver-searcher-adding-pthreads/), [wrote my own `scandir()`](http://geoff.greer.fm/2012/09/03/profiling-ag-writing-my-own-scandir/), [benchmarked every revision to find performance regressions](http://geoff.greer.fm/2012/08/25/the-silver-searcher-benchmarking-revisions/), and profiled with [gprof](http://geoff.greer.fm/2012/02/08/profiling-with-gprof/) and [Valgrind](http://geoff.greer.fm/2012/01/23/making-programs-faster-profiling/).
 
+## Documentation
+
+If you're looking for documentation on the web, try the [wiki](https://github.com/ggreer/the_silver_searcher/wiki), otherwise on the cli see `man ag`.
 
 ## Installing
 


### PR DESCRIPTION
:wave: Thanks for all the hard work in this project, I was getting a bit frustrated trying to find any documentation for how ignore works (I want to ignore some directory globs that don't seem to be working from `.ignore`) and it took a search through the issues to discover the wiki, as almost every Github project has a wiki tab (its the default) with nothing in it.

To help those people who are a bit scatter brained when it comes to looking for docs and expect there to be a "docs" link somewhere on the webpage or readme, I've added one, suggested improvements obviously welcome :)