### PR TITLE
changed the way malloc is handled in options.c

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 ACLOCAL_AMFLAGS = ${ACLOCAL_FLAGS}
 
 bin_PROGRAMS = ag
-ag_SOURCES = src/ignore.c src/ignore.h src/log.c src/log.h src/options.c src/options.h src/print.c src/print_w32.c src/print.h src/scandir.c src/scandir.h src/search.c src/search.h src/lang.c src/lang.h src/util.c src/util.h src/decompress.c src/decompress.h src/uthash.h src/main.c src/zfile.c
+ag_SOURCES = src/alloclist.c src/ignore.c src/ignore.h src/log.c src/log.h src/options.c src/options.h src/print.c src/print_w32.c src/print.h src/scandir.c src/scandir.h src/search.c src/search.h src/lang.c src/lang.h src/util.c src/util.h src/decompress.c src/decompress.h src/uthash.h src/main.c src/zfile.c
 ag_LDADD = ${PCRE_LIBS} ${LZMA_LIBS} ${ZLIB_LIBS} $(PTHREAD_LIBS)
 
 dist_man_MANS = doc/ag.1

--- a/Makefile.w32
+++ b/Makefile.w32
@@ -15,6 +15,7 @@ SRCS = \
 	src/scandir.c \
 	src/search.c \
 	src/util.c \
+	src/alloclist.c \
 	src/print_w32.c
 OBJS = $(subst .c,.o,$(SRCS))
 

--- a/src/alloclist.c
+++ b/src/alloclist.c
@@ -1,0 +1,47 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include "alloclist.h"
+
+// initialize allocation list
+void alloc_list_init(alloc_list *list){
+    list->head = NULL;
+}
+
+// try to add a new allocation node to list
+int alloc_list_add(alloc_list *list, void *data){
+    alloc_node *new_node = NULL;
+    if((new_node=(alloc_node*)malloc(sizeof(alloc_node)))==NULL){
+        return -1;
+    }
+    new_node->data = data;
+    new_node->next = list->head;
+    list->head = new_node;
+    return 0;
+}
+
+// remove the first element from allocation list
+int alloc_list_pop(alloc_list *list, void **data){
+    if(list->head==NULL){
+        return -1;
+    }
+    alloc_node *old_node = list->head;
+    list->head = list->head->next;
+    old_node->next = NULL;
+    *data = old_node->data;
+    free(old_node);
+    return 0;
+}
+
+// destroy only the allocation list nodes without freeing what they point to
+void alloc_list_destroy_clean(alloc_list *list){
+    void *data = NULL;
+    while(alloc_list_pop(list,&data)==0){}
+}
+
+// destroy the whole allocation list and free all elements it points to
+void alloc_list_destroy(alloc_list *list){
+    void *data = NULL;
+    while(alloc_list_pop(list,&data)==0){
+        free(data);
+    }
+}

--- a/src/alloclist.h
+++ b/src/alloclist.h
@@ -1,0 +1,22 @@
+#ifndef ALLOC_LIST_H
+#define ALLOC_LIST_H
+
+struct alloc_node{
+    void *data;
+    struct alloc_node *next;
+};
+
+struct alloc_list{
+    struct alloc_node *head;
+};
+
+typedef struct alloc_node alloc_node;
+typedef struct alloc_list alloc_list;
+
+void alloc_list_init(alloc_list *list);
+int alloc_list_add(alloc_list *list, void *data);
+int alloc_list_pop(alloc_list *list, void **data);
+void alloc_list_destroy_clean(alloc_list *list);
+void alloc_list_destroy(alloc_list *list);
+
+#endif


### PR DESCRIPTION
Based on issue #1531 the function 'parse_options' is handling allocated memory incorrectly when there's a new allocation that failed. A list of so-far allocated memory is kept and automatically free'd when new allocation fails.