### PR TITLE
Better CPU affinity, if ag is invoked with a nontrivial CPU mask

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -64,7 +64,7 @@ AC_CHECK_HEADERS([sys/cpuset.h err.h])
 AC_CHECK_MEMBER([struct dirent.d_type], [AC_DEFINE([HAVE_DIRENT_DTYPE], [], [Have dirent struct member d_type])], [], [[#include <dirent.h>]])
 AC_CHECK_MEMBER([struct dirent.d_namlen], [AC_DEFINE([HAVE_DIRENT_DNAMLEN], [], [Have dirent struct member d_namlen])], [], [[#include <dirent.h>]])
 
-AC_CHECK_FUNCS(fgetln fopencookie getline realpath strlcpy strndup vasprintf madvise posix_fadvise pthread_setaffinity_np pledge)
+AC_CHECK_FUNCS(fgetln fopencookie getline realpath strlcpy strndup vasprintf madvise posix_fadvise pthread_getaffinity_np pthread_setaffinity_np pledge)
 
 AC_CONFIG_FILES([Makefile the_silver_searcher.spec])
 AC_CONFIG_HEADERS([src/config.h])


### PR DESCRIPTION
On a Ryzen 5700U CPU, Linux 5.10.0, Debian bullseye, and `nosmt` on the kernel commandline, every task is effectively pinned to the CPU mask 0x5555:
```
On-line CPU(s) list:             0,2,4,6,8,10,12,14
Off-line CPU(s) list:            1,3,5,7,9,11,13,15
```

In order to avoid failures of `pthread_setaffinity_np`, check the CPUs that the main thread has available (and use it to set num_cores!) and then each time a thread is created, find the next set bit.

This also fixes the behavior when ag is deliberately pinned to some smaller number of CPUs than those on-line:
```
$ taskset 0x5555 ./ag -D booboo | ag "Using \d+ workers"
DEBUG: Using 7 workers
$ taskset 0x55 ag -D booboo | ag "Using \d+ workers"
DEBUG: Using 3 workers
```

Closes: #1459 