### PR TITLE
define _LARGEFILE64_SOURCE in musl systems

### DIFF
--- a/src/zfile.c
+++ b/src/zfile.c
@@ -7,6 +7,10 @@
 typedef _off64_t off64_t;
 #endif
 
+#ifndef __GLIBC__
+typedef off_t off64_t;
+#endif /* ifndef __GLIBC__ */
+
 #include <assert.h>
 #include <errno.h>
 #include <inttypes.h>


### PR DESCRIPTION
The off64_t data type is only available on musl libc if _LARGEFILE64_SOURCE is defined. Please refer: http://git.musl-libc.org/cgit/musl/tree/include/sys/types.h#n74