### PR TITLE
List empty files without -u

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -322,7 +322,7 @@ void search_file(const char *file_full_path) {
     f_len = statbuf.st_size;
 
     if (f_len == 0) {
-        if (opts.query[0] == '.' && opts.query_len == 1 && !opts.literal && opts.search_all_files) {
+        if (opts.query[0] == '.' && opts.query_len == 1 && !opts.literal) {
             matches_count = search_buf(buf, f_len, file_full_path);
         } else {
             log_debug("Skipping %s: file is empty.", file_full_path);


### PR DESCRIPTION
Fixes #1497 

`-l` should include empty files, and only exclude files subject to an exclusion filter (such as `.gitignore`).

Empty files are still in the subset of searchable files. `ag` does not need to open the file to know that there is no matching query (if there is a query), but that does not mean that `-l` should not list them.