### PR TITLE
feat: add .jinja to list of file types

### DIFF
--- a/src/lang.c
+++ b/src/lang.c
@@ -58,7 +58,7 @@ lang_spec_t langs[] = {
     { "j", { "ijs" } },
     { "jade", { "jade" } },
     { "java", { "java", "properties" } },
-    { "jinja2", { "j2" } },
+    { "jinja2", { "j2", "jinja" } },
     { "js", { "es6", "js", "jsx", "vue" } },
     { "json", { "json" } },
     { "jsp", { "jsp", "jspx", "jhtm", "jhtml", "jspf", "tag", "tagf" } },

--- a/tests/list_file_types.t
+++ b/tests/list_file_types.t
@@ -166,7 +166,7 @@ Language types are output:
         .java  .properties
   
     --jinja2
-        .j2
+        .j2  .jinja
   
     --js
         .es6  .js  .jsx  .vue


### PR DESCRIPTION
Improving upon https://github.com/ggreer/the_silver_searcher/pull/1187 . 

As of Jinja2 version 2.11 they have added `.jinja` as an official recommendation:

> Adding a .jinja extension, like user.html.jinja may make it easier for some IDEs or editor plugins, but is not required.

Source: https://jinja.palletsprojects.com/en/2.11.x/templates/#template-file-extension