### PR TITLE
Add .kts extension for kotlin files

### DIFF
--- a/src/lang.c
+++ b/src/lang.c
@@ -63,7 +63,7 @@ lang_spec_t langs[] = {
     { "json", { "json" } },
     { "jsp", { "jsp", "jspx", "jhtm", "jhtml", "jspf", "tag", "tagf" } },
     { "julia", { "jl" } },
-    { "kotlin", { "kt" } },
+    { "kotlin", { "kt", "kts" } },
     { "less", { "less" } },
     { "liquid", { "liquid" } },
     { "lisp", { "lisp", "lsp" } },

--- a/tests/list_file_types.t
+++ b/tests/list_file_types.t
@@ -181,7 +181,7 @@ Language types are output:
         .jl
   
     --kotlin
-        .kt
+        .kt  .kts
   
     --less
         .less


### PR DESCRIPTION
Hi,

Kotlin uses both `.kt` and `.kts` extensions, this PR adds support for searching `.kts`.