### PR TITLE
src/zfile.c: Use off_t instead of off64_t

### DIFF
--- a/src/zfile.c
+++ b/src/zfile.c
@@ -4,7 +4,7 @@
 #include <sys/types.h>
 
 #ifdef __CYGWIN__
-typedef _off64_t off64_t;
+typedef _off64_t off_t;
 #endif
 
 #include <assert.h>
@@ -331,14 +331,14 @@ zfile_read(void *cookie_, char *buf, size_t size) {
 }
 
 static int
-zfile_seek(void *cookie_, off64_t *offset_, int whence) {
+zfile_seek(void *cookie_, off_t *offset_, int whence) {
     struct zfile *cookie = cookie_;
-    off64_t new_offset = 0, offset = *offset_;
+    off_t new_offset = 0, offset = *offset_;
 
     if (whence == SEEK_SET) {
         new_offset = offset;
     } else if (whence == SEEK_CUR) {
-        new_offset = (off64_t)cookie->logic_offset + offset;
+        new_offset = (off_t)cookie->logic_offset + offset;
     } else {
         /* SEEK_END not ok */
         return -1;
@@ -348,7 +348,7 @@ zfile_seek(void *cookie_, off64_t *offset_, int whence) {
         return -1;
 
     /* Backward seeks to anywhere but 0 are not ok */
-    if (new_offset < (off64_t)cookie->logic_offset && new_offset != 0) {
+    if (new_offset < (off_t)cookie->logic_offset && new_offset != 0) {
         return -1;
     }
 


### PR DESCRIPTION
First discovered in while building on musl [1]. This is because musl-1.2.4 (9999 right now) will remove/removes the LFS compatibility hacks, like fopen64:
  - https://git.musl-libc.org/cgit/musl/commit/?id=246f1c811448f37a44b41cd8df8d0ef9736d95f4
  - https://git.musl-libc.org/cgit/musl/commit/?id=25e6fee27f4a293728dd15b659170e7b9c7db9bc

The gist is that bad configure tests (suffering from -Wimplicit-function-declaration) would build and link successfully because musl provided these symbols as aliases, despite not needing them (musl natively supports both LFS & time64).

To head this off, these aliases are now gone, but remain in libc.so for binary compatibility.

The proper fix is to just use the regular functions and not anything _LARGEFILE64_SOURCE As a temporary workaround you can typedef off_t to off64_t [2] to get it working.

[1]: https://bugs.gentoo.org/908582
[2]: https://github.com/gentoo/gentoo/pull/31186
Signed-off-by: Brahmajit Das <brahmajit.xyz@gmail.com>