### PR TITLE
bash completion: do not expand tilde

### DIFF
--- a/ag.bashcomp.sh
+++ b/ag.bashcomp.sh
@@ -6,8 +6,6 @@ _ag() {
   cur=$(_get_cword "=")
   prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-  _expand || return 0
-
   lngopt='
     --ackmate
     --ackmate-dir-filter


### PR DESCRIPTION
Make behavior of bash completion for `ag` consistent with `ls`, `man`, etc. in respect to tilde expansion to home directory path. Do not replace `~` by `/home/user` in response to `[Tab]` in the following cases:

    ag pattern ~us
    ag pattern ~/src

Completion of file names is still handled by `_filedir`. As to other utilities, e.g. `ls` uses `_longopt` function that does not call
`_expand` at all, while `man` has call of `_expand` but it is bypassed for file names.

Expansion of `~` is controlled by the following setting in `inputrc`:

    set expand-tilde on

For details see [info "(bash) Readline Init File Syntax"](https://www.gnu.org/software/bash/manual/html_node/Readline-Init-File-Syntax.html). Alternatively `M-&` (`tilde-expand` command) may be used to expand tilde at particular point [info "(bash) Miscellaneous Commands"](https://www.gnu.org/software/bash/manual/html_node/Miscellaneous-Commands.html).

If you are going to revert this commit, please, add a comment with an example when `_filedir` is not enough and `_expand` is really necessary.