### PR TITLE
Docs: Note PCRE as regex flavor of patterns.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ A code searching tool similar to `ack`, with a focus on speed.
 
 [![#ag on Freenode](https://img.shields.io/badge/Freenode-%23ag-brightgreen.svg)](https://webchat.freenode.net/?channels=ag)
 
+Search patterns can be literals or [Perl Compatible Regular Expressions (PCREs)](http://www.pcre.org/). 
+
 Do you know C? Want to improve ag? [I invite you to pair with me](http://geoff.greer.fm/2014/10/13/help-me-get-to-ag-10/).
 
 

--- a/doc/ag.1
+++ b/doc/ag.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "AG" "1" "December 2016" "" ""
+.TH "AG" "1" "March 2022" "" ""
 .
 .SH "NAME"
 \fBag\fR \- The Silver Searcher\. Like ack, but faster\.
@@ -11,6 +11,9 @@
 .
 .SH "DESCRIPTION"
 Recursively search for PATTERN in PATH\. Like grep or ack, but faster\.
+.
+.P
+PATTERN is a Perl\-Compatible Regular Expression (PCRE)\. Refer to pcre(3), pcrepattern(3) and pcresyntax(3) for details\.
 .
 .SH "OPTIONS"
 .
@@ -252,6 +255,10 @@ Only match whole words\.
 Use NUM worker threads\. Default is the number of CPU cores, with a max of 8\.
 .
 .TP
+\fB\-W \-\-width NUM\fR
+Truncate match lines after NUM characters\.
+.
+.TP
 \fB\-z \-\-search\-zip\fR
 Search contents of compressed files\. Currently, gz and xz are supported\. This option requires that ag is built with lzma and zlib\.
 .
@@ -284,4 +291,4 @@ Use the \fB\-t\fR option to search all text files; \fB\-a\fR to search all files
 ag was originally created by Geoff Greer\. More information (and the latest release) can be found at http://geoff\.greer\.fm/ag
 .
 .SH "SEE ALSO"
-grep(1)
+grep(1), pcre(3), pcrepattern(3), pcresyntax(3)

--- a/doc/ag.1.md
+++ b/doc/ag.1.md
@@ -9,6 +9,8 @@ ag(1) -- The Silver Searcher. Like ack, but faster.
 
 Recursively search for PATTERN in PATH. Like grep or ack, but faster.
 
+PATTERN is a Perl-Compatible Regular Expression (PCRE). Refer to pcre(3), pcrepattern(3) and pcresyntax(3) for details. 
+
 ## OPTIONS
 
   * `--ackmate`:
@@ -259,4 +261,4 @@ release) can be found at http://geoff.greer.fm/ag
 
 ## SEE ALSO
 
-grep(1)
+grep(1), pcre(3), pcrepattern(3), pcresyntax(3)


### PR DESCRIPTION
Will close #993.

The diff for `ag.1` includes some unrelated changes (specifically, about the `-W`/`--width` option) which i assume are the result of `generate_man.sh` not being run when `ag.1.md` was last modified; let me know if i should remove that change from this PR.