### PR TITLE
Add 'bzl' as a valid extension for Bazel

### DIFF
--- a/src/lang.c
+++ b/src/lang.c
@@ -13,7 +13,7 @@ lang_spec_t langs[] = {
     { "asp", { "asp", "asa", "aspx", "asax", "ashx", "ascx", "asmx" } },
     { "aspx", { "asp", "asa", "aspx", "asax", "ashx", "ascx", "asmx" } },
     { "batch", { "bat", "cmd" } },
-    { "bazel", { "bazel" } },
+    { "bazel", { "bazel", "bzl" } },
     { "bitbake", { "bb", "bbappend", "bbclass", "inc" } },
     { "cc", { "c", "h", "xs" } },
     { "cfmx", { "cfc", "cfm", "cfml" } },

--- a/tests/list_file_types.t
+++ b/tests/list_file_types.t
@@ -31,7 +31,7 @@ Language types are output:
         .bat  .cmd
   
     --bazel
-        .bazel
+        .bazel  .bzl
   
     --bitbake
         .bb  .bbappend  .bbclass  .inc


### PR DESCRIPTION
Bazel extensions are files ending in .bzl (<https://bazel.build/extending/concepts>)